### PR TITLE
Add branded 404 page and catch-all route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ const LoginPage = lazy(() => import('./pages/LoginPage.jsx'))
 const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage.jsx'))
 const SignupPage = lazy(() => import('./pages/SignupPage.jsx'))
 const MyPage = lazy(() => import('./pages/MyPage.jsx'))
+const NotFoundPage = lazy(() => import('./pages/NotFoundPage.jsx'))
 
 function getReturnPath(location) {
   return `${location.pathname}${location.search}${location.hash}`
@@ -268,6 +269,7 @@ function AppLayout() {
               )}
             />
             <Route path="/auth" element={<Navigate to="/login" replace />} />
+            <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </Suspense>
       </main>

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,34 @@
+import { Compass, Home, Undo2 } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+
+export default function NotFoundPage() {
+  const navigate = useNavigate()
+
+  return (
+    <section className="page-grid auth-page">
+      <div className="auth-status-shell">
+        <div className="panel auth-panel auth-status-panel">
+          <span className="auth-header-icon auth-status-icon" aria-hidden="true">
+            <Compass size={20} />
+          </span>
+          <div className="auth-header">
+            <p className="eyebrow">404 Not Found</p>
+            <h2>요청하신 페이지를 찾을 수 없어요.</h2>
+            <p className="helper-text">주소가 변경되었거나 삭제된 페이지일 수 있습니다. 아래 버튼으로 이동해 주세요.</p>
+          </div>
+
+          <div className="auth-actions">
+            <button type="button" className="ghost-button" onClick={() => navigate(-1)}>
+              <Undo2 size={16} aria-hidden="true" />
+              <span>이전 페이지</span>
+            </button>
+            <Link className="primary-button auth-submit" to="/">
+              <Home size={16} aria-hidden="true" />
+              <span>홈으로 이동</span>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a user-friendly 404 experience that matches the existing CubingHub UI patterns so unknown routes render a consistent branded page.

### Description
- Add a new `NotFoundPage` component at `frontend/src/pages/NotFoundPage.jsx` that reuses the app's panel/auth styles and includes actions to go back or return home.
- Wire the page into routing by lazy-importing `NotFoundPage` in `frontend/src/App.jsx` and adding a catch-all `Route path="*"` to render it for unmatched routes.

### Testing
- Ran `npm run lint` in `frontend/` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1968a0bcc832b81b50375e61fb2a8)