### PR TITLE
ci: 운영 runtime config 조건부 동기화 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,9 @@ infra
 homeserver/docs
 homeserver/launchd
 homeserver/monitoring
-homeserver/scripts
+homeserver/scripts/*
+!homeserver/scripts/deploy-home-server.sh
+!homeserver/scripts/backup-home-server.sh
 homeserver/workflows
 
 **/.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      sync_runtime_config:
+        description: Force runtime config publication and synchronization
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -16,6 +22,7 @@ concurrency:
 env:
   API_IMAGE_NAME: ghcr.io/xxh3898/cubing-hub-api
   WEB_IMAGE_NAME: ghcr.io/xxh3898/cubing-hub-web
+  RUNTIME_CONFIG_IMAGE_NAME: ghcr.io/xxh3898/cubing-hub-runtime-config
   VITE_API_BASE_URL: https://api.cubing-hub.com
 
 jobs:
@@ -36,11 +43,70 @@ jobs:
     permissions:
       actions: read
       contents: read
+      deployments: read
       packages: write
+    outputs:
+      runtime_config_mode: ${{ steps.runtime-config-mode.outputs.mode }}
+      runtime_config_digest: ${{ steps.publish-runtime-config.outputs.digest }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve last successful production revision
+        id: deployed-base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          deployments="$(
+            curl \
+              --fail \
+              --retry 3 \
+              --silent \
+              --show-error \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments?environment=production&per_page=30"
+          )"
+          deployed_sha=0000000000000000000000000000000000000000
+          while IFS=$'\t' read -r deployment_id deployment_candidate_sha; do
+            state="$(
+              curl \
+                --fail \
+                --retry 3 \
+                --silent \
+                --show-error \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses?per_page=1" \
+                | jq -r '.[0].state // empty'
+            )"
+            if [[ "${state}" == success ]]; then
+              deployed_sha="${deployment_candidate_sha}"
+              break
+            fi
+          done < <(jq -r '.[] | [.id, .sha] | @tsv' <<<"${deployments}")
+          if [[ ! "${deployed_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            printf 'Last successful deployment revision has an unexpected format\n' >&2
+            exit 64
+          fi
+          printf 'sha=%s\n' "${deployed_sha}" >>"${GITHUB_OUTPUT}"
+
+      - name: Detect runtime config changes
+        id: runtime-config-mode
+        env:
+          DEPLOYED_SHA: ${{ steps.deployed-base.outputs.sha }}
+          FORCE_SYNC: ${{ inputs.sync_runtime_config || false }}
+        run: |
+          mode="$(
+            /bin/bash ./homeserver/scripts/detect-runtime-config-change.sh \
+              "${DEPLOYED_SHA}" \
+              "${GITHUB_SHA}" \
+              "${FORCE_SYNC}"
+          )"
+          printf 'mode=%s\n' "${mode}" >>"${GITHUB_OUTPUT}"
 
       - name: Download backend jar
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
@@ -92,6 +158,25 @@ jobs:
           cache-from: type=gha,scope=cubing-hub-web-arm64
           cache-to: type=gha,mode=max,scope=cubing-hub-web-arm64
 
+      - name: Build and publish runtime config image
+        id: publish-runtime-config
+        if: steps.runtime-config-mode.outputs.mode == 'update'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: homeserver/runtime-config.Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.RUNTIME_CONFIG_IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            REVISION=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.sha }}
+          cache-from: type=gha,scope=cubing-hub-runtime-config
+          cache-to: type=gha,mode=max,scope=cubing-hub-runtime-config
+
       - name: Record published images
         env:
           API_IMAGE_DIGEST: ${{ steps.publish-api.outputs.digest }}
@@ -103,6 +188,14 @@ jobs:
             printf -- "  - Digest: \`%s\`\n" "${API_IMAGE_DIGEST}"
             printf -- "- Web: \`%s:%s\`\n" "${WEB_IMAGE_NAME}" "${GITHUB_SHA}"
             printf -- "  - Digest: \`%s\`\n" "${WEB_IMAGE_DIGEST}"
+            printf -- "- Runtime config mode: \`%s\`\n" \
+              "${{ steps.runtime-config-mode.outputs.mode }}"
+            if [[ "${{ steps.runtime-config-mode.outputs.mode }}" == update ]]; then
+              printf -- "- Runtime config digest: \`%s\`\n" \
+                "${{ steps.publish-runtime-config.outputs.digest }}"
+            else
+              printf -- "- Runtime config: current verified release retained\n"
+            fi
           } >>"${GITHUB_STEP_SUMMARY}"
 
   deploy:
@@ -146,7 +239,28 @@ jobs:
       - name: Deploy published images
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_CONFIG_MODE: ${{ needs.publish.outputs.runtime_config_mode }}
+          RUNTIME_CONFIG_DIGEST: ${{ needs.publish.outputs.runtime_config_digest }}
         run: |
+          set -Eeuo pipefail
+
+          case "${RUNTIME_CONFIG_MODE}" in
+            keep)
+              deploy_command="deploy-cubing-hub-v2 ${GITHUB_SHA} keep ${GITHUB_ACTOR}"
+              ;;
+            update)
+              if [[ ! "${RUNTIME_CONFIG_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                printf 'Runtime config digest has an unexpected format\n' >&2
+                exit 64
+              fi
+              deploy_command="deploy-cubing-hub-v2 ${GITHUB_SHA} update ${RUNTIME_CONFIG_DIGEST} ${GITHUB_ACTOR}"
+              ;;
+            *)
+              printf 'Runtime config mode has an unexpected value\n' >&2
+              exit 64
+              ;;
+          esac
+
           printf '%s' "${GHCR_TOKEN}" \
             | ssh \
                 -F /dev/null \
@@ -155,4 +269,4 @@ jobs:
                 -o IdentitiesOnly=yes \
                 -o StrictHostKeyChecking=yes \
                 homeserver@home-mini \
-                "deploy-cubing-hub ${GITHUB_SHA} ${GITHUB_ACTOR}"
+                "${deploy_command}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,8 +33,34 @@ jobs:
         run: |
           bash -n \
             homeserver/scripts/backup-home-server.sh \
+            homeserver/scripts/detect-runtime-config-change.sh \
             homeserver/scripts/deploy-home-server-ci.sh \
-            homeserver/scripts/deploy-home-server.sh
+            homeserver/scripts/deploy-home-server.sh \
+            homeserver/scripts/fixtures/mock-cubing-hub-docker.sh \
+            homeserver/scripts/test-backup-home-server.sh \
+            homeserver/scripts/test-deploy-home-server.sh
+
+      - name: Verify runtime config change detection
+        run: |
+          current_sha="$(git rev-parse HEAD)"
+          test "$(
+            /bin/bash ./homeserver/scripts/detect-runtime-config-change.sh \
+              "${current_sha}" \
+              "${current_sha}" \
+              false
+          )" = keep
+          test "$(
+            /bin/bash ./homeserver/scripts/detect-runtime-config-change.sh \
+              "${current_sha}" \
+              "${current_sha}" \
+              true
+          )" = update
+
+      - name: Test deploy v2 state transitions
+        run: /bin/bash ./homeserver/scripts/test-deploy-home-server.sh
+
+      - name: Test production backup Compose selection
+        run: /bin/bash ./homeserver/scripts/test-backup-home-server.sh
 
       - name: Run infrastructure tests
         run: >
@@ -49,6 +75,44 @@ jobs:
             --env-file homeserver/.env.example \
             --file homeserver/docker-compose.yml \
             config --quiet
+
+      - name: Build and verify runtime config image
+        run: |
+          docker build \
+            --file homeserver/runtime-config.Dockerfile \
+            --build-arg REVISION=1111111111111111111111111111111111111111 \
+            --tag cubing-hub-runtime-config:verify \
+            .
+
+          actual_revision="$(
+            docker image inspect \
+              --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+              cubing-hub-runtime-config:verify
+          )"
+          test "${actual_revision}" = 1111111111111111111111111111111111111111
+
+          container_id="$(docker create cubing-hub-runtime-config:verify)"
+          runtime_dir="$(mktemp -d)"
+
+          cleanup_runtime_config() {
+            docker rm "${container_id}" >/dev/null 2>&1 || true
+            rm -rf -- "${runtime_dir}"
+          }
+          trap cleanup_runtime_config EXIT INT TERM
+
+          docker cp "${container_id}:/runtime/." "${runtime_dir}"
+          test -f "${runtime_dir}/compose.yaml"
+          test -f "${runtime_dir}/nginx/cloudflare-edge-real-ip.conf"
+
+          cp homeserver/.env.example "${runtime_dir}/.env"
+          API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:1111111111111111111111111111111111111111 \
+          WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:1111111111111111111111111111111111111111 \
+            docker compose \
+              --project-directory "${runtime_dir}" \
+              --env-file "${runtime_dir}/.env" \
+              --file "${runtime_dir}/compose.yaml" \
+              config \
+              --quiet
 
           docker compose \
             --env-file homeserver/.env.example \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,13 +32,16 @@ jobs:
       - name: Validate shell scripts
         run: |
           bash -n \
+            homeserver/scripts/backup-home-server-bootstrap.sh \
             homeserver/scripts/backup-home-server.sh \
             homeserver/scripts/detect-runtime-config-change.sh \
             homeserver/scripts/deploy-home-server-ci.sh \
             homeserver/scripts/deploy-home-server.sh \
             homeserver/scripts/fixtures/mock-cubing-hub-docker.sh \
             homeserver/scripts/test-backup-home-server.sh \
-            homeserver/scripts/test-deploy-home-server.sh
+            homeserver/scripts/test-detect-runtime-config-change.sh \
+            homeserver/scripts/test-deploy-home-server.sh \
+            homeserver/scripts/test-runtime-script-bootstrap.sh
 
       - name: Verify runtime config change detection
         run: |
@@ -55,6 +58,8 @@ jobs:
               "${current_sha}" \
               true
           )" = update
+          /bin/bash ./homeserver/scripts/test-detect-runtime-config-change.sh
+          /bin/bash ./homeserver/scripts/test-runtime-script-bootstrap.sh
 
       - name: Test deploy v2 state transitions
         run: /bin/bash ./homeserver/scripts/test-deploy-home-server.sh
@@ -103,6 +108,24 @@ jobs:
           docker cp "${container_id}:/runtime/." "${runtime_dir}"
           test -f "${runtime_dir}/compose.yaml"
           test -f "${runtime_dir}/nginx/cloudflare-edge-real-ip.conf"
+          test -x "${runtime_dir}/scripts/deploy-cubing-hub.sh"
+          test -x "${runtime_dir}/scripts/backup-cubing-hub.sh"
+          test "$(stat -c '%a' "${runtime_dir}/scripts/deploy-cubing-hub.sh")" = 700
+          test "$(stat -c '%a' "${runtime_dir}/scripts/backup-cubing-hub.sh")" = 700
+          test "$(
+            find "${runtime_dir}" -mindepth 1 -printf '%P\n' | LC_ALL=C sort
+          )" = "$(
+            printf '%s\n' \
+              compose.yaml \
+              nginx \
+              nginx/cloudflare-edge-real-ip.conf \
+              scripts \
+              scripts/backup-cubing-hub.sh \
+              scripts/deploy-cubing-hub.sh
+          )"
+          bash -n \
+            "${runtime_dir}/scripts/deploy-cubing-hub.sh" \
+            "${runtime_dir}/scripts/backup-cubing-hub.sh"
 
           cp homeserver/.env.example "${runtime_dir}/.env"
           API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:1111111111111111111111111111111111111111 \

--- a/docs/Deployment & Infrastructure Design.md
+++ b/docs/Deployment & Infrastructure Design.md
@@ -4,6 +4,8 @@
 
 - 운영 목표는 Mac mini 한 대에서 `web`, `api`, `db`, `redis`를 Docker Compose로 실행하는 것이다.
 - API와 web 이미지는 GitHub-hosted ARM64 runner에서 검증하고 GHCR에 full commit SHA tag로 발행한다.
+- Compose와 공개 Nginx 설정은 변경된 배포에서만 immutable runtime-config
+  image로 발행하고 exact digest로 적용한다.
 - GitHub Actions는 Tailscale OIDC와 Cubing Hub 전용 forced-command SSH를 통해 Mac mini 배포 script만 호출한다.
 - 공개 traffic은 Mac mini의 공유 Cloudflare Tunnel과 external `edge` Docker network를 사용한다.
 - 삭제된 기존 원격 DB 데이터를 복구하거나 이관하지 않고 신규 MySQL volume에서 시작한다.
@@ -38,6 +40,7 @@
   - 운영 설정 Node test
   - production/admin Compose render
   - Nginx runtime config
+  - runtime-config 변경 감지와 artifact allowlist
   - frontend Dockerfile check
 - Images
   - GitHub-hosted ARM64 runner에서 API/web `linux/arm64` image build
@@ -67,7 +70,8 @@
 | 목적 | 경로 |
 | --- | --- |
 | App directory | `/Users/homeserver/Server/apps/cubing-hub` |
-| Compose | `/Users/homeserver/Server/apps/cubing-hub/compose.yaml` |
+| Legacy/bootstrap Compose | `/Users/homeserver/Server/apps/cubing-hub/compose.yaml` |
+| Verified runtime config | `/Users/homeserver/Server/apps/cubing-hub/runtime-config` |
 | Runtime env | `/Users/homeserver/Server/apps/cubing-hub/.env` |
 | Post images | `/Users/homeserver/Server/data/cubing-hub/post-images` |
 | Backup | `/Users/homeserver/Server/backups/cubing-hub` |
@@ -75,6 +79,8 @@
 | Backup script | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh` |
 
 - runtime 파일은 repository checkout 밖에 둔다.
+- v2 초기화 뒤 active Compose는 검증된 `state`와 atomic `current` pointer가
+  같은 immutable release를 가리킬 때만 사용한다.
 - `.env`와 private key는 Git에 추가하지 않는다.
 - 실제 비밀값은 문서, log, command output에 노출하지 않는다.
 
@@ -128,9 +134,11 @@
 
 1. `main`과 `MAC_MINI_DEPLOY_ENABLED=true` 조건 확인
 2. Validate 성공 확인
-3. GHCR 로그인
-4. API/web `linux/arm64` image를 같은 commit SHA tag로 발행
-5. image digest를 GitHub Actions summary에 기록
+3. 마지막 성공 Production revision 이후 runtime-config path 변경 여부 확인
+4. GHCR 로그인
+5. API/web `linux/arm64` image를 같은 commit SHA tag로 발행
+6. runtime config가 바뀐 경우에만 allowlisted artifact를 exact digest로 발행
+7. application SHA, config mode와 digest를 GitHub Actions summary에 기록
 
 ### Deploy
 
@@ -138,10 +146,13 @@
 2. Tailscale OIDC로 `home-mini` 연결
 3. 고정 `known_hosts`와 전용 SSH identity 검증
 4. GHCR token을 standard input으로 forced command에 전달
-5. Mac mini deploy script가 두 image를 pull
-6. 첫 배포는 `db`, `redis`부터 health 확인 뒤 API/web 기동
-7. 업데이트는 backup 성공 뒤 API/web를 같은 SHA로 교체
-8. web health 실패 시 이전 SHA로 rollback
+5. Mac mini deploy script가 API/web image와 `update`일 때만 runtime-config
+   exact digest를 pull
+6. artifact provenance·allowlist와 service/network/data/health 보호 경계 검증
+7. 첫 배포는 `db`, `redis`부터 health 확인 뒤 API/web 기동
+8. 업데이트는 backup 성공 뒤 API/web와 runtime config를 한 transaction으로 적용
+9. 모든 필수 service가 running/healthy일 때만 `state`와 `current` commit
+10. 실패 시 이전 application SHA와 config digest 쌍으로 rollback
 
 ## 6. GitHub 설정
 
@@ -173,6 +184,8 @@
 
 ```text
 deploy-cubing-hub <commit-sha> <registry-user>
+deploy-cubing-hub-v2 <commit-sha> keep <registry-user>
+deploy-cubing-hub-v2 <commit-sha> update <config-digest> <registry-user>
 ```
 
 - shell, port forwarding, PTY 같은 일반 원격 접근 권한을 배포 key에 부여하지 않는다.
@@ -183,8 +196,11 @@ deploy-cubing-hub <commit-sha> <registry-user>
 - `post_attachments.object_key`와 image snapshot의 파일 존재 여부를 대조한다.
 - 검증에 실패한 backup은 성공본으로 보관하지 않는다.
 - 성공한 backup은 최신 `3개`를 유지한다.
+- v2 초기화 뒤 backup은 검증된 active runtime-config release를 사용하며
+  손상된 `state`나 `current`에서 legacy Compose로 fallback하지 않는다.
 - 첫 배포는 이전 운영 SHA가 없으므로 공개 cutover 전에 실패를 해결한다.
-- 업데이트 health 실패 시 이전 API/web SHA로 Compose를 되돌린다.
+- 업데이트 health 실패 시 이전 API/web SHA와 runtime-config digest 쌍으로
+  Compose를 되돌린다.
 - 데이터 restore는 자동 rollback에 포함하지 않고 별도 승인과 격리 검증 뒤 진행한다.
 
 ## 9. Cloudflare route
@@ -259,6 +275,8 @@ route 변경 전 현재 Cloudflare 구성을 backup한다. Cubing Hub route만 �
 | --- | --- | --- |
 | API/web image pull 실패 | 새 SHA 배포 중단 | GHCR package 권한과 tag 확인 |
 | API health 실패 | 이전 API/web SHA rollback | application log와 DB/Redis 상태 확인 |
+| runtime config 검증 실패 | 운영 pair 유지 | artifact digest·revision·allowlist 확인 |
+| runtime config transaction 중단 | 후속 배포 중단 | `pending` 검증 뒤 recovery 명령 실행 |
 | MySQL 연결 실패 | DB health와 runtime env 확인 | volume과 Flyway history 확인 |
 | Redis 장애 | 인증/랭킹 영향 확인 | persistence와 rebuild 절차 검토 |
 | 이미지 파일 불일치 | 공개 전환 중단 | DB object key와 snapshot 대조 |

--- a/docs/Deployment & Infrastructure Design.md
+++ b/docs/Deployment & Infrastructure Design.md
@@ -148,7 +148,8 @@
 4. GHCR token을 standard input으로 forced command에 전달
 5. Mac mini deploy script가 API/web image와 `update`일 때만 runtime-config
    exact digest를 pull
-6. artifact provenance·allowlist와 service/network/data/health 보호 경계 검증
+6. artifact provenance·allowlist와 service/network/data 보호 경계, exact
+   healthcheck `test`, process user와 `tmpfs` target 집합 검증
 7. 첫 배포는 `db`, `redis`부터 health 확인 뒤 API/web 기동
 8. 업데이트는 backup 성공 뒤 API/web와 runtime config를 한 transaction으로 적용
 9. 모든 필수 service가 running/healthy일 때만 `state`와 `current` commit

--- a/docs/Deployment & Infrastructure Design.md
+++ b/docs/Deployment & Infrastructure Design.md
@@ -76,8 +76,8 @@
 | Runtime env | `/Users/homeserver/Server/apps/cubing-hub/.env` |
 | Post images | `/Users/homeserver/Server/data/cubing-hub/post-images` |
 | Backup | `/Users/homeserver/Server/backups/cubing-hub` |
-| Deploy script | `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh` |
-| Backup script | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh` |
+| Legacy deploy fallback | `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh` |
+| Legacy backup fallback | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh` |
 | Deploy bootstrap | `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh` |
 | Backup bootstrap | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh` |
 
@@ -88,7 +88,8 @@
 - 고정 forced-command wrapper/deploy bootstrap과 별도 backup bootstrap은
   최초 전환 때 수동 설치하며 runtime artifact로 자기 갱신하지 않는다.
   고정 deploy/backup worker는 기존 2파일 v2와 pre-v2 fallback용으로
-  보존한다.
+  보존하되 branch 원본으로 사전 교체하지 않는다. 첫 `update`부터 active
+  worker는 exact runtime-config release에서만 선택한다.
 - `.env`와 private key는 Git에 추가하지 않는다.
 - 실제 비밀값은 문서, log, command output에 노출하지 않는다.
 

--- a/docs/Deployment & Infrastructure Design.md
+++ b/docs/Deployment & Infrastructure Design.md
@@ -4,8 +4,9 @@
 
 - 운영 목표는 Mac mini 한 대에서 `web`, `api`, `db`, `redis`를 Docker Compose로 실행하는 것이다.
 - API와 web 이미지는 GitHub-hosted ARM64 runner에서 검증하고 GHCR에 full commit SHA tag로 발행한다.
-- Compose와 공개 Nginx 설정은 변경된 배포에서만 immutable runtime-config
-  image로 발행하고 exact digest로 적용한다.
+- Compose, 공개 Nginx 설정과 허용된 project deploy/backup script는 변경된
+  배포에서만 immutable runtime-config image로 발행하고 exact digest로
+  적용한다.
 - GitHub Actions는 Tailscale OIDC와 Cubing Hub 전용 forced-command SSH를 통해 Mac mini 배포 script만 호출한다.
 - 공개 traffic은 Mac mini의 공유 Cloudflare Tunnel과 external `edge` Docker network를 사용한다.
 - 삭제된 기존 원격 DB 데이터를 복구하거나 이관하지 않고 신규 MySQL volume에서 시작한다.
@@ -77,10 +78,17 @@
 | Backup | `/Users/homeserver/Server/backups/cubing-hub` |
 | Deploy script | `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh` |
 | Backup script | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh` |
+| Deploy bootstrap | `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh` |
+| Backup bootstrap | `/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh` |
 
 - runtime 파일은 repository checkout 밖에 둔다.
 - v2 초기화 뒤 active Compose는 검증된 `state`와 atomic `current` pointer가
-  같은 immutable release를 가리킬 때만 사용한다.
+  같은 immutable release를 가리킬 때만 사용한다. Active deploy/backup
+  script도 같은 release에서 선택한다.
+- 고정 forced-command wrapper/deploy bootstrap과 별도 backup bootstrap은
+  최초 전환 때 수동 설치하며 runtime artifact로 자기 갱신하지 않는다.
+  고정 deploy/backup worker는 기존 2파일 v2와 pre-v2 fallback용으로
+  보존한다.
 - `.env`와 private key는 Git에 추가하지 않는다.
 - 실제 비밀값은 문서, log, command output에 노출하지 않는다.
 
@@ -146,14 +154,19 @@
 2. Tailscale OIDC로 `home-mini` 연결
 3. 고정 `known_hosts`와 전용 SSH identity 검증
 4. GHCR token을 standard input으로 forced command에 전달
-5. Mac mini deploy script가 API/web image와 `update`일 때만 runtime-config
-   exact digest를 pull
-6. artifact provenance·allowlist와 service/network/data 보호 경계, exact
-   healthcheck `test`, process user와 `tmpfs` target 집합 검증
-7. 첫 배포는 `db`, `redis`부터 health 확인 뒤 API/web 기동
-8. 업데이트는 backup 성공 뒤 API/web와 runtime config를 한 transaction으로 적용
-9. 모든 필수 service가 running/healthy일 때만 `state`와 `current` commit
-10. 실패 시 이전 application SHA와 config digest 쌍으로 rollback
+5. Deploy/backup 공통 advisory lock을 획득하고 경합 또는 pending recovery는
+   운영 변경 전에 fail-closed
+6. Mac mini deploy bootstrap이 API/web image와 `update`일 때만
+   runtime-config exact digest를 pull
+7. artifact provenance·Compose/Nginx/deploy/backup allowlist, script
+   mode·문법과 service/network/data 보호 경계, exact healthcheck `test`,
+   process user와 `tmpfs` target 집합 검증
+8. 첫 배포는 `db`, `redis`부터 health 확인 뒤 API/web 기동
+9. 업데이트는 backup 성공 뒤 API/web와 runtime config를 한 transaction으로 적용
+10. 검증된 candidate deploy script가 모든 필수 service를
+   running/healthy로 만든 경우에만 `state`와 Compose/script 공통
+   `current`를 commit
+11. 실패 시 이전 application SHA와 config digest 쌍으로 rollback
 
 ## 6. GitHub 설정
 
@@ -199,6 +212,8 @@ deploy-cubing-hub-v2 <commit-sha> update <config-digest> <registry-user>
 - 성공한 backup은 최신 `3개`를 유지한다.
 - v2 초기화 뒤 backup은 검증된 active runtime-config release를 사용하며
   손상된 `state`나 `current`에서 legacy Compose로 fallback하지 않는다.
+- Deploy와 scheduled backup은 stable bootstrap의 같은 advisory lock으로
+  직렬화하며, lock 경합과 pending recovery에서는 backup을 시작하지 않는다.
 - 첫 배포는 이전 운영 SHA가 없으므로 공개 cutover 전에 실패를 해결한다.
 - 업데이트 health 실패 시 이전 API/web SHA와 runtime-config digest 쌍으로
   Compose를 되돌린다.

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -16,20 +16,29 @@
 /Users/homeserver/Server/apps/cubing-hub/runtime-config/state
 /Users/homeserver/Server/apps/cubing-hub/runtime-config/current
 /Users/homeserver/Server/apps/cubing-hub/runtime-config/releases/<digest>/compose.yaml
+/Users/homeserver/Server/apps/cubing-hub/runtime-config/releases/<digest>/scripts/deploy-cubing-hub.sh
+/Users/homeserver/Server/apps/cubing-hub/runtime-config/releases/<digest>/scripts/backup-cubing-hub.sh
 /Users/homeserver/Server/data/cubing-hub/post-images/
 /Users/homeserver/Server/backups/cubing-hub/
 ```
 
-runtime config v2 initialization marker가 있으면 backup은 state의 content
-hash와 `current` pointer가 함께 가리키는 immutable release Compose만
-사용한다. marker가 있는데 state 또는 current가 없으면 손상 상태로
-판단해 실패한다. marker, state, current가 모두 없는 기존 설치에서만 app
+runtime config v2 initialization marker가 있으면 별도 고정 backup bootstrap은
+state의 content hash와 `current` pointer가 함께 가리키는 immutable release의
+backup script를 실행한다. 해당 script는 같은 release Compose만 사용한다.
+marker가 있는데 state 또는 current가 없으면 손상 상태로 판단해 실패한다.
+marker, state, current가 모두 없는 기존 설치에서만 고정 bootstrap과 app
 directory의 legacy `compose.yaml`로 fallback한다.
+
+Backup bootstrap은 deploy bootstrap과 같은
+`/Users/homeserver/Server/apps/cubing-hub/.cubing-hub-operation.lock`을
+non-blocking으로 획득한다. 다른 deploy/backup이 실행 중이면 exit `75`로
+중단하고, runtime config `pending`이 있으면 recovery가 완료될 때까지
+backup을 시작하지 않는다. Persistent mode `600` lock file은 삭제하지 않는다.
 
 ## 백업 실행
 
 ```bash
-/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh
+/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
 ```
 
 스크립트는 다음 순서로 실행한다.
@@ -71,7 +80,7 @@ backup이 실패하면 기존 정상 backup은 삭제하지 않는다. 실패 �
 ## LaunchAgent
 
 `homeserver/launchd/com.cubinghub-backup.plist.example`은 매일
-04:10에 repository 밖의 고정 backup script를 실행한다.
+04:10에 repository 밖의 고정 backup bootstrap을 실행한다.
 
 ```bash
 mkdir -p /Users/homeserver/Library/LaunchAgents \

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -11,11 +11,20 @@
 ## 운영 경로
 
 ```text
-/Users/homeserver/Server/apps/cubing-hub/compose.yaml
 /Users/homeserver/Server/apps/cubing-hub/.env
+/Users/homeserver/Server/apps/cubing-hub/.runtime-config-v2-initialized
+/Users/homeserver/Server/apps/cubing-hub/runtime-config/state
+/Users/homeserver/Server/apps/cubing-hub/runtime-config/current
+/Users/homeserver/Server/apps/cubing-hub/runtime-config/releases/<digest>/compose.yaml
 /Users/homeserver/Server/data/cubing-hub/post-images/
 /Users/homeserver/Server/backups/cubing-hub/
 ```
+
+runtime config v2 initialization marker가 있으면 backup은 state의 content
+hash와 `current` pointer가 함께 가리키는 immutable release Compose만
+사용한다. marker가 있는데 state 또는 current가 없으면 손상 상태로
+판단해 실패한다. marker, state, current가 모두 없는 기존 설치에서만 app
+directory의 legacy `compose.yaml`로 fallback한다.
 
 ## 백업 실행
 

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -26,23 +26,60 @@ deploy-cubing-hub-v2 <40자리 commit SHA> update <config digest> <registry user
 v2 workflow를 `main`에 병합하기 전에 repository의
 `homeserver/scripts/deploy-home-server.sh`,
 `homeserver/scripts/deploy-home-server-ci.sh`,
+`homeserver/scripts/backup-home-server-bootstrap.sh`,
 `homeserver/scripts/backup-home-server.sh`를 각각 Mac mini의
 `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh`와
 `/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh`,
+`/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh`,
 `/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh`에 사전
 설치해야 한다. 기존 파일을 timestamp backup으로 보존하고, 설치본의
 SHA-256이 repository 원본과 일치하는지, mode가 `700`인지, `/bin/bash -n`과
 잘못된 forced command 거부가 통과하는지 확인한 뒤에만 merge한다.
 이 prerequisite가 완료되지 않으면 기존 wrapper가 v2 명령을 거부하거나
 backup이 legacy Compose만 찾으므로 workflow를 병합하지 않는다.
-deploy·backup script는 runtime config artifact의 자동 동기화 대상이
-아니다.
+`deploy-home-server-ci.sh`와 `backup-home-server-bootstrap.sh`는 최초 v2
+전환을 위한 stable wrapper/bootstrap이며 runtime artifact로 자동 교체하지
+않는다. 고정 deploy/backup worker는 기존 2파일 v2 또는 pre-v2 fallback용으로
+보존한다.
 
 마지막 성공 production deployment 이후 `homeserver/docker-compose.yml`,
-pinned Cloudflare real-IP 설정 또는 `homeserver/runtime-config.Dockerfile`이
-변경된 배포만 immutable runtime-config image를 새로 발행하고 `update`한다.
-따라서 설정 배포가 실패해도 다음 배포가 변경을 이어받는다. 애플리케이션만
-바뀌면 `keep`으로 현재 검증된 config digest를 유지한다.
+pinned Cloudflare real-IP 설정, 허용된 deploy/backup script,
+`.dockerignore`의 runtime artifact 입력 또는
+`homeserver/runtime-config.Dockerfile`이 변경된 배포만 immutable
+runtime-config image를 새로 발행하고 `update`한다. 따라서 설정·script
+배포가 실패해도 다음 배포가 변경을 이어받는다. 애플리케이션만 바뀌면
+`keep`으로 현재 검증된 config digest를 유지한다.
+
+runtime-config image에는 아래 네 파일만 들어간다.
+
+```text
+compose.yaml
+nginx/cloudflare-edge-real-ip.conf
+scripts/deploy-cubing-hub.sh
+scripts/backup-cubing-hub.sh
+```
+
+고정 forced-command/bootstrap은 exact digest, revision/project label, regular-file
+allowlist, 전체 content hash, script mode `700`과 `/bin/bash -n`을 검증한
+뒤 immutable release의 candidate deploy script를 실행한다. 첫 성공 전에는
+legacy Compose와 고정 legacy backup worker를 사용한다. v2 성공 뒤에는
+`runtime-config/current`가 Compose와 deploy/backup script의 공통 active
+release를 가리킨다. `keep`, recovery와 정기 backup은 이 release의 검증된
+script를 사용한다.
+
+Deploy와 scheduled backup 진입점은
+`/Users/homeserver/Server/apps/cubing-hub/.cubing-hub-operation.lock`의 같은
+non-blocking advisory lock을 FD `9`로 잡고 worker 전체 실행 동안 유지한다.
+다른 작업이 실행 중이면 새 작업은 exit `75`로 fail-closed하며 pull, backup,
+state 또는 container 변경을 시작하지 않는다. Lock file은 mode `600`
+regular file로 계속 보존하고 프로세스 종료 시 kernel lock이 자동
+해제되므로 수동으로 삭제하지 않는다.
+
+Artifact 추출·script 검증 또는 candidate preflight가 실패하면
+`state`, `current`, `.env`와 실행 중 container를 바꾸지 않는다. Candidate
+배포가 실패하면 기존 application/config pair를 재적용하며 `current`는
+기존 release를 유지한다. Stable wrapper/bootstrap 자체를 바꾸는 작업만
+기존 파일의 timestamp backup과 별도 운영 승인 아래 수동 설치한다.
 
 배포 script는 Compose 전체 snapshot을 복제하지 않는다. healthcheck timing,
 logging, restart, replica, PID·tmpfs mount option과 일반 application
@@ -79,7 +116,8 @@ migration·backup·rollback 계획으로 진행한다.
 두 번째 배포부터는 다음 순서로 진행한다.
 
 1. 신규 API/Web image pull과, `update`일 때만 runtime config exact digest pull
-2. config provenance, 파일 allowlist, network·upload bind 계약과 Compose render
+2. config provenance, 파일 allowlist, deploy/backup script mode·문법,
+   network·upload bind 계약과 Compose render
 3. 운영 DB 실행 상태 확인
 4. MySQL dump와 게시글 이미지 backup
 5. `.env`의 API/Web image를 같은 신규 SHA로 교체
@@ -98,11 +136,13 @@ v2 배포가 강제 종료되거나 host가 재시작되어
 말고 Mac mini에서 다음 recovery 명령을 실행한다.
 
 ```bash
-/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh recover
+/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh recover
 ```
 
-recovery는 pending key와 SHA/digest 형식, 마지막 검증 state, release
-allowlist와 content hash를 먼저 대조한다.
+고정 forced-command/bootstrap은 검증된 state가 있으면 active release의 deploy
+script로 recovery를 전달한다. Recovery는 pending key와 SHA/digest 형식,
+마지막 검증 state, Compose·Nginx·deploy/backup script allowlist와 content
+hash를 먼저 대조한다.
 
 - 성공 state가 이미 target pair라면 `.env`와 실행 service를 검증한 뒤
   검증된 target release로 stale `current` pointer를 원자 조정하고 pending
@@ -202,12 +242,16 @@ test -f "${runtime_release}/compose.yaml"
 ## 백업
 
 ```bash
-/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh
+/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
 ```
 
-스크립트는 MySQL dump와 게시글 이미지 snapshot을 같은 run으로 만들고,
+고정 backup bootstrap은 `state`, `current`, content hash를 검증해 active
+release의 backup worker를 실행한다. Worker는 MySQL dump와 게시글 이미지
+snapshot을 같은 run으로 만들고,
 `post_attachments.object_key`가 가리키는 파일이 없으면 실패한다.
 성공 결과를 최종 directory로 이동한 뒤에만 오래된 backup을 정리한다.
+Deploy 또는 다른 backup이 공통 lock을 보유하거나 runtime config
+`pending` recovery가 남아 있으면 backup은 운영 data를 읽기 전에 실패한다.
 
 성공한 backup은 기본으로 최신 3개만 보관한다. 실패한 run은 조사할 수
 있도록 임시 directory를 남기며 기존 정상 backup을 삭제하지 않는다.

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -2,8 +2,10 @@
 
 ## 배포 전 확인
 
-- `/Users/homeserver/Server/apps/cubing-hub/compose.yaml`과 `.env`가
-  존재한다.
+- `/Users/homeserver/Server/apps/cubing-hub/.env`가 존재하고, runtime
+  config v2 도입 후에는 검증된 `state`와 `current` release가 일치한다.
+  v2 state가 아직 없는 기존 설치에서만 app directory의 legacy
+  `compose.yaml`을 사용한다.
 - `API_IMAGE`, `WEB_IMAGE`는 GHCR의 같은 40자리 commit SHA를 가리킨다.
 - 두 image의 platform은 `linux/arm64`다.
 - `/Users/homeserver/Server/data/cubing-hub/post-images/`가 존재한다.
@@ -17,7 +19,54 @@ GitHub Actions는 GHCR token을 stdin으로 전달하고 forced-command SSH에�
 
 ```text
 deploy-cubing-hub <40자리 commit SHA> <registry user>
+deploy-cubing-hub-v2 <40자리 commit SHA> keep <registry user>
+deploy-cubing-hub-v2 <40자리 commit SHA> update <config digest> <registry user>
 ```
+
+v2 workflow를 `main`에 병합하기 전에 repository의
+`homeserver/scripts/deploy-home-server.sh`,
+`homeserver/scripts/deploy-home-server-ci.sh`,
+`homeserver/scripts/backup-home-server.sh`를 각각 Mac mini의
+`/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh`와
+`/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh`,
+`/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh`에 사전
+설치해야 한다. 기존 파일을 timestamp backup으로 보존하고, 설치본의
+SHA-256이 repository 원본과 일치하는지, mode가 `700`인지, `/bin/bash -n`과
+잘못된 forced command 거부가 통과하는지 확인한 뒤에만 merge한다.
+이 prerequisite가 완료되지 않으면 기존 wrapper가 v2 명령을 거부하거나
+backup이 legacy Compose만 찾으므로 workflow를 병합하지 않는다.
+deploy·backup script는 runtime config artifact의 자동 동기화 대상이
+아니다.
+
+마지막 성공 production deployment 이후 `homeserver/docker-compose.yml`,
+pinned Cloudflare real-IP 설정 또는 `homeserver/runtime-config.Dockerfile`이
+변경된 배포만 immutable runtime-config image를 새로 발행하고 `update`한다.
+따라서 설정 배포가 실패해도 다음 배포가 변경을 이어받는다. 애플리케이션만
+바뀌면 `keep`으로 현재 검증된 config digest를 유지한다.
+
+배포 script는 Compose 전체 snapshot을 복제하지 않는다. healthcheck timing,
+logging, restart, replica, PID·tmpfs와 일반 application environment 변경은
+Compose render와 service health로 검증한다. 대신 아래 운영 보호 경계만
+고정한다.
+
+- `db`, `redis`, `api`, `web` service와 API/Web exact image
+- DB·Redis command/entrypoint, DB의 `MYSQL_*`, API의 DB·Redis·upload identity와
+  Spring profile·datasource·JPA·Flyway·Liquibase·SQL init·config JSON 및
+  JVM option 설정
+- API/Web image command·entrypoint override 금지
+- DB의 loopback `mysqladmin ping`, Redis의 `redis-cli ping`, Web의
+  loopback actuator `status=UP`·Host probe 의미와 배포 완료 시 실제
+  running/healthy 상태. 동등한 probe 표현과 timing은 변경 가능
+- MySQL·Redis named volume과 기존 upload bind identity
+- internal application, API 전용 outbound, shared edge network 경계
+- host port, privileged mode, Docker socket, host namespace, 추가 host bind,
+  `extra_hosts`·link를 통한 service hostname override 금지
+- Compose `configs`, `secrets`, `env_file`을 통한 host file 주입 금지
+- candidate release의 pinned Nginx real-IP bind
+
+DB·Redis image·실행 명령이나 data-sensitive Spring 설정 등 위 보호 경계를
+바꾸는 작업은 일반 runtime config 동기화가 아니라 별도
+migration·backup·rollback 계획으로 진행한다.
 
 첫 배포는 기존 image SHA가 없으므로 다음 순서로 진행한다.
 
@@ -29,33 +78,86 @@ deploy-cubing-hub <40자리 commit SHA> <registry user>
 
 두 번째 배포부터는 다음 순서로 진행한다.
 
-1. 신규 API/web image pull과 Compose render
-2. 운영 DB 실행 상태 확인
-3. MySQL dump와 게시글 이미지 backup
-4. `.env`의 API/web image를 같은 신규 SHA로 교체
-5. Compose 적용과 health 확인
-6. 실패 시 이전 API/web SHA를 함께 복구
+1. 신규 API/Web image pull과, `update`일 때만 runtime config exact digest pull
+2. config provenance, 파일 allowlist, network·upload bind 계약과 Compose render
+3. 운영 DB 실행 상태 확인
+4. MySQL dump와 게시글 이미지 backup
+5. `.env`의 API/Web image를 같은 신규 SHA로 교체
+6. Compose 적용과 health 확인
+7. 실패 시 이전 API/Web SHA와 runtime config를 함께 복구
 
 DB migration은 image rollback과 별개다. Flyway migration 뒤 이전
 image가 새 schema와 호환되지 않으면 자동 rollback 결과를 성공으로
 간주하지 말고 수동 판단한다.
+
+## 중단된 runtime config transaction 복구
+
+v2 배포가 강제 종료되거나 host가 재시작되어
+`/Users/homeserver/Server/apps/cubing-hub/runtime-config/pending`이 남으면
+후속 v2 배포는 fail closed한다. pending 파일을 직접 삭제하거나 수정하지
+말고 Mac mini에서 다음 recovery 명령을 실행한다.
+
+```bash
+/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh recover
+```
+
+recovery는 pending key와 SHA/digest 형식, 마지막 검증 state, release
+allowlist와 content hash를 먼저 대조한다.
+
+- 성공 state가 이미 target pair라면 `.env`와 실행 service를 검증한 뒤
+  검증된 target release로 stale `current` pointer를 원자 조정하고 pending
+  marker를 정리한다.
+- state가 previous pair라면 이전 API/Web SHA와 config release를
+  `--pull never`로 다시 적용하고 health가 통과한 뒤 marker를 정리한다.
+- runtime config 도입 전 기존 설치라면 legacy Compose와 이전 SHA로
+  복구한다.
+- 정상 image가 한 번도 없던 bootstrap 중단이라면 API/Web을 중지하고
+  zero-SHA placeholder로 되돌려 다음 배포가 첫 배포로 다시 시작하게 한다.
+- pending/state가 서로 맞지 않거나 release가 변조됐으면 아무것도
+  정리하지 않고 실패한다.
+- 첫 성공 시 app directory에 별도 initialization marker를 원자 생성한다.
+  이 marker가 있는데 `state` 또는 `current`가 사라지면 pre-v2 설치로
+  fallback하지 않고 실패한다. marker가 생기기 전 실패한 bootstrap의
+  동일 digest candidate release는 다음 `update`에서 image와 다시 대조한
+  뒤 재사용할 수 있다.
+
+복구 후 production Compose `ps`, API/Web health, DB·Redis health와 public
+URL을 다시 확인한다. Flyway migration은 recovery가 되돌리지 않는다.
 
 ## 수동 상태 확인
 
 Mac mini에서 다음 명령을 사용한다.
 
 ```bash
-cd /Users/homeserver/Server/apps/cubing-hub
+app_dir=/Users/homeserver/Server/apps/cubing-hub
+runtime_root="${app_dir}/runtime-config"
+runtime_digest="$(
+  /usr/bin/sed -n 's/^RUNTIME_CONFIG_DIGEST=//p' \
+    "${runtime_root}/state"
+)"
+[[ "${runtime_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+runtime_release="${runtime_root}/releases/${runtime_digest#sha256:}"
+test "$(/usr/bin/readlink "${runtime_root}/current")" = \
+  "releases/${runtime_digest#sha256:}"
+test -f "${runtime_release}/compose.yaml"
+
 /usr/local/bin/docker compose \
-  --env-file .env \
-  --file compose.yaml \
+  --project-name cubing-hub \
+  --project-directory "${runtime_release}" \
+  --env-file "${app_dir}/.env" \
+  --file "${runtime_release}/compose.yaml" \
   ps
 
 /usr/local/bin/docker compose \
-  --env-file .env \
-  --file compose.yaml \
+  --project-name cubing-hub \
+  --project-directory "${runtime_release}" \
+  --env-file "${app_dir}/.env" \
+  --file "${runtime_release}/compose.yaml" \
   logs --tail 200 api web db redis
 ```
+
+runtime config v2 state가 아직 없는 기존 설치에서만
+`${app_dir}/compose.yaml`을 Compose file로 사용한다.
 
 공개 경로는 아래를 확인한다.
 
@@ -72,10 +174,24 @@ curl -fsS https://api.cubing-hub.com/actuator/health
 Mac mini app directory에 설치하고 admin profile을 실행한다.
 
 ```bash
+app_dir=/Users/homeserver/Server/apps/cubing-hub
+runtime_root="${app_dir}/runtime-config"
+runtime_digest="$(
+  /usr/bin/sed -n 's/^RUNTIME_CONFIG_DIGEST=//p' \
+    "${runtime_root}/state"
+)"
+[[ "${runtime_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+runtime_release="${runtime_root}/releases/${runtime_digest#sha256:}"
+test "$(/usr/bin/readlink "${runtime_root}/current")" = \
+  "releases/${runtime_digest#sha256:}"
+test -f "${runtime_release}/compose.yaml"
+
 /usr/local/bin/docker compose \
-  --env-file .env \
-  --file compose.yaml \
-  --file compose.admin.yaml \
+  --project-name cubing-hub \
+  --project-directory "${runtime_release}" \
+  --env-file "${app_dir}/.env" \
+  --file "${runtime_release}/compose.yaml" \
+  --file "${app_dir}/compose.admin.yaml" \
   --profile admin \
   up --detach db-admin-proxy
 ```
@@ -109,7 +225,8 @@ Mac mini app directory에 설치하고 admin profile을 실행한다.
 
 ## 장애와 rollback
 
-- API/web image 문제면 이전 두 SHA로 함께 되돌린다.
+- API/Web 또는 runtime config 문제면 이전 두 SHA와 이전 config digest를
+  한 쌍으로 되돌린다.
 - DB와 image volume을 삭제하는 `docker compose down -v`를 사용하지
   않는다.
 - 첫 배포 실패 시 신규 data service는 보존하고 실패한 API/web만

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -45,18 +45,18 @@ pinned Cloudflare real-IP 설정 또는 `homeserver/runtime-config.Dockerfile`�
 바뀌면 `keep`으로 현재 검증된 config digest를 유지한다.
 
 배포 script는 Compose 전체 snapshot을 복제하지 않는다. healthcheck timing,
-logging, restart, replica, PID·tmpfs와 일반 application environment 변경은
-Compose render와 service health로 검증한다. 대신 아래 운영 보호 경계만
-고정한다.
+logging, restart, replica, PID·tmpfs mount option과 일반 application
+environment 변경은 Compose render와 service health로 검증한다. 대신 아래
+운영 보호 경계만 고정한다.
 
 - `db`, `redis`, `api`, `web` service와 API/Web exact image
 - DB·Redis command/entrypoint, DB의 `MYSQL_*`, API의 DB·Redis·upload identity와
   Spring profile·datasource·JPA·Flyway·Liquibase·SQL init·config JSON 및
   JVM option 설정
 - API/Web image command·entrypoint override 금지
-- DB의 loopback `mysqladmin ping`, Redis의 `redis-cli ping`, Web의
-  loopback actuator `status=UP`·Host probe 의미와 배포 완료 시 실제
-  running/healthy 상태. 동등한 probe 표현과 timing은 변경 가능
+- DB·Redis·Web healthcheck `test` 명령과 배포 완료 시 실제
+  running/healthy 상태. healthcheck timing은 변경 가능
+- 각 service의 process user와 정규화한 `tmpfs` mount target 집합
 - MySQL·Redis named volume과 기존 upload bind identity
 - internal application, API 전용 outbound, shared edge network 경계
 - host port, privileged mode, Docker socket, host namespace, 추가 host bind,

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -23,24 +23,28 @@ deploy-cubing-hub-v2 <40자리 commit SHA> keep <registry user>
 deploy-cubing-hub-v2 <40자리 commit SHA> update <config digest> <registry user>
 ```
 
-v2 workflow를 `main`에 병합하기 전에 repository의
-`homeserver/scripts/deploy-home-server.sh`,
-`homeserver/scripts/deploy-home-server-ci.sh`,
-`homeserver/scripts/backup-home-server-bootstrap.sh`,
-`homeserver/scripts/backup-home-server.sh`를 각각 Mac mini의
-`/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh`와
-`/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh`,
-`/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh`,
-`/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh`에 사전
-설치해야 한다. 기존 파일을 timestamp backup으로 보존하고, 설치본의
-SHA-256이 repository 원본과 일치하는지, mode가 `700`인지, `/bin/bash -n`과
-잘못된 forced command 거부가 통과하는지 확인한 뒤에만 merge한다.
-이 prerequisite가 완료되지 않으면 기존 wrapper가 v2 명령을 거부하거나
-backup이 legacy Compose만 찾으므로 workflow를 병합하지 않는다.
-`deploy-home-server-ci.sh`와 `backup-home-server-bootstrap.sh`는 최초 v2
-전환을 위한 stable wrapper/bootstrap이며 runtime artifact로 자동 교체하지
-않는다. 고정 deploy/backup worker는 기존 2파일 v2 또는 pre-v2 fallback용으로
-보존한다.
+현재 운영 서버에서 v2 workflow를 `main`에 병합하기 전에는 아래 두 stable
+진입점만 한 번 설치한다.
+
+```text
+homeserver/scripts/deploy-home-server-ci.sh
+  -> /Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh
+homeserver/scripts/backup-home-server-bootstrap.sh
+  -> /Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
+```
+
+기존 진입점은 timestamp backup으로 보존하고, 설치본의 SHA-256이 repository
+원본과 일치하는지, mode가 `700`인지, `/bin/bash -n`과 잘못된 forced command
+및 backup 인자 거부가 통과하는지 확인한 뒤에만 merge한다.
+`deploy-home-server.sh`와 `backup-home-server.sh`를 고정 운영 경로에
+사전 설치하거나 branch 원본으로 교체하지 않는다. 기존 고정 worker는
+pre-v2 또는 기존 2파일 release의 recovery fallback으로만 보존한다.
+설치 전에는 기존 deploy worker가 `recover`를 지원하고 기존 backup worker가
+실행 가능한지 확인한다. 이 fallback 계약을 충족하지 않으면 worker를 임의로
+덮어쓰지 말고 전환을 중단한다.
+첫 `update`가 exact runtime-config digest 안의 새 deploy/backup worker를
+함께 staging하며, 이후 worker 변경도 runtime-config 변경으로 감지해
+자동 동기화한다.
 
 마지막 성공 production deployment 이후 `homeserver/docker-compose.yml`,
 pinned Cloudflare real-IP 설정, 허용된 deploy/backup script,
@@ -61,8 +65,9 @@ scripts/backup-cubing-hub.sh
 
 고정 forced-command/bootstrap은 exact digest, revision/project label, regular-file
 allowlist, 전체 content hash, script mode `700`과 `/bin/bash -n`을 검증한
-뒤 immutable release의 candidate deploy script를 실행한다. 첫 성공 전에는
-legacy Compose와 고정 legacy backup worker를 사용한다. v2 성공 뒤에는
+뒤 immutable release의 candidate deploy script를 실행한다. 첫 성공 전
+recovery에만 legacy Compose와 고정 legacy worker를 사용할 수 있다. 정상
+`update`와 backup은 candidate release worker를 사용한다. v2 성공 뒤에는
 `runtime-config/current`가 Compose와 deploy/backup script의 공통 active
 release를 가리킨다. `keep`, recovery와 정기 backup은 이 release의 검증된
 script를 사용한다.

--- a/homeserver/docs/mac-mini-server-setup.md
+++ b/homeserver/docs/mac-mini-server-setup.md
@@ -38,26 +38,37 @@
 
 1. Docker Desktop for Apple Silicon을 설치하고 로그인 뒤 자동 시작을
    확인한다.
-2. external network를 한 번만 만든다.
+2. 배포·백업 script가 Compose JSON 계약을 검사할 때 사용하는 system
+   Python을 확인한다.
+
+   ```bash
+   test -x /usr/bin/python3
+   /usr/bin/python3 --version
+   ```
+
+   `/usr/bin/python3`가 없으면 Homebrew Python이나 임의 PATH로 대체하지
+   말고 준비를 중단한다. Xcode Command Line Tools 설치 여부와 운영 영향은
+   별도 승인 후 확인한다.
+3. external network를 한 번만 만든다.
 
    ```bash
    /usr/local/bin/docker network inspect edge >/dev/null 2>&1 \
      || /usr/local/bin/docker network create edge
    ```
 
-3. 고정 운영 directory와 빈 게시글 이미지 directory를 만든다.
-4. `homeserver/docker-compose.yml`,
+4. 고정 운영 directory와 빈 게시글 이미지 directory를 만든다.
+5. `homeserver/docker-compose.yml`,
    `homeserver/nginx/cloudflare-edge-real-ip.conf`,
    `homeserver/scripts/deploy-home-server.sh`,
    `homeserver/scripts/deploy-home-server-ci.sh`,
    `homeserver/scripts/backup-home-server.sh`를 고정 경로에 설치한다.
    Nginx 설정은 app directory의 `nginx/` 아래에 둔다.
-5. `.env`의 image 두 개는 같은 full commit SHA를 사용하고 DB/JWT/SMTP
+6. `.env`의 image 두 개는 같은 full commit SHA를 사용하고 DB/JWT/SMTP
    secret을 실제 값으로 교체한다.
-6. 배포·백업 script와 `.env` 권한을 제한한다.
-7. Tailscale `tag:ci`에서 Mac mini SSH로 접근할 수 있는 최소 ACL과
+7. 배포·백업 script와 `.env` 권한을 제한한다.
+8. Tailscale `tag:ci`에서 Mac mini SSH로 접근할 수 있는 최소 ACL과
    workload identity federation credential을 구성한다.
-8. Cubing Hub 전용 SSH 공개키를 forced command와 함께 등록한다.
+9. Cubing Hub 전용 SSH 공개키를 forced command와 함께 등록한다.
 
 forced command는 아래 wrapper만 실행해야 한다.
 
@@ -70,7 +81,12 @@ wrapper는 아래 형식만 허용하며 `eval`, `bash -c`, 임의 shell 명령�
 
 ```text
 deploy-cubing-hub <40자리 commit SHA> <registry user>
+deploy-cubing-hub-v2 <40자리 commit SHA> keep <registry user>
+deploy-cubing-hub-v2 <40자리 commit SHA> update <sha256 digest> <registry user>
 ```
+
+legacy 명령은 runtime config v2 전환 전 설치에서만 사용한다. v2 state가
+초기화된 뒤에는 `keep` 또는 exact digest를 전달하는 `update`만 허용한다.
 
 ## 데이터 초기화
 

--- a/homeserver/docs/mac-mini-server-setup.md
+++ b/homeserver/docs/mac-mini-server-setup.md
@@ -30,12 +30,17 @@
 /Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
 ```
 
-`compose.yaml`, 배포 wrapper/bootstrap과 별도 백업 bootstrap은 최초 v2
-전환 전에 검증한 저장소 파일을 위 고정 경로에 한 번 설치한다. 이후
-허용된 deploy/backup script는 runtime-config release로 전달하며 고정
-bootstrap을 자동 교체하지 않는다. `.env`는
+신규 서버의 `compose.yaml`과 기존 고정 deploy/backup worker는 pre-v2
+bootstrap·recovery seed다. 현재 운영 서버를 v2로 전환할 때는 이 worker를
+branch 원본으로 교체하지 않고 stable deploy/backup bootstrap 두 개만 한 번
+설치한다. 이후 허용된 deploy/backup worker는 runtime-config release로
+전달하며 stable bootstrap을 자동 교체하지 않는다. `.env`는
 `homeserver/.env.example`을 복사한 뒤 실제 secret으로 교체하고 mode를
 `600`으로 제한한다.
+
+현재 운영 서버 전환 전에는 기존 deploy fallback의 `recover` 지원과 기존
+backup fallback의 실행 가능 여부를 확인한다. 둘 중 하나라도 충족하지 않으면
+고정 worker를 자동 교체하지 말고 별도 전환 계획으로 중단한다.
 
 ## 최초 준비
 
@@ -61,20 +66,21 @@ bootstrap을 자동 교체하지 않는다. `.env`는
    ```
 
 4. 고정 운영 directory와 빈 게시글 이미지 directory를 만든다.
-5. `homeserver/docker-compose.yml`,
-   `homeserver/nginx/cloudflare-edge-real-ip.conf`,
-   `homeserver/scripts/deploy-home-server.sh`,
-   `homeserver/scripts/deploy-home-server-ci.sh`,
-   `homeserver/scripts/backup-home-server-bootstrap.sh`,
-   `homeserver/scripts/backup-home-server.sh`를 최초 bootstrap으로 고정
-   경로에 설치한다.
-   Nginx 설정은 app directory의 `nginx/` 아래에 둔다.
-6. `.env`의 image 두 개는 같은 full commit SHA를 사용하고 DB/JWT/SMTP
+5. 새 서버를 처음 준비하는 경우에만 `homeserver/docker-compose.yml`,
+   `homeserver/nginx/cloudflare-edge-real-ip.conf`와 pre-v2 fallback
+   deploy/backup worker를 초기 seed로 설치한다. 이미 운영 중인 서버의
+   고정 worker는 교체하지 않는다. Nginx 설정은 app directory의
+   `nginx/` 아래에 둔다.
+6. `homeserver/scripts/deploy-home-server-ci.sh`와
+   `homeserver/scripts/backup-home-server-bootstrap.sh`를 stable 진입점으로
+   한 번 설치한다. 첫 v2 `update`부터 deploy/backup worker는 exact
+   runtime-config digest로만 갱신한다.
+7. `.env`의 image 두 개는 같은 full commit SHA를 사용하고 DB/JWT/SMTP
    secret을 실제 값으로 교체한다.
-7. 배포·백업 script와 `.env` 권한을 제한한다.
-8. Tailscale `tag:ci`에서 Mac mini SSH로 접근할 수 있는 최소 ACL과
+8. 배포·백업 script와 `.env` 권한을 제한한다.
+9. Tailscale `tag:ci`에서 Mac mini SSH로 접근할 수 있는 최소 ACL과
    workload identity federation credential을 구성한다.
-9. Cubing Hub 전용 SSH 공개키를 forced command와 함께 등록한다.
+10. Cubing Hub 전용 SSH 공개키를 forced command와 함께 등록한다.
 
 forced command는 아래 wrapper만 실행해야 한다.
 

--- a/homeserver/docs/mac-mini-server-setup.md
+++ b/homeserver/docs/mac-mini-server-setup.md
@@ -27,10 +27,13 @@
 /Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh
 /Users/homeserver/Server/scripts/deploy/deploy-cubing-hub-ci.sh
 /Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh
+/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
 ```
 
-`compose.yaml`, 배포 script, 백업 script는 검증한 저장소 파일을 위
-고정 경로에 설치한다. `.env`는
+`compose.yaml`, 배포 wrapper/bootstrap과 별도 백업 bootstrap은 최초 v2
+전환 전에 검증한 저장소 파일을 위 고정 경로에 한 번 설치한다. 이후
+허용된 deploy/backup script는 runtime-config release로 전달하며 고정
+bootstrap을 자동 교체하지 않는다. `.env`는
 `homeserver/.env.example`을 복사한 뒤 실제 secret으로 교체하고 mode를
 `600`으로 제한한다.
 
@@ -38,17 +41,18 @@
 
 1. Docker Desktop for Apple Silicon을 설치하고 로그인 뒤 자동 시작을
    확인한다.
-2. 배포·백업 script가 Compose JSON 계약을 검사할 때 사용하는 system
-   Python을 확인한다.
+2. 배포·백업 script가 Compose JSON 계약과 공통 operation lock을 검사할 때
+   사용하는 system 도구를 확인한다.
 
    ```bash
    test -x /usr/bin/python3
+   test -x /usr/bin/lockf
    /usr/bin/python3 --version
    ```
 
-   `/usr/bin/python3`가 없으면 Homebrew Python이나 임의 PATH로 대체하지
-   말고 준비를 중단한다. Xcode Command Line Tools 설치 여부와 운영 영향은
-   별도 승인 후 확인한다.
+   `/usr/bin/python3` 또는 `/usr/bin/lockf`가 없으면 Homebrew 도구나 임의
+   PATH로 대체하지 말고 준비를 중단한다. Xcode Command Line Tools 설치
+   여부와 운영 영향은 별도 승인 후 확인한다.
 3. external network를 한 번만 만든다.
 
    ```bash
@@ -61,7 +65,9 @@
    `homeserver/nginx/cloudflare-edge-real-ip.conf`,
    `homeserver/scripts/deploy-home-server.sh`,
    `homeserver/scripts/deploy-home-server-ci.sh`,
-   `homeserver/scripts/backup-home-server.sh`를 고정 경로에 설치한다.
+   `homeserver/scripts/backup-home-server-bootstrap.sh`,
+   `homeserver/scripts/backup-home-server.sh`를 최초 bootstrap으로 고정
+   경로에 설치한다.
    Nginx 설정은 app directory의 `nginx/` 아래에 둔다.
 6. `.env`의 image 두 개는 같은 full commit SHA를 사용하고 DB/JWT/SMTP
    secret을 실제 값으로 교체한다.
@@ -87,6 +93,19 @@ deploy-cubing-hub-v2 <40자리 commit SHA> update <sha256 digest> <registry user
 
 legacy 명령은 runtime config v2 전환 전 설치에서만 사용한다. v2 state가
 초기화된 뒤에는 `keep` 또는 exact digest를 전달하는 `update`만 허용한다.
+`deploy-home-server-ci.sh`가 stable forced-command/bootstrap 역할을 하고
+`backup-home-server-bootstrap.sh`가 정기 backup 진입점 역할을 한다.
+`update` artifact는 Compose, pinned Nginx 설정과 허용된 deploy/backup
+script만 포함한다. 검증된 성공 뒤 `runtime-config/current`가 이 네 파일의
+active release가 되며, 고정 deploy/backup bootstrap은 active script를
+검증한 뒤 전달 실행한다.
+
+두 bootstrap은
+`/Users/homeserver/Server/apps/cubing-hub/.cubing-hub-operation.lock`의
+같은 advisory lock을 사용한다. Lock 경합은 exit `75`로 실패하므로 기존
+작업이 끝난 뒤 재시도한다. Lock file은 mode `600` regular file로 계속
+남겨 두며, 파일 존재 자체는 실행 중인 lock을 뜻하지 않으므로 삭제하거나
+stale PID 방식으로 복구하지 않는다.
 
 ## 데이터 초기화
 

--- a/homeserver/launchd/com.cubinghub-backup.plist.example
+++ b/homeserver/launchd/com.cubinghub-backup.plist.example
@@ -7,7 +7,7 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh</string>
+    <string>/Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh</string>
   </array>
 
   <key>StartCalendarInterval</key>

--- a/homeserver/runtime-config.Dockerfile
+++ b/homeserver/runtime-config.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+ARG REVISION
+
+LABEL org.opencontainers.image.source="https://github.com/xxh3898/cubing-hub"
+LABEL org.opencontainers.image.revision="${REVISION}"
+LABEL io.chochiho.runtime-config.project="cubing-hub"
+
+COPY homeserver/docker-compose.yml /runtime/compose.yaml
+COPY homeserver/nginx/cloudflare-edge-real-ip.conf /runtime/nginx/cloudflare-edge-real-ip.conf
+
+CMD ["/runtime/compose.yaml"]

--- a/homeserver/runtime-config.Dockerfile
+++ b/homeserver/runtime-config.Dockerfile
@@ -8,5 +8,7 @@ LABEL io.chochiho.runtime-config.project="cubing-hub"
 
 COPY homeserver/docker-compose.yml /runtime/compose.yaml
 COPY homeserver/nginx/cloudflare-edge-real-ip.conf /runtime/nginx/cloudflare-edge-real-ip.conf
+COPY --chmod=0700 homeserver/scripts/deploy-home-server.sh /runtime/scripts/deploy-cubing-hub.sh
+COPY --chmod=0700 homeserver/scripts/backup-home-server.sh /runtime/scripts/backup-cubing-hub.sh
 
 CMD ["/runtime/compose.yaml"]

--- a/homeserver/scripts/backup-home-server-bootstrap.sh
+++ b/homeserver/scripts/backup-home-server-bootstrap.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly LOCKF_BIN=/usr/bin/lockf
+readonly PYTHON_BIN=/usr/bin/python3
+readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
+readonly LEGACY_BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh
+readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
+readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
+readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
+readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
+readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
+readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
+readonly OPERATION_LOCK="${APP_DIR}/.cubing-hub-operation.lock"
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+fail() {
+  printf 'Cubing Hub backup bootstrap failed: %s\n' "$1" >&2
+  exit 1
+}
+
+acquire_operation_lock() {
+  local lock_status
+
+  if [[ ! -x "${PYTHON_BIN}" ]]; then
+    fail "Python is not executable: ${PYTHON_BIN}"
+  fi
+  if [[ ! -x "${LOCKF_BIN}" ]]; then
+    fail "lockf is not executable: ${LOCKF_BIN}"
+  fi
+  if [[ -L "${OPERATION_LOCK}" ]] \
+    || { [[ -e "${OPERATION_LOCK}" ]] && [[ ! -f "${OPERATION_LOCK}" ]]; }
+  then
+    fail "operation lock path must be a regular non-symlink file"
+  fi
+
+  umask 077
+  if ! exec 9>>"${OPERATION_LOCK}"; then
+    fail "operation lock file could not be opened"
+  fi
+
+  /bin/chmod 600 "${OPERATION_LOCK}"
+  if "${LOCKF_BIN}" -s -t 0 9
+  then
+    return
+  else
+    lock_status="$?"
+  fi
+
+  exec 9>&-
+  if [[ "${lock_status}" -eq 75 ]]; then
+    printf 'Another Cubing Hub deploy or backup operation is already running\n' >&2
+    exit 75
+  fi
+  fail "operation lock validation failed"
+}
+
+is_digest() {
+  [[ "$1" =~ ^sha256:[0-9a-f]{64}$ ]] && [[ "$1" != "${ZERO_DIGEST}" ]]
+}
+
+read_state_value() {
+  local key="$1"
+
+  /usr/bin/sed -n "s/^${key}=//p" "${RUNTIME_CONFIG_STATE}" \
+    | /usr/bin/tail -n 1
+}
+
+validate_state_file() {
+  local application_revision
+  local keys
+  local previous_digest
+  local previous_revision
+  local runtime_content_sha
+  local runtime_digest
+  local runtime_revision
+
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    fail "runtime config state must be a regular non-symlink file"
+  fi
+
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_STATE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'APPLICATION_REVISION\nPREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION' ]]; then
+    fail "runtime config state keys are invalid"
+  fi
+
+  application_revision="$(read_state_value APPLICATION_REVISION)"
+  previous_revision="$(read_state_value PREVIOUS_APPLICATION_REVISION)"
+  previous_digest="$(read_state_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  runtime_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  runtime_revision="$(read_state_value RUNTIME_CONFIG_REVISION)"
+
+  if [[ ! "${application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${application_revision}" == "${ZERO_SHA}" ]] \
+    || [[ ! "${previous_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || { [[ "${previous_digest}" != "${ZERO_DIGEST}" ]] && ! is_digest "${previous_digest}"; } \
+    || [[ ! "${runtime_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || ! is_digest "${runtime_digest}" \
+    || [[ ! "${runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${runtime_revision}" == "${ZERO_SHA}" ]]
+  then
+    fail "runtime config state values are invalid"
+  fi
+}
+
+validate_initialization_marker() {
+  if [[ ! -f "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ "$(/bin/cat "${RUNTIME_CONFIG_INITIALIZED}")" != RUNTIME_CONFIG_V2=initialized ]]
+  then
+    fail "runtime config initialization marker is invalid"
+  fi
+}
+
+release_shape() {
+  local entries
+  local release_dir="$1"
+  local unexpected
+
+  if [[ ! -d "${release_dir}" || -L "${release_dir}" ]]; then
+    fail "runtime config release is missing or unsafe"
+  fi
+  unexpected="$(
+    /usr/bin/find "${release_dir}" ! -type d ! -type f -print
+  )"
+  if [[ -n "${unexpected}" ]]; then
+    fail "runtime config contains unsupported file types"
+  fi
+  entries="$(
+    /usr/bin/find "${release_dir}" -mindepth 1 -print \
+      | /usr/bin/sed "s#^${release_dir}/##" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    printf 'legacy'
+    return
+  fi
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf\nscripts\nscripts/backup-cubing-hub.sh\nscripts/deploy-cubing-hub.sh' ]]; then
+    printf 'synced'
+    return
+  fi
+  fail "runtime config entry allowlist does not match"
+}
+
+validate_synced_scripts() {
+  local release_dir="$1"
+  local script
+
+  for script in \
+    "${release_dir}/scripts/backup-cubing-hub.sh" \
+    "${release_dir}/scripts/deploy-cubing-hub.sh"
+  do
+    if [[ ! -x "${script}" || -L "${script}" ]]; then
+      fail "runtime config script is missing, unsafe, or not executable"
+    fi
+    if ! "${PYTHON_BIN}" -c \
+      'import os, stat, sys; raise SystemExit(0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o700 else 1)' \
+      "${script}"
+    then
+      fail "runtime config script mode must be 700"
+    fi
+    if ! /bin/bash -n "${script}"; then
+      fail "runtime config script syntax is invalid"
+    fi
+  done
+}
+
+runtime_config_content_sha256() {
+  local release_dir="$1"
+  local shape="$2"
+
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if [[ "${shape}" == synced ]]; then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+if [[ "$#" -ne 0 ]]; then
+  printf 'Usage: backup-cubing-hub-bootstrap.sh\n' >&2
+  exit 64
+fi
+acquire_operation_lock
+if [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+  fail "an incomplete runtime config transaction requires recovery"
+fi
+
+if [[ ! -e "${RUNTIME_CONFIG_STATE}" && ! -L "${RUNTIME_CONFIG_STATE}" ]]; then
+  if [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+    || [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]
+  then
+    fail "runtime config pointer or marker exists without verified state"
+  fi
+  exec "${LEGACY_BACKUP_SCRIPT}"
+fi
+
+validate_initialization_marker
+validate_state_file
+runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+expected_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+release_dir="${RUNTIME_CONFIG_RELEASES}/${runtime_digest#sha256:}"
+expected_current_target="releases/${runtime_digest#sha256:}"
+
+if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+  || [[ "$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")" != "${expected_current_target}" ]]
+then
+  fail "runtime config current pointer does not match verified state"
+fi
+
+shape="$(release_shape "${release_dir}")"
+if [[ "$(runtime_config_content_sha256 "${release_dir}" "${shape}")" != "${expected_content_sha}" ]]; then
+  fail "runtime config release integrity check failed"
+fi
+if [[ "${shape}" == legacy ]]; then
+  exec "${LEGACY_BACKUP_SCRIPT}"
+fi
+
+validate_synced_scripts "${release_dir}"
+exec "${release_dir}/scripts/backup-cubing-hub.sh"

--- a/homeserver/scripts/backup-home-server.sh
+++ b/homeserver/scripts/backup-home-server.sh
@@ -114,7 +114,7 @@ validate_state_file() {
 
 validate_release_files() {
   local release_dir="$1"
-  local files
+  local entries
   local unexpected
 
   if [[ ! -d "${release_dir}" || -L "${release_dir}" ]]; then
@@ -128,14 +128,50 @@ validate_release_files() {
     fail "runtime config contains unsupported file types"
   fi
 
-  files="$(
-    /usr/bin/find "${release_dir}" -type f -print \
+  entries="$(
+    /usr/bin/find "${release_dir}" -mindepth 1 -print \
       | /usr/bin/sed "s#^${release_dir}/##" \
       | LC_ALL=C /usr/bin/sort
   )"
-  if [[ "${files}" != $'compose.yaml\nnginx/cloudflare-edge-real-ip.conf' ]]; then
-    fail "runtime config file allowlist does not match"
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    return
   fi
+  if [[ "${entries}" != $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf\nscripts\nscripts/backup-cubing-hub.sh\nscripts/deploy-cubing-hub.sh' ]]; then
+    fail "runtime config entry allowlist does not match"
+  fi
+  validate_release_scripts "${release_dir}"
+}
+
+release_has_synced_scripts() {
+  local release_dir="$1"
+
+  [[ -f "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+    && [[ ! -L "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+    && [[ -f "${release_dir}/scripts/deploy-cubing-hub.sh" ]] \
+    && [[ ! -L "${release_dir}/scripts/deploy-cubing-hub.sh" ]]
+}
+
+validate_release_scripts() {
+  local release_dir="$1"
+  local script
+
+  for script in \
+    "${release_dir}/scripts/backup-cubing-hub.sh" \
+    "${release_dir}/scripts/deploy-cubing-hub.sh"
+  do
+    if [[ ! -x "${script}" ]]; then
+      fail "runtime config script is not executable"
+    fi
+    if ! "${PYTHON_BIN}" -c \
+      'import os, stat, sys; raise SystemExit(0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o700 else 1)' \
+      "${script}"
+    then
+      fail "runtime config script mode must be 700"
+    fi
+    if ! /bin/bash -n "${script}"; then
+      fail "runtime config script syntax is invalid"
+    fi
+  done
 }
 
 runtime_config_content_sha256() {
@@ -145,6 +181,12 @@ runtime_config_content_sha256() {
     /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
     /usr/bin/shasum -a 256 \
       "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if release_has_synced_scripts "${release_dir}"; then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
 }
 

--- a/homeserver/scripts/backup-home-server.sh
+++ b/homeserver/scripts/backup-home-server.sh
@@ -5,14 +5,24 @@ set -Eeuo pipefail
 umask 077
 
 readonly DOCKER_BIN=/usr/local/bin/docker
+readonly PYTHON_BIN=/usr/bin/python3
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
-readonly COMPOSE_FILE="${APP_DIR}/compose.yaml"
+readonly PROJECT_NAME=cubing-hub
+readonly LEGACY_COMPOSE_FILE="${APP_DIR}/compose.yaml"
 readonly ENV_FILE="${APP_DIR}/.env"
 readonly BACKUP_ROOT=/Users/homeserver/Server/backups/cubing-hub
+readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
+readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
+readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
+readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
+readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
 readonly BACKUP_RETENTION_COUNT=3
 
 work_dir=
 final_dir=
+active_compose_file=
 
 usage() {
   printf 'Usage: backup-cubing-hub.sh\n' >&2
@@ -42,42 +52,209 @@ if [[ ! -x "${DOCKER_BIN}" ]]; then
   fail "Docker CLI is not executable: ${DOCKER_BIN}"
 fi
 
-if [[ ! -f "${COMPOSE_FILE}" || ! -f "${ENV_FILE}" ]]; then
-  fail "production Compose configuration is incomplete"
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  fail "Python is not executable: ${PYTHON_BIN}"
 fi
+
+if [[ ! -f "${ENV_FILE}" || -L "${ENV_FILE}" ]]; then
+  fail "production environment configuration is missing or unsafe"
+fi
+
+is_digest() {
+  [[ "$1" =~ ^sha256:[0-9a-f]{64}$ ]] && [[ "$1" != "${ZERO_DIGEST}" ]]
+}
+
+read_state_value() {
+  local key="$1"
+
+  /usr/bin/sed -n "s/^${key}=//p" "${RUNTIME_CONFIG_STATE}" \
+    | /usr/bin/tail -n 1
+}
+
+validate_state_file() {
+  local application_revision
+  local keys
+  local previous_revision
+  local previous_digest
+  local runtime_content_sha
+  local runtime_digest
+  local runtime_revision
+
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    fail "runtime config state must be a regular non-symlink file"
+  fi
+
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_STATE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'APPLICATION_REVISION\nPREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION' ]]; then
+    fail "runtime config state keys are invalid"
+  fi
+
+  application_revision="$(read_state_value APPLICATION_REVISION)"
+  previous_revision="$(read_state_value PREVIOUS_APPLICATION_REVISION)"
+  previous_digest="$(read_state_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  runtime_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  runtime_revision="$(read_state_value RUNTIME_CONFIG_REVISION)"
+
+  if [[ ! "${application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${application_revision}" == "${ZERO_SHA}" ]] \
+    || [[ ! "${previous_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || { [[ "${previous_digest}" != "${ZERO_DIGEST}" ]] && ! is_digest "${previous_digest}"; } \
+    || [[ ! "${runtime_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || ! is_digest "${runtime_digest}" \
+    || [[ ! "${runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${runtime_revision}" == "${ZERO_SHA}" ]]
+  then
+    fail "runtime config state values are invalid"
+  fi
+}
+
+validate_release_files() {
+  local release_dir="$1"
+  local files
+  local unexpected
+
+  if [[ ! -d "${release_dir}" || -L "${release_dir}" ]]; then
+    fail "verified runtime config release is missing or unsafe"
+  fi
+
+  unexpected="$(
+    /usr/bin/find "${release_dir}" ! -type d ! -type f -print
+  )"
+  if [[ -n "${unexpected}" ]]; then
+    fail "runtime config contains unsupported file types"
+  fi
+
+  files="$(
+    /usr/bin/find "${release_dir}" -type f -print \
+      | /usr/bin/sed "s#^${release_dir}/##" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${files}" != $'compose.yaml\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    fail "runtime config file allowlist does not match"
+  fi
+}
+
+runtime_config_content_sha256() {
+  local release_dir="$1"
+
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+validate_initialization_marker() {
+  if [[ ! -f "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ "$(/bin/cat "${RUNTIME_CONFIG_INITIALIZED}")" != RUNTIME_CONFIG_V2=initialized ]]
+  then
+    fail "runtime config initialization marker is invalid"
+  fi
+}
+
+select_compose_file() {
+  local current_target
+  local expected_current_target
+  local release_dir
+  local runtime_content_sha
+  local runtime_digest
+
+  if [[ ! -e "${RUNTIME_CONFIG_STATE}" && ! -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    if [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]]; then
+      fail "runtime config current pointer exists without verified state"
+    fi
+    if [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]; then
+      validate_initialization_marker
+      fail "initialized runtime config state is missing"
+    fi
+    if [[ ! -f "${LEGACY_COMPOSE_FILE}" || -L "${LEGACY_COMPOSE_FILE}" ]]; then
+      fail "legacy production Compose configuration is missing or unsafe"
+    fi
+    printf '%s' "${LEGACY_COMPOSE_FILE}"
+    return
+  fi
+
+  if [[ ! -e "${RUNTIME_CONFIG_INITIALIZED}" && ! -L "${RUNTIME_CONFIG_INITIALIZED}" ]]; then
+    fail "runtime config state exists without initialization marker"
+  fi
+  validate_initialization_marker
+  validate_state_file
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  runtime_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  release_dir="${RUNTIME_CONFIG_RELEASES}/${runtime_digest#sha256:}"
+  expected_current_target="releases/${runtime_digest#sha256:}"
+
+  if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]]; then
+    fail "verified runtime config current pointer is missing"
+  fi
+  current_target="$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")"
+  if [[ "${current_target}" != "${expected_current_target}" ]]; then
+    fail "runtime config current pointer does not match verified state"
+  fi
+
+  validate_release_files "${release_dir}"
+  if [[ "$(runtime_config_content_sha256 "${release_dir}")" != "${runtime_content_sha}" ]]; then
+    fail "runtime config release integrity check failed"
+  fi
+
+  printf '%s/compose.yaml' "${release_dir}"
+}
+
+active_compose_file="$(select_compose_file)"
 
 compose() {
   "${DOCKER_BIN}" \
     compose \
-    --project-directory "${APP_DIR}" \
+    --project-name "${PROJECT_NAME}" \
+    --project-directory "$(/usr/bin/dirname "${active_compose_file}")" \
     --env-file "${ENV_FILE}" \
-    --file "${COMPOSE_FILE}" \
+    --file "${active_compose_file}" \
     "$@"
 }
 
-read_env_value() {
-  local key="$1"
-  local value
+resolve_post_images_host_dir() {
+  local rendered
 
-  value="$(
-    /usr/bin/awk -F= -v key="${key}" '
-      $1 == key {
-        value = substr($0, index($0, "=") + 1)
-        count += 1
-      }
-      END {
-        if (count != 1 || value == "") {
-          exit 1
-        }
-        print value
-      }
-    ' "${ENV_FILE}"
-  )" || fail "${key} must appear exactly once and be non-empty in ${ENV_FILE}"
+  rendered="$(
+    unset POST_IMAGES_HOST_DIR
+    compose config --format json
+  )"
+  printf '%s' "${rendered}" \
+    | "${PYTHON_BIN}" -c '
+import json
+import sys
 
-  printf '%s' "${value}"
+config = json.load(sys.stdin)
+sources = []
+for service_name in ("api", "web"):
+    service = config.get("services", {}).get(service_name, {})
+    volumes = service.get("volumes", [])
+    matches = [
+        volume
+        for volume in volumes
+        if isinstance(volume, dict)
+        and volume.get("type") == "bind"
+        and volume.get("target") == "/data/post-images"
+        and isinstance(volume.get("source"), str)
+        and volume["source"]
+    ]
+    if len(matches) != 1:
+        raise SystemExit(
+            f"{service_name} must have exactly one post image bind mount"
+        )
+    sources.append(matches[0]["source"])
+if sources[0] != sources[1]:
+    raise SystemExit("API and web post image bind sources must match")
+print(sources[0], end="")
+'
 }
 
-post_images_host_dir="$(read_env_value POST_IMAGES_HOST_DIR)"
+post_images_host_dir="$(resolve_post_images_host_dir)"
 if [[ ! -d "${post_images_host_dir}" ]]; then
   fail "post image directory does not exist: ${post_images_host_dir}"
 fi

--- a/homeserver/scripts/deploy-home-server-ci.sh
+++ b/homeserver/scripts/deploy-home-server-ci.sh
@@ -2,28 +2,478 @@
 
 set -Eeuo pipefail
 
-readonly DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh
+readonly DOCKER_BIN=/usr/local/bin/docker
+readonly LOCKF_BIN=/usr/bin/lockf
+readonly PYTHON_BIN=/usr/bin/python3
+readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
+readonly LEGACY_DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh
+readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
+readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
+readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
+readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
+readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
+readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
+readonly OPERATION_LOCK="${APP_DIR}/.cubing-hub-operation.lock"
+readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+fail() {
+  printf 'Cubing Hub deploy bootstrap failed: %s\n' "$1" >&2
+  exit 1
+}
+
+acquire_operation_lock() {
+  local lock_status
+
+  if [[ ! -x "${PYTHON_BIN}" ]]; then
+    fail "Python is not executable: ${PYTHON_BIN}"
+  fi
+  if [[ ! -x "${LOCKF_BIN}" ]]; then
+    fail "lockf is not executable: ${LOCKF_BIN}"
+  fi
+  if [[ -L "${OPERATION_LOCK}" ]] \
+    || { [[ -e "${OPERATION_LOCK}" ]] && [[ ! -f "${OPERATION_LOCK}" ]]; }
+  then
+    fail "operation lock path must be a regular non-symlink file"
+  fi
+
+  umask 077
+  if ! exec 9>>"${OPERATION_LOCK}"; then
+    fail "operation lock file could not be opened"
+  fi
+
+  /bin/chmod 600 "${OPERATION_LOCK}"
+  if "${LOCKF_BIN}" -s -t 0 9
+  then
+    return
+  else
+    lock_status="$?"
+  fi
+
+  exec 9>&-
+  if [[ "${lock_status}" -eq 75 ]]; then
+    printf 'Another Cubing Hub deploy or backup operation is already running\n' >&2
+    exit 75
+  fi
+  fail "operation lock validation failed"
+}
+
+is_digest() {
+  [[ "$1" =~ ^sha256:[0-9a-f]{64}$ ]] && [[ "$1" != "${ZERO_DIGEST}" ]]
+}
+
+read_state_value() {
+  local key="$1"
+
+  /usr/bin/sed -n "s/^${key}=//p" "${RUNTIME_CONFIG_STATE}" \
+    | /usr/bin/tail -n 1
+}
+
+validate_state_file() {
+  local application_revision
+  local keys
+  local previous_digest
+  local previous_revision
+  local runtime_content_sha
+  local runtime_digest
+  local runtime_revision
+
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    fail "runtime config state must be a regular non-symlink file"
+  fi
+
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_STATE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'APPLICATION_REVISION\nPREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION' ]]; then
+    fail "runtime config state keys are invalid"
+  fi
+
+  application_revision="$(read_state_value APPLICATION_REVISION)"
+  previous_revision="$(read_state_value PREVIOUS_APPLICATION_REVISION)"
+  previous_digest="$(read_state_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  runtime_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  runtime_revision="$(read_state_value RUNTIME_CONFIG_REVISION)"
+
+  if [[ ! "${application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${application_revision}" == "${ZERO_SHA}" ]] \
+    || [[ ! "${previous_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || { [[ "${previous_digest}" != "${ZERO_DIGEST}" ]] && ! is_digest "${previous_digest}"; } \
+    || [[ ! "${runtime_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || ! is_digest "${runtime_digest}" \
+    || [[ ! "${runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${runtime_revision}" == "${ZERO_SHA}" ]]
+  then
+    fail "runtime config state values are invalid"
+  fi
+}
+
+validate_initialization_marker() {
+  if [[ ! -f "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ "$(/bin/cat "${RUNTIME_CONFIG_INITIALIZED}")" != RUNTIME_CONFIG_V2=initialized ]]
+  then
+    fail "runtime config initialization marker is invalid"
+  fi
+}
+
+release_shape() {
+  local entries
+  local release_dir="$1"
+  local unexpected
+
+  if [[ ! -d "${release_dir}" || -L "${release_dir}" ]]; then
+    fail "runtime config release is missing or unsafe"
+  fi
+
+  unexpected="$(
+    /usr/bin/find "${release_dir}" ! -type d ! -type f -print
+  )"
+  if [[ -n "${unexpected}" ]]; then
+    fail "runtime config contains unsupported file types"
+  fi
+
+  entries="$(
+    /usr/bin/find "${release_dir}" -mindepth 1 -print \
+      | /usr/bin/sed "s#^${release_dir}/##" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    printf 'legacy'
+    return
+  fi
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf\nscripts\nscripts/backup-cubing-hub.sh\nscripts/deploy-cubing-hub.sh' ]]; then
+    printf 'synced'
+    return
+  fi
+  fail "runtime config entry allowlist does not match"
+}
+
+validate_synced_scripts() {
+  local release_dir="$1"
+  local script
+
+  for script in \
+    "${release_dir}/scripts/backup-cubing-hub.sh" \
+    "${release_dir}/scripts/deploy-cubing-hub.sh"
+  do
+    if [[ ! -x "${script}" || -L "${script}" ]]; then
+      fail "runtime config script is missing, unsafe, or not executable"
+    fi
+    if ! "${PYTHON_BIN}" -c \
+      'import os, stat, sys; raise SystemExit(0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o700 else 1)' \
+      "${script}"
+    then
+      fail "runtime config script mode must be 700"
+    fi
+    if ! /bin/bash -n "${script}"; then
+      fail "runtime config script syntax is invalid"
+    fi
+  done
+}
+
+validate_release() {
+  local expected_shape="${2:-either}"
+  local release_dir="$1"
+  local shape
+
+  shape="$(release_shape "${release_dir}")"
+  if [[ "${expected_shape}" != either && "${shape}" != "${expected_shape}" ]]; then
+    fail "runtime config release shape is not ${expected_shape}"
+  fi
+  if [[ "${shape}" == synced ]]; then
+    validate_synced_scripts "${release_dir}"
+  fi
+  printf '%s' "${shape}"
+}
+
+runtime_config_content_sha256() {
+  local release_dir="$1"
+  local shape
+
+  shape="$(validate_release "${release_dir}")"
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if [[ "${shape}" == synced ]]; then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+validate_verified_state() {
+  local current_target
+  local expected_content_sha
+  local expected_current_target
+  local release_dir
+  local runtime_digest
+
+  if [[ ! -e "${RUNTIME_CONFIG_STATE}" && ! -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    if [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+      || [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]
+    then
+      fail "runtime config pointer or marker exists without verified state"
+    fi
+    return
+  fi
+
+  validate_initialization_marker
+  validate_state_file
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  expected_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  release_dir="${RUNTIME_CONFIG_RELEASES}/${runtime_digest#sha256:}"
+  expected_current_target="releases/${runtime_digest#sha256:}"
+
+  if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]]; then
+    fail "verified runtime config current pointer is missing"
+  fi
+  current_target="$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")"
+  if [[ "${current_target}" != "${expected_current_target}" ]]; then
+    fail "runtime config current pointer does not match verified state"
+  fi
+  validate_release "${release_dir}" >/dev/null
+  if [[ "$(runtime_config_content_sha256 "${release_dir}")" != "${expected_content_sha}" ]]; then
+    fail "runtime config release integrity check failed"
+  fi
+
+  printf '%s' "${release_dir}"
+}
+
+validated_recovery_release() {
+  local expected_content_sha
+  local release_dir
+  local runtime_digest
+
+  if [[ ! -e "${RUNTIME_CONFIG_STATE}" && ! -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    return
+  fi
+  validate_state_file
+  if [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]; then
+    validate_initialization_marker
+  fi
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  expected_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  release_dir="${RUNTIME_CONFIG_RELEASES}/${runtime_digest#sha256:}"
+  validate_release "${release_dir}" >/dev/null
+  if [[ "$(runtime_config_content_sha256 "${release_dir}")" != "${expected_content_sha}" ]]; then
+    fail "runtime config release integrity check failed"
+  fi
+  printf '%s' "${release_dir}"
+}
+
+if [[ "$#" -eq 1 && "$1" == recover && -z "${SSH_ORIGINAL_COMMAND:-}" ]]; then
+  acquire_operation_lock
+  recovery_release="$(validated_recovery_release)"
+  if [[ -n "${recovery_release}" ]] \
+    && [[ "$(validate_release "${recovery_release}")" == synced ]]
+  then
+    exec "${recovery_release}/scripts/deploy-cubing-hub.sh" recover
+  fi
+  exec "${LEGACY_DEPLOY_SCRIPT}" recover
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  printf 'Only a direct local recover argument is allowed\n' >&2
+  exit 64
+fi
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
-
 if [[ "${original_command}" =~ ^deploy-cubing-hub[[:space:]]([0-9a-fA-F]{40})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
-  exec "${DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  acquire_operation_lock
+  exec "${LEGACY_DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
 fi
+
+config_mode=
+config_digest=
+commit_sha=
+registry_user=
 
 if [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[[:space:]]keep[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
-  exec "${DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" keep "${BASH_REMATCH[2]}"
+  commit_sha="${BASH_REMATCH[1]}"
+  config_mode=keep
+  registry_user="${BASH_REMATCH[2]}"
+elif [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[[:space:]]update[[:space:]](sha256:[0-9a-f]{64})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
+  commit_sha="${BASH_REMATCH[1]}"
+  config_mode=update
+  config_digest="${BASH_REMATCH[2]}"
+  registry_user="${BASH_REMATCH[3]}"
+else
+  printf '%s\n' \
+    'Only deploy-cubing-hub or strictly formatted deploy-cubing-hub-v2 commands are allowed' \
+    >&2
+  exit 64
 fi
 
-if [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[[:space:]]update[[:space:]](sha256:[0-9a-f]{64})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
-  exec \
-    "${DEPLOY_SCRIPT}" \
-    "${BASH_REMATCH[1]}" \
+if [[ "${config_mode}" == update ]] && ! is_digest "${config_digest}"; then
+  printf 'Runtime config digest is invalid\n' >&2
+  exit 64
+fi
+acquire_operation_lock
+if [[ ! -x "${DOCKER_BIN}" ]]; then
+  fail "Docker CLI is not executable: ${DOCKER_BIN}"
+fi
+if [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+  fail "an incomplete runtime config transaction requires recovery"
+fi
+
+current_release="$(validate_verified_state)"
+if [[ "${config_mode}" == keep ]]; then
+  if [[ -z "${current_release}" ]] \
+    || [[ "$(validate_release "${current_release}")" != synced ]]
+  then
+    fail "keep mode requires a verified script-enabled runtime config release"
+  fi
+  candidate_release="${current_release}"
+fi
+
+registry_token="$(/bin/cat)"
+if [[ -z "${registry_token}" ]]; then
+  printf 'GHCR token must not be empty\n' >&2
+  exit 64
+fi
+
+umask 077
+
+docker_config_dir=
+token_file=
+release_temp=
+config_container_id=
+logged_in=false
+
+cleanup() {
+  registry_token=
+
+  if [[ -n "${config_container_id}" ]]; then
+    "${DOCKER_BIN}" rm "${config_container_id}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${release_temp}" && -d "${release_temp}" ]] \
+    && [[ "$(/usr/bin/basename "${release_temp}")" == .tmp.* ]]
+  then
+    /bin/rm -rf -- "${release_temp}"
+  fi
+  if [[ "${logged_in}" == true && -n "${docker_config_dir}" ]]; then
+    "${DOCKER_BIN}" \
+      --config "${docker_config_dir}" \
+      logout ghcr.io \
+      >/dev/null 2>&1 \
+      || true
+  fi
+  if [[ -n "${docker_config_dir}" && -d "${docker_config_dir}" ]] \
+    && [[ "$(/usr/bin/basename "${docker_config_dir}")" == cubing-hub-bootstrap-docker.* ]]
+  then
+    /bin/rm -rf -- "${docker_config_dir}"
+  fi
+  if [[ -n "${token_file}" && -f "${token_file}" ]] \
+    && [[ "$(/usr/bin/basename "${token_file}")" == cubing-hub-token.* ]]
+  then
+    /bin/rm -f -- "${token_file}"
+  fi
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ "${config_mode}" == update ]]; then
+  config_image="${RUNTIME_CONFIG_REPOSITORY}@${config_digest}"
+  docker_config_dir="$(
+    /usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-hub-bootstrap-docker.XXXXXX"
+  )"
+  printf '%s' "${registry_token}" \
+    | "${DOCKER_BIN}" \
+        --config "${docker_config_dir}" \
+        login ghcr.io \
+        --username "${registry_user}" \
+        --password-stdin \
+        >/dev/null
+  logged_in=true
+
+  "${DOCKER_BIN}" \
+    --config "${docker_config_dir}" \
+    pull "${config_image}" \
+    >/dev/null
+
+  actual_revision="$(
+    "${DOCKER_BIN}" \
+      image inspect \
+      --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+      "${config_image}"
+  )"
+  if [[ "${actual_revision}" != "${commit_sha}" ]]; then
+    fail "runtime config revision label does not match deployment revision"
+  fi
+  actual_project="$(
+    "${DOCKER_BIN}" \
+      image inspect \
+      --format '{{ index .Config.Labels "io.chochiho.runtime-config.project" }}' \
+      "${config_image}"
+  )"
+  if [[ "${actual_project}" != cubing-hub ]]; then
+    fail "runtime config project label is invalid"
+  fi
+
+  /bin/mkdir -p "${RUNTIME_CONFIG_RELEASES}"
+  candidate_release="${RUNTIME_CONFIG_RELEASES}/${config_digest#sha256:}"
+  release_temp="$(
+    /usr/bin/mktemp -d "${RUNTIME_CONFIG_RELEASES}/.tmp.XXXXXX"
+  )"
+  config_container_id="$("${DOCKER_BIN}" create "${config_image}")"
+  "${DOCKER_BIN}" cp "${config_container_id}:/runtime/." "${release_temp}"
+  "${DOCKER_BIN}" rm "${config_container_id}" >/dev/null
+  config_container_id=
+
+  validate_release "${release_temp}" synced >/dev/null
+  /bin/chmod -R go-rwx "${release_temp}"
+  validate_release "${release_temp}" synced >/dev/null
+
+  if [[ -d "${candidate_release}" ]]; then
+    validate_release "${candidate_release}" synced >/dev/null
+    if ! /usr/bin/diff -qr "${release_temp}" "${candidate_release}" >/dev/null; then
+      fail "existing runtime config release differs from exact digest artifact"
+    fi
+    /bin/rm -rf -- "${release_temp}"
+    release_temp=
+  else
+    /bin/mv -- "${release_temp}" "${candidate_release}"
+    release_temp=
+  fi
+fi
+
+candidate_script="${candidate_release}/scripts/deploy-cubing-hub.sh"
+if [[ ! -x "${candidate_script}" || -L "${candidate_script}" ]]; then
+  fail "verified candidate deploy script is missing or unsafe"
+fi
+
+token_file="$(
+  /usr/bin/mktemp "${TMPDIR:-/tmp}/cubing-hub-token.XXXXXX"
+)"
+/bin/chmod 600 "${token_file}"
+printf '%s' "${registry_token}" >"${token_file}"
+registry_token=
+exec 3<"${token_file}"
+/bin/rm -f -- "${token_file}"
+token_file=
+
+cleanup
+trap - EXIT INT TERM
+
+if [[ "${config_mode}" == update ]]; then
+  exec "${candidate_script}" \
+    "${commit_sha}" \
     update \
-    "${BASH_REMATCH[2]}" \
-    "${BASH_REMATCH[3]}"
+    "${config_digest}" \
+    "${registry_user}" \
+    <&3 3<&-
 fi
-
-printf '%s\n' \
-  'Only deploy-cubing-hub or strictly formatted deploy-cubing-hub-v2 commands are allowed' \
-  >&2
-exit 64
+exec "${candidate_script}" \
+  "${commit_sha}" \
+  keep \
+  "${registry_user}" \
+  <&3 3<&-

--- a/homeserver/scripts/deploy-home-server-ci.sh
+++ b/homeserver/scripts/deploy-home-server-ci.sh
@@ -6,9 +6,24 @@ readonly DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
 
-if [[ ! "${original_command}" =~ ^deploy-cubing-hub[[:space:]]([0-9a-fA-F]{40})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
-  printf 'Only deploy-cubing-hub <commit-sha> <registry-user> is allowed\n' >&2
-  exit 64
+if [[ "${original_command}" =~ ^deploy-cubing-hub[[:space:]]([0-9a-fA-F]{40})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
+  exec "${DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
 fi
 
-exec "${DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+if [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[[:space:]]keep[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
+  exec "${DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" keep "${BASH_REMATCH[2]}"
+fi
+
+if [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[[:space:]]update[[:space:]](sha256:[0-9a-f]{64})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
+  exec \
+    "${DEPLOY_SCRIPT}" \
+    "${BASH_REMATCH[1]}" \
+    update \
+    "${BASH_REMATCH[2]}" \
+    "${BASH_REMATCH[3]}"
+fi
+
+printf '%s\n' \
+  'Only deploy-cubing-hub or strictly formatted deploy-cubing-hub-v2 commands are allowed' \
+  >&2
+exit 64

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -418,7 +418,7 @@ validate_compose_contract() {
     "${baseline_rendered}" \
     | "${PYTHON_BIN}" -c '
 import json
-import re
+import posixpath
 import sys
 
 candidate, baseline = json.load(sys.stdin)
@@ -518,45 +518,58 @@ if (
 ):
     fail("API data-sensitive environment changes require a separate migration procedure")
 
-def probe_text(service_name):
-    healthcheck = candidate_services[service_name].get("healthcheck")
+def healthcheck_test_for(service, label):
+    healthcheck = service.get("healthcheck")
+    if healthcheck is None:
+        return None
     if not isinstance(healthcheck, dict) or healthcheck.get("disable") is True:
-        fail(f"{service_name} healthcheck is required")
+        fail(f"{label} healthcheck is invalid")
     test = healthcheck.get("test")
-    if isinstance(test, list):
-        parts = test
-    elif isinstance(test, str):
-        parts = [test]
-    else:
-        fail(f"{service_name} healthcheck probe is invalid")
-    if not parts:
-        fail(f"{service_name} healthcheck probe is empty")
-    return " ".join(str(part) for part in parts).lower()
+    if (
+        not isinstance(test, list)
+        or not test
+        or test[0] not in ("CMD", "CMD-SHELL")
+    ):
+        fail(f"{label} healthcheck probe is invalid")
+    return test
 
-def has_loopback(probe):
-    return any(value in probe for value in ("127.0.0.1", "localhost", "::1"))
+def tmpfs_targets_for(service, label):
+    entries = service.get("tmpfs", [])
+    if entries is None:
+        return set()
+    if not isinstance(entries, list):
+        fail(f"{label} tmpfs contract is invalid")
+    targets = []
+    for entry in entries:
+        if isinstance(entry, str):
+            target = entry.split(":", 1)[0]
+        elif isinstance(entry, dict):
+            target = entry.get("target")
+        else:
+            fail(f"{label} tmpfs contract is invalid")
+        if not isinstance(target, str) or not target.startswith("/"):
+            fail(f"{label} tmpfs target is invalid")
+        targets.append(posixpath.normpath(target))
+    if len(targets) != len(set(targets)):
+        fail(f"{label} tmpfs target set is invalid")
+    return set(targets)
 
-db_probe = probe_text("db")
-if (
-    "mysqladmin" not in db_probe
-    or re.search(r"\bping\b", db_probe) is None
-    or not has_loopback(db_probe)
-):
-    fail("db healthcheck must retain mysqladmin ping against loopback")
-
-redis_probe = probe_text("redis")
-if "redis-cli" not in redis_probe or re.search(r"\bping\b", redis_probe) is None:
-    fail("redis healthcheck must retain redis-cli ping")
-
-web_probe = probe_text("web")
-if (
-    not has_loopback(web_probe)
-    or "/actuator/health" not in web_probe
-    or "status" not in web_probe
-    or re.search(r"\bup\b", web_probe) is None
-    or re.search(r"\bhost\s*:\s*api\.cubing-hub\.com\b", web_probe) is None
-):
-    fail("web healthcheck must retain loopback API readiness, status UP, and Host semantics")
+for name in ("db", "redis", "api", "web"):
+    if candidate_services[name].get("user") != baseline_services[name].get("user"):
+        fail(f"{name} user differs from the active verified configuration")
+    if tmpfs_targets_for(candidate_services[name], name) != tmpfs_targets_for(
+        baseline_services[name],
+        f"active {name}",
+    ):
+        fail(f"{name} tmpfs target set differs from the active verified configuration")
+    if healthcheck_test_for(
+        candidate_services[name],
+        name,
+    ) != healthcheck_test_for(
+        baseline_services[name],
+        f"active {name}",
+    ):
+        fail(f"{name} healthcheck test differs from the active verified configuration")
 
 for name, service in candidate_services.items():
     if service.get("ports"):

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -163,7 +163,7 @@ if [[ "${legacy_mode}" == true ]]; then
   require_legacy_compose
 fi
 
-if [[ "${recovery_mode}" == false && ! -x "${BACKUP_SCRIPT}" ]]; then
+if [[ "${legacy_mode}" == true && ! -x "${BACKUP_SCRIPT}" ]]; then
   fail "production backup script is not executable"
 fi
 

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -3,16 +3,33 @@
 set -Eeuo pipefail
 
 readonly DOCKER_BIN=/usr/local/bin/docker
+readonly PYTHON_BIN=/usr/bin/python3
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
-readonly COMPOSE_FILE="${APP_DIR}/compose.yaml"
+readonly PROJECT_NAME=cubing-hub
+readonly LEGACY_COMPOSE_FILE="${APP_DIR}/compose.yaml"
 readonly ENV_FILE="${APP_DIR}/.env"
 readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh
+readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
+readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
+readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
+readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
+readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
+readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
 readonly API_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-api
 readonly WEB_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-web
+readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
 readonly HEALTH_TIMEOUT_SECONDS=240
 
 usage() {
-  printf 'Usage: deploy-cubing-hub.sh <commit-sha> <registry-user>\n' >&2
+  printf '%s\n' \
+    'Usage:' \
+    '  deploy-cubing-hub.sh <commit-sha> <registry-user>' \
+    '  deploy-cubing-hub.sh <commit-sha> keep <registry-user>' \
+    '  deploy-cubing-hub.sh <commit-sha> update <config-digest> <registry-user>' \
+    '  deploy-cubing-hub.sh recover' \
+    >&2
 }
 
 fail() {
@@ -20,21 +37,85 @@ fail() {
   exit 1
 }
 
-if [[ "$#" -ne 2 ]]; then
-  usage
-  exit 64
-fi
+require_legacy_compose() {
+  if [[ ! -f "${LEGACY_COMPOSE_FILE}" ]]; then
+    fail "legacy production Compose configuration is missing"
+  fi
+}
 
-commit_sha="$1"
-registry_user="$2"
+validate_initialization_marker() {
+  if [[ ! -f "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_INITIALIZED}" ]] \
+    || [[ "$(/bin/cat "${RUNTIME_CONFIG_INITIALIZED}")" != RUNTIME_CONFIG_V2=initialized ]]
+  then
+    fail "runtime config initialization marker is invalid"
+  fi
+}
 
-if [[ ! "${commit_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+is_digest() {
+  [[ "$1" =~ ^sha256:[0-9a-f]{64}$ ]] && [[ "$1" != "${ZERO_DIGEST}" ]]
+}
+
+legacy_mode=false
+recovery_mode=false
+config_mode=legacy
+config_digest=
+commit_sha=
+registry_user=
+
+case "$#" in
+  1)
+    if [[ "$1" != recover ]]; then
+      usage
+      exit 64
+    fi
+    recovery_mode=true
+    config_mode=recover
+    ;;
+  2)
+    legacy_mode=true
+    commit_sha="$1"
+    registry_user="$2"
+    ;;
+  3)
+    commit_sha="$1"
+    config_mode="$2"
+    registry_user="$3"
+    if [[ "${config_mode}" != keep ]]; then
+      usage
+      exit 64
+    fi
+    ;;
+  4)
+    commit_sha="$1"
+    config_mode="$2"
+    config_digest="$3"
+    registry_user="$4"
+    if [[ "${config_mode}" != update ]]; then
+      usage
+      exit 64
+    fi
+    ;;
+  *)
+    usage
+    exit 64
+    ;;
+esac
+
+if [[ "${recovery_mode}" == false && ! "${commit_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
   printf 'Commit SHA must contain exactly 40 hexadecimal characters\n' >&2
   exit 64
 fi
 
-if [[ ! "${registry_user}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+if [[ "${recovery_mode}" == false && ! "${registry_user}" =~ ^[A-Za-z0-9_-]+$ ]]; then
   printf 'Registry user contains unsupported characters\n' >&2
+  exit 64
+fi
+
+if [[ "${config_mode}" == update ]] \
+  && { [[ ! "${config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || [[ "${config_digest}" == "${ZERO_DIGEST}" ]]; }
+then
+  printf 'Runtime config digest must use sha256 followed by 64 lowercase hexadecimal characters\n' >&2
   exit 64
 fi
 
@@ -42,18 +123,57 @@ if [[ ! -x "${DOCKER_BIN}" ]]; then
   fail "Docker CLI is not executable: ${DOCKER_BIN}"
 fi
 
-if [[ ! -f "${COMPOSE_FILE}" || ! -f "${ENV_FILE}" ]]; then
-  fail "production Compose configuration is incomplete"
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  fail "Python is not executable: ${PYTHON_BIN}"
 fi
 
-if [[ ! -x "${BACKUP_SCRIPT}" ]]; then
+if [[ ! -f "${ENV_FILE}" ]]; then
+  fail "production environment configuration is missing"
+fi
+
+if [[ "${recovery_mode}" == false ]] \
+  && [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]
+then
+  fail "an incomplete runtime config transaction requires recovery"
+fi
+if [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]; then
+  validate_initialization_marker
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]] \
+    || [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]]
+  then
+    fail "initialized runtime config requires verified state and current pointer"
+  fi
+elif [[ "${recovery_mode}" == false ]] \
+  && {
+    [[ -e "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]] \
+      || [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]];
+  }
+then
+  fail "runtime config state exists without initialization marker"
+fi
+if [[ "${legacy_mode}" == true ]] \
+  && {
+    [[ -e "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]] \
+      || [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]];
+  }
+then
+  fail "legacy deployment is disabled after runtime config state initialization"
+fi
+if [[ "${legacy_mode}" == true ]]; then
+  require_legacy_compose
+fi
+
+if [[ "${recovery_mode}" == false && ! -x "${BACKUP_SCRIPT}" ]]; then
   fail "production backup script is not executable"
 fi
 
-registry_token="$(/bin/cat)"
-if [[ -z "${registry_token}" ]]; then
-  printf 'GHCR token must not be empty\n' >&2
-  exit 64
+registry_token=
+if [[ "${recovery_mode}" == false ]]; then
+  registry_token="$(/bin/cat)"
+  if [[ -z "${registry_token}" ]]; then
+    printf 'GHCR token must not be empty\n' >&2
+    exit 64
+  fi
 fi
 
 umask 077
@@ -62,6 +182,13 @@ docker_config_dir="$(
   /usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-hub-docker-config.XXXXXX"
 )"
 env_temp=
+state_temp=
+pending_temp=
+release_temp=
+current_link_temp=
+initialization_temp=
+config_container_id=
+prepared_release=
 logged_in=false
 
 # ShellCheck cannot infer that trap invokes this cleanup function.
@@ -71,6 +198,27 @@ cleanup() {
 
   if [[ -n "${env_temp}" && -e "${env_temp}" ]]; then
     /bin/unlink "${env_temp}"
+  fi
+
+  if [[ -n "${config_container_id}" ]]; then
+    "${DOCKER_BIN}" rm "${config_container_id}" >/dev/null 2>&1 || true
+  fi
+
+  for cleanup_path in \
+    "${state_temp}" \
+    "${pending_temp}" \
+    "${current_link_temp}" \
+    "${initialization_temp}"
+  do
+    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]]; then
+      /bin/rm -f -- "${cleanup_path}"
+    fi
+  done
+
+  if [[ -n "${release_temp}" && -d "${release_temp}" ]] \
+    && [[ "$(/usr/bin/basename "${release_temp}")" == .tmp.* ]]
+  then
+    /bin/rm -rf -- "${release_temp}"
   fi
 
   if [[ "${logged_in}" == true ]]; then
@@ -90,12 +238,15 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+active_compose_file="${LEGACY_COMPOSE_FILE}"
+
 compose() {
   "${DOCKER_BIN}" \
     compose \
-    --project-directory "${APP_DIR}" \
+    --project-name "${PROJECT_NAME}" \
+    --project-directory "$(/usr/bin/dirname "${active_compose_file}")" \
     --env-file "${ENV_FILE}" \
-    --file "${COMPOSE_FILE}" \
+    --file "${active_compose_file}" \
     "$@"
 }
 
@@ -177,6 +328,829 @@ extract_sha() {
   printf '%s' "${image_sha}"
 }
 
+read_state_value() {
+  local key="$1"
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" ]]; then
+    return 0
+  fi
+  /usr/bin/sed -n "s/^${key}=//p" "${RUNTIME_CONFIG_STATE}" \
+    | /usr/bin/tail -n 1
+}
+
+release_dir_for_digest() {
+  printf '%s/%s\n' "${RUNTIME_CONFIG_RELEASES}" "${1#sha256:}"
+}
+
+validate_release_files() {
+  local release_dir="$1"
+  local unexpected
+  local files
+
+  unexpected="$(
+    /usr/bin/find "${release_dir}" ! -type d ! -type f -print
+  )"
+  if [[ -n "${unexpected}" ]]; then
+    fail "runtime config contains unsupported file types"
+  fi
+
+  files="$(
+    /usr/bin/find "${release_dir}" -type f -print \
+      | /usr/bin/sed "s#^${release_dir}/##" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${files}" != $'compose.yaml\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    fail "runtime config file allowlist does not match"
+  fi
+}
+
+runtime_config_content_sha256() {
+  local release_dir="$1"
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+render_compose_json() {
+  local compose_file="$1"
+  local api_image="$2"
+  local web_image="$3"
+
+  API_IMAGE="${api_image}" \
+  WEB_IMAGE="${web_image}" \
+    "${DOCKER_BIN}" \
+      compose \
+      --project-name "${PROJECT_NAME}" \
+      --project-directory "$(/usr/bin/dirname "${compose_file}")" \
+      --env-file "${ENV_FILE}" \
+      --file "${compose_file}" \
+      config \
+      --no-env-resolution \
+      --format json
+}
+
+validate_compose_contract() {
+  local compose_file="$1"
+  local api_image="$2"
+  local web_image="$3"
+  local baseline_file="${validation_baseline_compose_file:-${compose_file}}"
+  local baseline_api_image="${validation_baseline_api_image:-${api_image}}"
+  local baseline_web_image="${validation_baseline_web_image:-${web_image}}"
+  local candidate_rendered
+  local baseline_rendered
+
+  candidate_rendered="$(
+    render_compose_json \
+      "${compose_file}" \
+      "${api_image}" \
+      "${web_image}"
+  )"
+  baseline_rendered="$(
+    render_compose_json \
+      "${baseline_file}" \
+      "${baseline_api_image}" \
+      "${baseline_web_image}"
+  )"
+
+  printf '[%s,%s]' \
+    "${candidate_rendered}" \
+    "${baseline_rendered}" \
+    | "${PYTHON_BIN}" -c '
+import json
+import re
+import sys
+
+candidate, baseline = json.load(sys.stdin)
+expected_api_image, expected_web_image, expected_real_ip_source = sys.argv[1:4]
+required_services = {"db", "redis", "api", "web"}
+
+def fail(message):
+    raise SystemExit(message)
+
+def services(config, label):
+    value = config.get("services", {})
+    if set(value) != required_services:
+        fail(f"{label} runtime config must contain only db, redis, api, and web")
+    return value
+
+candidate_services = services(candidate, "candidate")
+baseline_services = services(baseline, "active")
+
+if candidate.get("configs") or candidate.get("secrets"):
+    fail("runtime config must not define Compose configs or secrets")
+for name, service in candidate_services.items():
+    if service.get("configs") or service.get("secrets") or service.get("env_file"):
+        fail(f"{name} must not mount configs, secrets, or env files")
+
+if candidate.get("name") != "cubing-hub":
+    fail("Compose project name must remain cubing-hub")
+if candidate_services["api"].get("image") != expected_api_image:
+    fail("API image does not match the requested deployment")
+if candidate_services["web"].get("image") != expected_web_image:
+    fail("Web image does not match the requested deployment")
+for name in ("db", "redis"):
+    if candidate_services[name].get("image") != baseline_services[name].get("image"):
+        fail(f"{name} image changes require a separate data-service procedure")
+    for field in ("command", "entrypoint"):
+        if candidate_services[name].get(field) != baseline_services[name].get(field):
+            fail(f"{name} {field} changes require a separate data-service procedure")
+
+def service_environment(service, label):
+    environment = service.get("environment", {})
+    if not isinstance(environment, dict):
+        fail(f"{label} environment contract is invalid")
+    return environment
+
+candidate_db_environment = service_environment(candidate_services["db"], "db")
+baseline_db_environment = service_environment(baseline_services["db"], "active db")
+if (
+    {
+        name: value
+        for name, value in candidate_db_environment.items()
+        if name.startswith("MYSQL_")
+    }
+    != {
+        name: value
+        for name, value in baseline_db_environment.items()
+        if name.startswith("MYSQL_")
+    }
+):
+    fail("db MYSQL environment changes require a separate data-service procedure")
+
+protected_api_environment_names = {
+    "DB_USERNAME",
+    "DB_PASSWORD",
+    "JDK_JAVA_OPTIONS",
+    "JAVA_OPTS",
+    "JAVA_TOOL_OPTIONS",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "RANKING_REDIS_REBUILD_MODE",
+    "SPRING_APPLICATION_JSON",
+    "_JAVA_OPTIONS",
+}
+protected_api_environment_prefixes = (
+    "POST_IMAGES_",
+    "SPRING_CONFIG_",
+    "SPRING_PROFILES_",
+    "SPRING_DATASOURCE_",
+    "SPRING_JPA_",
+    "SPRING_FLYWAY_",
+    "SPRING_LIQUIBASE_",
+    "SPRING_SQL_INIT_",
+)
+
+def protected_api_environment(service):
+    environment = service_environment(service, "API")
+    return {
+        name: value
+        for name, value in environment.items()
+        if (
+            name in protected_api_environment_names
+            or name.startswith(protected_api_environment_prefixes)
+        )
+    }
+
+if (
+    protected_api_environment(candidate_services["api"])
+    != protected_api_environment(baseline_services["api"])
+):
+    fail("API data-sensitive environment changes require a separate migration procedure")
+
+def probe_text(service_name):
+    healthcheck = candidate_services[service_name].get("healthcheck")
+    if not isinstance(healthcheck, dict) or healthcheck.get("disable") is True:
+        fail(f"{service_name} healthcheck is required")
+    test = healthcheck.get("test")
+    if isinstance(test, list):
+        parts = test
+    elif isinstance(test, str):
+        parts = [test]
+    else:
+        fail(f"{service_name} healthcheck probe is invalid")
+    if not parts:
+        fail(f"{service_name} healthcheck probe is empty")
+    return " ".join(str(part) for part in parts).lower()
+
+def has_loopback(probe):
+    return any(value in probe for value in ("127.0.0.1", "localhost", "::1"))
+
+db_probe = probe_text("db")
+if (
+    "mysqladmin" not in db_probe
+    or re.search(r"\bping\b", db_probe) is None
+    or not has_loopback(db_probe)
+):
+    fail("db healthcheck must retain mysqladmin ping against loopback")
+
+redis_probe = probe_text("redis")
+if "redis-cli" not in redis_probe or re.search(r"\bping\b", redis_probe) is None:
+    fail("redis healthcheck must retain redis-cli ping")
+
+web_probe = probe_text("web")
+if (
+    not has_loopback(web_probe)
+    or "/actuator/health" not in web_probe
+    or "status" not in web_probe
+    or re.search(r"\bup\b", web_probe) is None
+    or re.search(r"\bhost\s*:\s*api\.cubing-hub\.com\b", web_probe) is None
+):
+    fail("web healthcheck must retain loopback API readiness, status UP, and Host semantics")
+
+for name, service in candidate_services.items():
+    if service.get("ports"):
+        fail(f"{name} must not publish host ports")
+    if service.get("extra_hosts") or service.get("external_links") or service.get("links"):
+        fail(f"{name} must not override protected service hostnames")
+    if (
+        service.get("privileged") is True
+        or service.get("use_api_socket") is True
+        or service.get("cap_add")
+        or service.get("devices")
+        or service.get("volumes_from")
+    ):
+        fail(f"{name} must not receive host or Docker privileges")
+    for field in ("pid", "ipc", "uts", "cgroup", "userns_mode", "network_mode"):
+        if service.get(field) == "host":
+            fail(f"{name} must not share the host namespace")
+
+for name in ("api", "web"):
+    for field in ("command", "entrypoint"):
+        if candidate_services[name].get(field) is not None:
+            fail(f"{name} must not override its image {field}")
+
+expected_attachments = {
+    "db": {"application"},
+    "redis": {"application"},
+    "api": {"application", "outbound"},
+    "web": {"application", "edge"},
+}
+for name, expected in expected_attachments.items():
+    attachments = candidate_services[name].get("networks", {})
+    if set(attachments) != expected:
+        fail(f"{name} network boundary is invalid")
+web_edge = candidate_services["web"]["networks"].get("edge")
+if not isinstance(web_edge, dict) or web_edge.get("aliases") != ["cubing-hub-web"]:
+    fail("Web edge alias must remain cubing-hub-web")
+
+networks = candidate.get("networks", {})
+if set(networks) != {"application", "outbound", "edge"}:
+    fail("runtime config network set is invalid")
+application = networks["application"]
+outbound = networks["outbound"]
+edge = networks["edge"]
+if (
+    application.get("name") != "cubing-hub_application"
+    or application.get("driver") not in (None, "bridge")
+    or application.get("internal") is not True
+    or application.get("external") is True
+    or application.get("driver_opts")
+):
+    fail("application network must remain project-private and internal")
+if (
+    outbound.get("name") != "cubing-hub_outbound"
+    or outbound.get("driver") not in (None, "bridge")
+    or outbound.get("internal") is True
+    or outbound.get("external") is True
+    or outbound.get("driver_opts")
+):
+    fail("outbound network must remain a project-private egress bridge")
+if edge.get("name") != "edge" or edge.get("external") is not True:
+    fail("edge network must remain the shared external edge")
+
+volumes = candidate.get("volumes", {})
+if set(volumes) != {"mysql-data", "redis-data"}:
+    fail("runtime config data volume set is invalid")
+for key, expected_name, message in (
+    ("mysql-data", "cubing-hub_mysql-data", "MySQL persistent volume contract is invalid"),
+    ("redis-data", "cubing-hub_redis-data", "Redis persistent volume contract is invalid"),
+):
+    volume = volumes[key]
+    if (
+        volume.get("name") != expected_name
+        or volume.get("external") is True
+        or volume.get("driver") not in (None, "local")
+        or volume.get("driver_opts")
+    ):
+        fail(message)
+
+def mounts(service_name):
+    value = candidate_services[service_name].get("volumes", [])
+    if not isinstance(value, list):
+        fail(f"{service_name} volume contract is invalid")
+    return value
+
+def mount_by_target(service, target, label):
+    matches = [
+        value
+        for value in service.get("volumes", [])
+        if isinstance(value, dict) and value.get("target") == target
+    ]
+    if len(matches) != 1:
+        fail(f"{label} mount identity is invalid")
+    return matches[0]
+
+db_mounts = mounts("db")
+redis_mounts = mounts("redis")
+if len(db_mounts) != 1 or {
+    key: db_mounts[0].get(key)
+    for key in ("type", "source", "target")
+} != {
+    "type": "volume",
+    "source": "mysql-data",
+    "target": "/var/lib/mysql",
+} or db_mounts[0].get("volume") not in (None, {}):
+    fail("MySQL persistent volume contract is invalid")
+if len(redis_mounts) != 1 or {
+    key: redis_mounts[0].get(key)
+    for key in ("type", "source", "target")
+} != {
+    "type": "volume",
+    "source": "redis-data",
+    "target": "/data",
+} or redis_mounts[0].get("volume") not in (None, {}):
+    fail("Redis persistent volume contract is invalid")
+
+active_upload = mount_by_target(
+    baseline_services["api"],
+    "/data/post-images",
+    "active upload",
+)
+expected_upload_source = active_upload.get("source")
+if active_upload.get("type") != "bind" or not expected_upload_source:
+    fail("active upload bind identity is invalid")
+
+api_mounts = mounts("api")
+web_mounts = mounts("web")
+if len(api_mounts) != 1 or len(web_mounts) != 2:
+    fail("application services contain an unsupported host bind")
+api_upload = mount_by_target(candidate_services["api"], "/data/post-images", "API upload")
+web_upload = mount_by_target(candidate_services["web"], "/data/post-images", "Web upload")
+real_ip = mount_by_target(
+    candidate_services["web"],
+    "/etc/nginx/conf.d/00-cloudflare-real-ip.conf",
+    "Nginx real-IP",
+)
+if (
+    api_upload.get("type") != "bind"
+    or api_upload.get("source") != expected_upload_source
+    or api_upload.get("read_only") is True
+    or api_upload.get("bind") not in (None, {})
+):
+    fail("API upload bind identity is invalid")
+if (
+    web_upload.get("type") != "bind"
+    or web_upload.get("source") != expected_upload_source
+    or web_upload.get("read_only") is not True
+    or web_upload.get("bind") not in (None, {})
+):
+    fail("Web upload bind identity is invalid")
+if (
+    real_ip.get("type") != "bind"
+    or real_ip.get("source") != expected_real_ip_source
+    or real_ip.get("read_only") is not True
+    or real_ip.get("bind") not in (None, {})
+):
+    fail("Nginx must mount the candidate release real-IP configuration")
+' \
+      "${api_image}" \
+      "${web_image}" \
+      "$(/usr/bin/dirname "${compose_file}")/nginx/cloudflare-edge-real-ip.conf"
+}
+
+prepare_runtime_release() {
+  local digest="$1"
+  local expected_revision="$2"
+  local config_image="${RUNTIME_CONFIG_REPOSITORY}@${digest}"
+  local actual_project
+  local actual_revision
+  local release_dir
+
+  "${DOCKER_BIN}" \
+    --config "${docker_config_dir}" \
+    pull "${config_image}" \
+    >/dev/null
+
+  actual_revision="$(
+    "${DOCKER_BIN}" \
+      image inspect \
+      --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+      "${config_image}"
+  )"
+  if [[ "${actual_revision}" != "${expected_revision}" ]]; then
+    fail "runtime config revision label does not match deployment revision"
+  fi
+
+  actual_project="$(
+    "${DOCKER_BIN}" \
+      image inspect \
+      --format '{{ index .Config.Labels "io.chochiho.runtime-config.project" }}' \
+      "${config_image}"
+  )"
+  if [[ "${actual_project}" != cubing-hub ]]; then
+    fail "runtime config project label is invalid"
+  fi
+
+  /bin/mkdir -p "${RUNTIME_CONFIG_RELEASES}"
+  release_dir="$(release_dir_for_digest "${digest}")"
+  release_temp="$(
+    /usr/bin/mktemp -d "${RUNTIME_CONFIG_RELEASES}/.tmp.XXXXXX"
+  )"
+  config_container_id="$("${DOCKER_BIN}" create "${config_image}")"
+  "${DOCKER_BIN}" cp "${config_container_id}:/runtime/." "${release_temp}"
+  "${DOCKER_BIN}" rm "${config_container_id}" >/dev/null
+  config_container_id=
+
+  validate_release_files "${release_temp}"
+  /bin/chmod -R go-rwx "${release_temp}"
+
+  if [[ -d "${release_dir}" ]]; then
+    validate_release_files "${release_dir}"
+    if ! /usr/bin/diff -qr "${release_temp}" "${release_dir}" >/dev/null; then
+      fail "existing runtime config release differs from exact digest artifact"
+    fi
+    /bin/rm -rf -- "${release_temp}"
+    release_temp=
+    prepared_release="${release_dir}"
+    return 0
+  fi
+
+  /bin/mv -- "${release_temp}" "${release_dir}"
+  release_temp=
+  prepared_release="${release_dir}"
+}
+
+write_pending_state() {
+  local previous_sha="$1"
+  local previous_config_digest="$2"
+  local target_sha="$3"
+  local target_config_digest="$4"
+
+  /bin/mkdir -p "${RUNTIME_CONFIG_ROOT}"
+  pending_temp="$(
+    /usr/bin/mktemp "${RUNTIME_CONFIG_ROOT}/.pending.tmp.XXXXXX"
+  )"
+  {
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${previous_sha}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_config_digest}"
+    printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_sha}"
+    printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${target_config_digest}"
+  } >"${pending_temp}"
+  /bin/chmod 600 "${pending_temp}"
+  /bin/mv -f -- "${pending_temp}" "${RUNTIME_CONFIG_PENDING}"
+  pending_temp=
+}
+
+replace_current_link() {
+  local release_dir="$1"
+
+  current_link_temp="${RUNTIME_CONFIG_ROOT}/.current.$$"
+  /bin/ln -s "releases/$("/usr/bin/basename" "${release_dir}")" "${current_link_temp}"
+  "${PYTHON_BIN}" -c \
+    'import os, sys; os.replace(sys.argv[1], sys.argv[2])' \
+    "${current_link_temp}" \
+    "${RUNTIME_CONFIG_CURRENT}"
+  current_link_temp=
+}
+
+write_initialization_marker() {
+  if [[ -e "${RUNTIME_CONFIG_INITIALIZED}" || -L "${RUNTIME_CONFIG_INITIALIZED}" ]]; then
+    validate_initialization_marker
+    return
+  fi
+
+  initialization_temp="$(
+    /usr/bin/mktemp "${APP_DIR}/.runtime-config-v2-initialized.tmp.XXXXXX"
+  )"
+  printf 'RUNTIME_CONFIG_V2=initialized\n' >"${initialization_temp}"
+  /bin/chmod 400 "${initialization_temp}"
+  /bin/mv -f -- "${initialization_temp}" "${RUNTIME_CONFIG_INITIALIZED}"
+  initialization_temp=
+}
+
+write_success_state() {
+  local application_revision="$1"
+  local runtime_config_digest="$2"
+  local runtime_config_revision="$3"
+  local runtime_config_content_sha="$4"
+  local previous_sha="$5"
+  local previous_config_digest="$6"
+  local release_dir="$7"
+
+  state_temp="$(
+    /usr/bin/mktemp "${RUNTIME_CONFIG_ROOT}/.state.tmp.XXXXXX"
+  )"
+  {
+    printf 'APPLICATION_REVISION=%s\n' "${application_revision}"
+    printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${runtime_config_digest}"
+    printf 'RUNTIME_CONFIG_REVISION=%s\n' "${runtime_config_revision}"
+    printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' "${runtime_config_content_sha}"
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${previous_sha}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_config_digest}"
+  } >"${state_temp}"
+  /bin/chmod 600 "${state_temp}"
+  /bin/mv -f -- "${state_temp}" "${RUNTIME_CONFIG_STATE}"
+  state_temp=
+
+  replace_current_link "${release_dir}"
+  write_initialization_marker
+  /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+}
+
+read_pending_value() {
+  local key="$1"
+  local value
+
+  value="$(
+    /usr/bin/awk -F= -v key="${key}" '
+      $1 == key {
+        value = substr($0, index($0, "=") + 1)
+        count += 1
+      }
+      END {
+        if (count != 1) {
+          exit 1
+        }
+        print value
+      }
+    ' "${RUNTIME_CONFIG_PENDING}"
+  )" || fail "${key} must appear exactly once in ${RUNTIME_CONFIG_PENDING}"
+
+  printf '%s' "${value}"
+}
+
+validate_pending_state() {
+  local keys
+
+  if [[ ! -f "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+    fail "runtime config recovery requires a regular pending state file"
+  fi
+
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_PENDING}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'PREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nTARGET_APPLICATION_REVISION\nTARGET_RUNTIME_CONFIG_DIGEST' ]]; then
+    fail "runtime config pending state keys are invalid"
+  fi
+}
+
+validate_state_file() {
+  local application_revision
+  local keys
+  local previous_revision
+  local previous_digest
+  local runtime_content_sha
+  local runtime_digest
+  local runtime_revision
+
+  if [[ ! -f "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    fail "runtime config state must be a regular non-symlink file"
+  fi
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_STATE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'APPLICATION_REVISION\nPREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION' ]]; then
+    fail "runtime config state keys are invalid"
+  fi
+
+  application_revision="$(read_state_value APPLICATION_REVISION)"
+  previous_revision="$(read_state_value PREVIOUS_APPLICATION_REVISION)"
+  previous_digest="$(read_state_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  runtime_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  runtime_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  runtime_revision="$(read_state_value RUNTIME_CONFIG_REVISION)"
+  if [[ ! "${application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${application_revision}" == "${ZERO_SHA}" ]] \
+    || [[ ! "${previous_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || { [[ "${previous_digest}" != "${ZERO_DIGEST}" ]] && ! is_digest "${previous_digest}"; } \
+    || [[ ! "${runtime_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || ! is_digest "${runtime_digest}" \
+    || [[ ! "${runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ "${runtime_revision}" == "${ZERO_SHA}" ]]
+  then
+    fail "runtime config state values are invalid"
+  fi
+}
+
+validate_verified_release() {
+  local digest="$1"
+  local expected_content_sha="$2"
+  local release_dir
+
+  if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ "${digest}" == "${ZERO_DIGEST}" ]] \
+    || [[ ! "${expected_content_sha}" =~ ^[0-9a-f]{64}$ ]]
+  then
+    fail "runtime config state is invalid"
+  fi
+
+  release_dir="$(release_dir_for_digest "${digest}")"
+  if [[ ! -d "${release_dir}" ]]; then
+    fail "runtime config release is missing during recovery"
+  fi
+  validate_release_files "${release_dir}"
+  if [[ "$(runtime_config_content_sha256 "${release_dir}")" != "${expected_content_sha}" ]]; then
+    fail "runtime config release integrity check failed during recovery"
+  fi
+
+  printf '%s' "${release_dir}"
+}
+
+deployment_service_set_is_healthy() {
+  local rendered
+
+  rendered="$(compose ps --format json)"
+  printf '%s' "${rendered}" \
+    | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("no Cubing Hub service status was returned")
+
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+entries = value if isinstance(value, list) else [value]
+required_services = {"api", "db", "redis", "web"}
+health_required = {"db", "redis", "web"}
+seen = set()
+
+for entry in entries:
+    service = entry.get("Service", "")
+    if service not in required_services:
+        raise SystemExit(f"unexpected running service: {service}")
+    seen.add(service)
+    if str(entry.get("State", "")).lower() != "running":
+        raise SystemExit(f"{service} is not running")
+    health = str(entry.get("Health", "")).lower()
+    if service in health_required and health != "healthy":
+        raise SystemExit(f"{service} is not healthy")
+    if health and health != "healthy":
+        raise SystemExit(f"{service} health is not healthy")
+
+if seen != required_services:
+    raise SystemExit("Cubing Hub service set is incomplete")
+'
+}
+
+recover_pending_transaction() {
+  local previous_sha
+  local previous_digest
+  local target_sha
+  local target_digest
+  local state_sha
+  local state_digest
+  local state_content_sha
+  local state_previous_sha
+  local state_previous_digest
+  local recovery_release
+  local recovery_api_image
+  local recovery_web_image
+  local expected_current
+
+  validate_pending_state
+  if [[ -e "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    validate_state_file
+  fi
+  previous_sha="$(read_pending_value PREVIOUS_APPLICATION_REVISION)"
+  previous_digest="$(read_pending_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  target_sha="$(read_pending_value TARGET_APPLICATION_REVISION)"
+  target_digest="$(read_pending_value TARGET_RUNTIME_CONFIG_DIGEST)"
+
+  if [[ ! "${previous_sha}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "${target_sha}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "${previous_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ ! "${target_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ "${target_digest}" == "${ZERO_DIGEST}" ]]
+  then
+    fail "runtime config pending state values are invalid"
+  fi
+
+  state_sha="$(read_state_value APPLICATION_REVISION)"
+  state_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  state_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  state_previous_sha="$(read_state_value PREVIOUS_APPLICATION_REVISION)"
+  state_previous_digest="$(read_state_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+
+  if [[ "${state_sha}" == "${target_sha}" && "${state_digest}" == "${target_digest}" ]]; then
+    if [[ "${previous_sha}" != "${target_sha}" ]] \
+      || [[ "${previous_digest}" != "${target_digest}" ]]
+    then
+      if [[ "${state_previous_sha}" != "${previous_sha}" ]] \
+        || [[ "${state_previous_digest}" != "${previous_digest}" ]]
+      then
+        fail "completed target predecessor does not match pending state"
+      fi
+    fi
+    recovery_release="$(
+      validate_verified_release "${target_digest}" "${state_content_sha}"
+    )"
+    recovery_api_image="${API_IMAGE_REPOSITORY}:${target_sha}"
+    recovery_web_image="${WEB_IMAGE_REPOSITORY}:${target_sha}"
+    if [[ "$(read_env_value API_IMAGE)" != "${recovery_api_image}" ]] \
+      || [[ "$(read_env_value WEB_IMAGE)" != "${recovery_web_image}" ]]
+    then
+      fail "application image environment does not match completed target state"
+    fi
+
+    active_compose_file="${recovery_release}/compose.yaml"
+    validate_compose_contract \
+      "${active_compose_file}" \
+      "${recovery_api_image}" \
+      "${recovery_web_image}"
+    if ! deployment_service_set_is_healthy; then
+      fail "completed target services are not all healthy and running"
+    fi
+
+    expected_current="releases/$("/usr/bin/basename" "${recovery_release}")"
+    if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+      || [[ "$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")" != "${expected_current}" ]]
+    then
+      replace_current_link "${recovery_release}"
+    fi
+    write_initialization_marker
+    /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+    printf 'Completed Cubing Hub runtime config transaction finalized: %s\n' "${target_sha}"
+    return 0
+  fi
+
+  if [[ "${previous_sha}" == "${ZERO_SHA}" ]]; then
+    if [[ -n "${state_sha}" || "${previous_digest}" != "${ZERO_DIGEST}" ]]; then
+      fail "bootstrap recovery state is inconsistent"
+    fi
+    require_legacy_compose
+    write_image_env \
+      "${API_IMAGE_REPOSITORY}:${ZERO_SHA}" \
+      "${WEB_IMAGE_REPOSITORY}:${ZERO_SHA}"
+    active_compose_file="${LEGACY_COMPOSE_FILE}"
+    if ! compose stop api web; then
+      fail "bootstrap recovery could not stop interrupted app services"
+    fi
+    /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+    printf 'Interrupted Cubing Hub bootstrap cleared with app services stopped\n'
+    return 0
+  fi
+
+  recovery_api_image="${API_IMAGE_REPOSITORY}:${previous_sha}"
+  recovery_web_image="${WEB_IMAGE_REPOSITORY}:${previous_sha}"
+  if [[ -z "${state_sha}" && -z "${state_digest}" && "${previous_digest}" == "${ZERO_DIGEST}" ]]; then
+    require_legacy_compose
+    active_compose_file="${LEGACY_COMPOSE_FILE}"
+  else
+    if [[ "${state_sha}" != "${previous_sha}" || "${state_digest}" != "${previous_digest}" ]]; then
+      fail "pending transaction does not match the last verified runtime config state"
+    fi
+    recovery_release="$(
+      validate_verified_release "${previous_digest}" "${state_content_sha}"
+    )"
+    active_compose_file="${recovery_release}/compose.yaml"
+  fi
+
+  validate_compose_contract \
+    "${active_compose_file}" \
+    "${recovery_api_image}" \
+    "${recovery_web_image}"
+
+  write_image_env "${recovery_api_image}" "${recovery_web_image}"
+  if ! compose up \
+    --detach \
+    --no-build \
+    --pull never \
+    --remove-orphans \
+    --wait \
+    --wait-timeout "${HEALTH_TIMEOUT_SECONDS}"
+  then
+    fail "runtime config recovery could not restore the previous verified pair"
+  fi
+  if ! deployment_service_set_is_healthy; then
+    fail "runtime config recovery restored an unhealthy service set"
+  fi
+
+  if [[ -n "${state_sha}" ]]; then
+    expected_current="releases/$("/usr/bin/basename" "${recovery_release}")"
+    if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+      || [[ "$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")" != "${expected_current}" ]]
+    then
+      replace_current_link "${recovery_release}"
+    fi
+    write_initialization_marker
+  fi
+  /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+  printf 'Cubing Hub runtime config transaction recovered to: %s\n' "${previous_sha}"
+}
+
+if [[ "${recovery_mode}" == true ]]; then
+  recover_pending_transaction
+  exit 0
+fi
+
 normalized_sha="$(
   printf '%s' "${commit_sha}" \
     | /usr/bin/tr '[:upper:]' '[:lower:]'
@@ -212,22 +1186,121 @@ registry_token=
 "${DOCKER_BIN}" --config "${docker_config_dir}" pull "${new_api_image}"
 "${DOCKER_BIN}" --config "${docker_config_dir}" pull "${new_web_image}"
 
-API_IMAGE="${new_api_image}" \
-WEB_IMAGE="${new_web_image}" \
-  "${DOCKER_BIN}" \
-    compose \
-    --project-directory "${APP_DIR}" \
-    --env-file "${ENV_FILE}" \
-    --file "${COMPOSE_FILE}" \
-    config \
-    --quiet
+if [[ "${legacy_mode}" == true ]]; then
+  current_compose_file="${LEGACY_COMPOSE_FILE}"
+  candidate_compose_file="${LEGACY_COMPOSE_FILE}"
+else
+  for image in "${new_api_image}" "${new_web_image}"; do
+    actual_revision="$(
+      "${DOCKER_BIN}" \
+        image inspect \
+        --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+        "${image}"
+    )"
+    if [[ "${actual_revision}" != "${normalized_sha}" ]]; then
+      fail "application image revision label does not match deployment revision"
+    fi
+  done
 
+  current_config_digest="$(read_state_value RUNTIME_CONFIG_DIGEST)"
+  current_config_revision="$(read_state_value RUNTIME_CONFIG_REVISION)"
+  current_config_content_sha="$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  current_state_sha="$(read_state_value APPLICATION_REVISION)"
+
+  if [[ ! -e "${RUNTIME_CONFIG_STATE}" && ! -L "${RUNTIME_CONFIG_STATE}" ]] \
+    && [[ -e "${RUNTIME_CONFIG_CURRENT}" || -L "${RUNTIME_CONFIG_CURRENT}" ]]
+  then
+    fail "runtime config state is missing while the current release pointer exists"
+  fi
+  if [[ -e "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]] \
+    && {
+      [[ ! -f "${RUNTIME_CONFIG_STATE}" ]] \
+        || [[ -L "${RUNTIME_CONFIG_STATE}" ]] \
+        || [[ ! "${current_config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+        || [[ "${current_config_digest}" == "${ZERO_DIGEST}" ]] \
+        || [[ ! "${current_config_revision}" =~ ^[0-9a-f]{40}$ ]] \
+        || [[ ! "${current_config_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+        || [[ "${current_state_sha}" != "${previous_sha}" ]];
+    }
+  then
+    fail "current runtime config state is invalid"
+  fi
+  if [[ -e "${RUNTIME_CONFIG_STATE}" || -L "${RUNTIME_CONFIG_STATE}" ]]; then
+    validate_state_file
+  fi
+
+  if [[ "${current_config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    && [[ "${current_config_digest}" != "${ZERO_DIGEST}" ]]
+  then
+    current_release="$(release_dir_for_digest "${current_config_digest}")"
+    current_compose_file="${current_release}/compose.yaml"
+  else
+    current_release=
+    require_legacy_compose
+    current_compose_file="${LEGACY_COMPOSE_FILE}"
+  fi
+
+  if [[ -n "${current_release}" ]]; then
+    expected_current_target="releases/${current_config_digest#sha256:}"
+    if [[ ! -L "${RUNTIME_CONFIG_CURRENT}" ]] \
+      || [[ "$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")" != "${expected_current_target}" ]]
+    then
+      fail "current runtime config pointer does not match verified state"
+    fi
+    if [[ ! "${current_config_revision}" =~ ^[0-9a-f]{40}$ ]] \
+      || [[ ! "${current_config_content_sha}" =~ ^[0-9a-f]{64}$ ]]
+    then
+      fail "current runtime config state is invalid"
+    fi
+    if [[ ! -d "${current_release}" ]]; then
+      fail "current runtime config release is missing"
+    fi
+    validate_release_files "${current_release}"
+    if [[ "$(runtime_config_content_sha256 "${current_release}")" != "${current_config_content_sha}" ]]; then
+      fail "current runtime config release integrity check failed"
+    fi
+  fi
+
+  if [[ "${config_mode}" == update ]]; then
+    candidate_config_digest="${config_digest}"
+    candidate_config_revision="${normalized_sha}"
+    prepare_runtime_release "${config_digest}" "${normalized_sha}"
+    candidate_release="${prepared_release}"
+    candidate_config_content_sha="$(
+      runtime_config_content_sha256 "${candidate_release}"
+    )"
+  else
+    if [[ -z "${current_release}" ]]; then
+      fail "keep mode requires an existing verified runtime config state"
+    fi
+    candidate_config_digest="${current_config_digest}"
+    candidate_config_revision="${current_config_revision}"
+    candidate_config_content_sha="${current_config_content_sha}"
+    candidate_release="${current_release}"
+  fi
+
+  candidate_compose_file="${candidate_release}/compose.yaml"
+fi
+
+validation_baseline_compose_file="${current_compose_file}"
+validation_baseline_api_image="${current_api_image}"
+validation_baseline_web_image="${current_web_image}"
+validate_compose_contract \
+  "${candidate_compose_file}" \
+  "${new_api_image}" \
+  "${new_web_image}"
+validation_baseline_compose_file=
+validation_baseline_api_image=
+validation_baseline_web_image=
+
+active_compose_file="${current_compose_file}"
 running_services="$(compose ps --status running --services)"
 if ! /usr/bin/grep -qx db <<<"${running_services}"; then
   if [[ -n "${previous_sha}" ]]; then
     fail "production db service must be running before an update"
   fi
 
+  active_compose_file="${candidate_compose_file}"
   data_images=()
   while IFS= read -r data_image; do
     data_images+=("${data_image}")
@@ -254,7 +1327,17 @@ if [[ -n "${previous_sha}" ]]; then
   "${BACKUP_SCRIPT}"
 fi
 
+if [[ "${legacy_mode}" == false ]]; then
+  previous_config_digest="${current_config_digest:-${ZERO_DIGEST}}"
+  write_pending_state \
+    "${previous_sha:-${ZERO_SHA}}" \
+    "${previous_config_digest}" \
+    "${normalized_sha}" \
+    "${candidate_config_digest}"
+fi
+
 write_image_env "${new_api_image}" "${new_web_image}"
+active_compose_file="${candidate_compose_file}"
 
 if compose up \
   --detach \
@@ -264,8 +1347,22 @@ if compose up \
   --wait \
   --wait-timeout "${HEALTH_TIMEOUT_SECONDS}"
 then
-  printf 'Cubing Hub deployment succeeded: %s\n' "${normalized_sha}"
-  exit 0
+  if ! deployment_service_set_is_healthy; then
+    printf 'Cubing Hub deployment did not produce a healthy service set\n' >&2
+  else
+    if [[ "${legacy_mode}" == false ]]; then
+      write_success_state \
+        "${normalized_sha}" \
+        "${candidate_config_digest}" \
+        "${candidate_config_revision}" \
+        "${candidate_config_content_sha}" \
+        "${previous_sha:-${ZERO_SHA}}" \
+        "${previous_config_digest}" \
+        "${candidate_release}"
+    fi
+    printf 'Cubing Hub deployment succeeded: %s\n' "${normalized_sha}"
+    exit 0
+  fi
 fi
 
 printf 'Cubing Hub deployment failed for commit: %s\n' "${normalized_sha}" >&2
@@ -277,6 +1374,7 @@ if [[ -n "${previous_sha}" ]]; then
 
   printf 'Rolling back application images to: %s\n' "${previous_sha}" >&2
   write_image_env "${previous_api_image}" "${previous_web_image}"
+  active_compose_file="${current_compose_file}"
 
   if compose up \
     --detach \
@@ -286,7 +1384,14 @@ if [[ -n "${previous_sha}" ]]; then
     --wait \
     --wait-timeout "${HEALTH_TIMEOUT_SECONDS}"
   then
-    printf 'Application image rollback succeeded: %s\n' "${previous_sha}" >&2
+    if ! deployment_service_set_is_healthy; then
+      printf 'Application image rollback restored an unhealthy service set\n' >&2
+    else
+      if [[ "${legacy_mode}" == false ]]; then
+        /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+      fi
+      printf 'Application image rollback succeeded: %s\n' "${previous_sha}" >&2
+    fi
   else
     printf 'Application image rollback failed: %s\n' "${previous_sha}" >&2
     compose logs --tail 100 api web >&2 || true
@@ -294,7 +1399,14 @@ if [[ -n "${previous_sha}" ]]; then
 else
   printf 'No previous SHA image exists; keeping data services and stopping failed app containers\n' >&2
   write_image_env "${current_api_image}" "${current_web_image}"
-  compose stop api web || true
+  active_compose_file="${current_compose_file}"
+  if compose stop api web; then
+    if [[ "${legacy_mode}" == false ]]; then
+      /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+    fi
+  else
+    printf 'Application bootstrap teardown failed; pending transaction retained\n' >&2
+  fi
 fi
 
 printf 'Database migration is not rolled back automatically\n' >&2

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -343,9 +343,12 @@ release_dir_for_digest() {
 
 validate_release_files() {
   local release_dir="$1"
+  local entries
   local unexpected
-  local files
 
+  if [[ ! -d "${release_dir}" || -L "${release_dir}" ]]; then
+    fail "runtime config release is missing or unsafe"
+  fi
   unexpected="$(
     /usr/bin/find "${release_dir}" ! -type d ! -type f -print
   )"
@@ -353,14 +356,59 @@ validate_release_files() {
     fail "runtime config contains unsupported file types"
   fi
 
-  files="$(
-    /usr/bin/find "${release_dir}" -type f -print \
+  entries="$(
+    /usr/bin/find "${release_dir}" -mindepth 1 -print \
       | /usr/bin/sed "s#^${release_dir}/##" \
       | LC_ALL=C /usr/bin/sort
   )"
-  if [[ "${files}" != $'compose.yaml\nnginx/cloudflare-edge-real-ip.conf' ]]; then
-    fail "runtime config file allowlist does not match"
+  if [[ "${entries}" == $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf' ]]; then
+    return
   fi
+  if [[ "${entries}" != $'compose.yaml\nnginx\nnginx/cloudflare-edge-real-ip.conf\nscripts\nscripts/backup-cubing-hub.sh\nscripts/deploy-cubing-hub.sh' ]]; then
+    fail "runtime config entry allowlist does not match"
+  fi
+  validate_release_scripts "${release_dir}"
+}
+
+validate_candidate_release_files() {
+  local release_dir="$1"
+
+  validate_release_files "${release_dir}"
+  if ! release_has_synced_scripts "${release_dir}"; then
+    fail "candidate runtime config must contain deploy and backup scripts"
+  fi
+}
+
+release_has_synced_scripts() {
+  local release_dir="$1"
+
+  [[ -f "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+    && [[ ! -L "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+    && [[ -f "${release_dir}/scripts/deploy-cubing-hub.sh" ]] \
+    && [[ ! -L "${release_dir}/scripts/deploy-cubing-hub.sh" ]]
+}
+
+validate_release_scripts() {
+  local release_dir="$1"
+  local script
+
+  for script in \
+    "${release_dir}/scripts/backup-cubing-hub.sh" \
+    "${release_dir}/scripts/deploy-cubing-hub.sh"
+  do
+    if [[ ! -x "${script}" ]]; then
+      fail "runtime config script is not executable"
+    fi
+    if ! "${PYTHON_BIN}" -c \
+      'import os, stat, sys; raise SystemExit(0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o700 else 1)' \
+      "${script}"
+    then
+      fail "runtime config script mode must be 700"
+    fi
+    if ! /bin/bash -n "${script}"; then
+      fail "runtime config script syntax is invalid"
+    fi
+  done
 }
 
 runtime_config_content_sha256() {
@@ -369,6 +417,12 @@ runtime_config_content_sha256() {
     /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
     /usr/bin/shasum -a 256 \
       "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if release_has_synced_scripts "${release_dir}"; then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
 }
 
@@ -775,11 +829,11 @@ prepare_runtime_release() {
   "${DOCKER_BIN}" rm "${config_container_id}" >/dev/null
   config_container_id=
 
-  validate_release_files "${release_temp}"
+  validate_candidate_release_files "${release_temp}"
   /bin/chmod -R go-rwx "${release_temp}"
 
   if [[ -d "${release_dir}" ]]; then
-    validate_release_files "${release_dir}"
+    validate_candidate_release_files "${release_dir}"
     if ! /usr/bin/diff -qr "${release_temp}" "${release_dir}" >/dev/null; then
       fail "existing runtime config release differs from exact digest artifact"
     fi
@@ -1199,6 +1253,7 @@ registry_token=
 "${DOCKER_BIN}" --config "${docker_config_dir}" pull "${new_api_image}"
 "${DOCKER_BIN}" --config "${docker_config_dir}" pull "${new_web_image}"
 
+active_backup_script="${BACKUP_SCRIPT}"
 if [[ "${legacy_mode}" == true ]]; then
   current_compose_file="${LEGACY_COMPOSE_FILE}"
   candidate_compose_file="${LEGACY_COMPOSE_FILE}"
@@ -1292,6 +1347,10 @@ else
     candidate_release="${current_release}"
   fi
 
+  if release_has_synced_scripts "${candidate_release}"; then
+    active_backup_script="${candidate_release}/scripts/backup-cubing-hub.sh"
+  fi
+
   candidate_compose_file="${candidate_release}/compose.yaml"
 fi
 
@@ -1337,7 +1396,10 @@ if ! /usr/bin/grep -qx db <<<"${running_services}"; then
 fi
 
 if [[ -n "${previous_sha}" ]]; then
-  "${BACKUP_SCRIPT}"
+  if [[ ! -x "${active_backup_script}" || -L "${active_backup_script}" ]]; then
+    fail "verified production backup script is missing or unsafe"
+  fi
+  "${active_backup_script}"
 fi
 
 if [[ "${legacy_mode}" == false ]]; then

--- a/homeserver/scripts/detect-runtime-config-change.sh
+++ b/homeserver/scripts/detect-runtime-config-change.sh
@@ -37,8 +37,11 @@ if git diff --quiet \
   "${before_sha}" \
   "${after_sha}" \
   -- \
+  .dockerignore \
   homeserver/docker-compose.yml \
   homeserver/nginx/cloudflare-edge-real-ip.conf \
+  homeserver/scripts/backup-home-server.sh \
+  homeserver/scripts/deploy-home-server.sh \
   homeserver/runtime-config.Dockerfile
 then
   printf 'keep\n'

--- a/homeserver/scripts/detect-runtime-config-change.sh
+++ b/homeserver/scripts/detect-runtime-config-change.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+
+if [[ "$#" -ne 3 ]]; then
+  printf 'Usage: detect-runtime-config-change.sh <before-sha> <after-sha> <force-sync>\n' >&2
+  exit 64
+fi
+
+before_sha="$1"
+after_sha="$2"
+force_sync="$3"
+
+if [[ ! "${before_sha}" =~ ^[0-9a-fA-F]{40}$ ]] \
+  || [[ ! "${after_sha}" =~ ^[0-9a-fA-F]{40}$ ]]
+then
+  printf 'Git revisions must contain exactly 40 hexadecimal characters\n' >&2
+  exit 64
+fi
+
+if [[ "${force_sync}" != true && "${force_sync}" != false ]]; then
+  printf 'force-sync must be true or false\n' >&2
+  exit 64
+fi
+
+if [[ "${force_sync}" == true ]] \
+  || [[ "${before_sha}" == "${ZERO_SHA}" ]] \
+  || ! git cat-file -e "${before_sha}^{commit}" 2>/dev/null
+then
+  printf 'update\n'
+  exit 0
+fi
+
+if git diff --quiet \
+  "${before_sha}" \
+  "${after_sha}" \
+  -- \
+  homeserver/docker-compose.yml \
+  homeserver/nginx/cloudflare-edge-real-ip.conf \
+  homeserver/runtime-config.Dockerfile
+then
+  printf 'keep\n'
+else
+  printf 'update\n'
+fi

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -22,7 +22,7 @@ case "${command_name}" in
     ;;
   cp)
     destination="$2"
-    /bin/mkdir -p "${destination}/nginx"
+    /bin/mkdir -p "${destination}/nginx" "${destination}/scripts"
     if [[ "${FAKE_FAIL_CP:-false}" == true ]]; then
       exit 1
     fi
@@ -30,6 +30,30 @@ case "${command_name}" in
     /bin/cp \
       "${FAKE_RUNTIME_REAL_IP}" \
       "${destination}/nginx/cloudflare-edge-real-ip.conf"
+    /bin/cp \
+      "${FAKE_RUNTIME_BACKUP_SCRIPT}" \
+      "${destination}/scripts/backup-cubing-hub.sh"
+    /bin/cp \
+      "${FAKE_RUNTIME_DEPLOY_SCRIPT}" \
+      "${destination}/scripts/deploy-cubing-hub.sh"
+    /bin/chmod 700 \
+      "${destination}/scripts/backup-cubing-hub.sh" \
+      "${destination}/scripts/deploy-cubing-hub.sh"
+    if [[ "${FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX:-false}" == true ]]; then
+      printf '\nif\n' >>"${destination}/scripts/deploy-cubing-hub.sh"
+    fi
+    if [[ "${FAKE_RUNTIME_INSECURE_SCRIPT_MODE:-false}" == true ]]; then
+      /bin/chmod 755 "${destination}/scripts/backup-cubing-hub.sh"
+    fi
+    if [[ "${FAKE_RUNTIME_EXTRA_FILE:-false}" == true ]]; then
+      printf 'unexpected\n' >"${destination}/unexpected"
+    fi
+    if [[ "${FAKE_RUNTIME_EXTRA_DIR:-false}" == true ]]; then
+      /bin/mkdir "${destination}/unexpected-directory"
+    fi
+    if [[ "${FAKE_RUNTIME_SYMLINK:-false}" == true ]]; then
+      /bin/ln -s compose.yaml "${destination}/unexpected-link"
+    fi
     ;;
   image)
     test "$1" = inspect
@@ -54,7 +78,7 @@ case "${command_name}" in
           ;;
       esac
     elif [[ "${format}" == *io.chochiho.runtime-config.project* ]]; then
-      printf 'cubing-hub\n'
+      printf '%s\n' "${FAKE_CONFIG_PROJECT:-cubing-hub}"
     else
       exit 1
     fi

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+if [[ "${1:-}" == --config ]]; then
+  shift 2
+fi
+
+command_name="${1:-}"
+shift || true
+
+if [[ -n "${FAKE_DOCKER_LOG:-}" ]]; then
+  printf '%s %s\n' "${command_name}" "$*" >>"${FAKE_DOCKER_LOG}"
+fi
+
+case "${command_name}" in
+  login|logout|pull|rm)
+    exit 0
+    ;;
+  create)
+    printf 'mock-runtime-config-container\n'
+    ;;
+  cp)
+    destination="$2"
+    /bin/mkdir -p "${destination}/nginx"
+    if [[ "${FAKE_FAIL_CP:-false}" == true ]]; then
+      exit 1
+    fi
+    /bin/cp "${FAKE_RUNTIME_COMPOSE}" "${destination}/compose.yaml"
+    /bin/cp \
+      "${FAKE_RUNTIME_REAL_IP}" \
+      "${destination}/nginx/cloudflare-edge-real-ip.conf"
+    ;;
+  image)
+    test "$1" = inspect
+    shift
+    test "$1" = --format
+    shift
+    format="$1"
+    image="$2"
+    if [[ "${format}" == *org.opencontainers.image.revision* ]]; then
+      case "${image}" in
+        *cubing-hub-runtime-config*)
+          printf '%s\n' "${FAKE_CONFIG_REVISION}"
+          ;;
+        *"${FAKE_REVISION_ONE}"*)
+          printf '%s\n' "${FAKE_REVISION_ONE}"
+          ;;
+        *"${FAKE_REVISION_TWO}"*)
+          printf '%s\n' "${FAKE_REVISION_TWO}"
+          ;;
+        *)
+          printf '%s\n' "${FAKE_REVISION_THREE}"
+          ;;
+      esac
+    elif [[ "${format}" == *io.chochiho.runtime-config.project* ]]; then
+      printf 'cubing-hub\n'
+    else
+      exit 1
+    fi
+    ;;
+  compose)
+    arguments=" $* "
+    if [[ "${arguments}" == *" up "* ]] \
+      && [[ -n "${FAKE_FAIL_APP_UP_ONCE_FILE:-}" ]] \
+      && [[ ! -e "${FAKE_FAIL_APP_UP_ONCE_FILE}" ]]
+    then
+      : >"${FAKE_FAIL_APP_UP_ONCE_FILE}"
+      exit 1
+    elif [[ "${arguments}" == *" ps --format json "* ]]; then
+      service_health="${FAKE_SERVICE_HEALTH:-healthy}"
+      api_health="${FAKE_API_HEALTH:-}"
+      printf \
+        '[{"Service":"db","State":"running","Health":"%s"},{"Service":"redis","State":"running","Health":"%s"},{"Service":"api","State":"running","Health":"%s"},{"Service":"web","State":"running","Health":"%s"}]\n' \
+        "${service_health}" \
+        "${service_health}" \
+        "${api_health}" \
+        "${service_health}"
+    elif [[ "${arguments}" == *" --format json "* ]]; then
+      compose_file=
+      previous_argument=
+      for argument in "$@"; do
+        if [[ "${previous_argument}" == --file ]]; then
+          compose_file="${argument}"
+          break
+        fi
+        previous_argument="${argument}"
+      done
+      if [[ "${compose_file}" == "-" ]]; then
+        /bin/cat >/dev/null
+        printf \
+          '{"services":{"probe":{"environment":{"CORS_ALLOWED_ORIGINS":"https://cubing-hub.com,https://www.cubing-hub.com","DB_NAME":"cubing_hub","DB_USERNAME":"cubing_hub","DB_PASSWORD":"change-me","FEEDBACK_DISCORD_WEBHOOK_URL":"","JWT_EXPIRATION":"1800000","JWT_REFRESH_EXPIRATION":"604800000","JWT_SECRET":"change-me","MYSQL_ROOT_PASSWORD":"change-me","POST_IMAGES_HOST_DIR":"/Users/homeserver/Server/data/cubing-hub/post-images","POST_IMAGES_KEY_PREFIX":"community/posts","POST_IMAGES_PUBLIC_BASE_URL":"https://api.cubing-hub.com/uploads","RANKING_REDIS_REBUILD_MODE":"disabled","SMTP_AUTH":"true","SMTP_FROM_ADDRESS":"","SMTP_HOST":"%s","SMTP_PASSWORD":"%s","SMTP_PORT":"587","SMTP_STARTTLS_ENABLE":"true","SMTP_USERNAME":""}}}}\n' \
+          "${FAKE_RESOLVED_SMTP_HOST-smtp.gmail.com}" \
+          "${FAKE_RESOLVED_SMTP_PASSWORD:-}"
+        exit 0
+      fi
+      api_image="${FAKE_RENDER_API_IMAGE:-${API_IMAGE}}"
+      web_image="${FAKE_RENDER_WEB_IMAGE:-${WEB_IMAGE}}"
+      db_image="${FAKE_RENDER_DB_IMAGE:-mysql:8.0.46}"
+      redis_image="${FAKE_RENDER_REDIS_IMAGE:-redis:7.2.14-alpine}"
+      real_ip_source="$(
+        /usr/bin/dirname "${compose_file}"
+      )/nginx/cloudflare-edge-real-ip.conf"
+      real_ip_source="${FAKE_RENDER_REAL_IP_SOURCE:-${real_ip_source}}"
+      upload_source="${FAKE_RENDER_UPLOAD_SOURCE:-/Users/homeserver/Server/data/cubing-hub/post-images}"
+      database_name="${FAKE_RENDER_DATABASE_NAME:-cubing_hub}"
+      database_user="${FAKE_RENDER_DATABASE_USER:-cubing_hub}"
+      database_password="${FAKE_RENDER_DATABASE_PASSWORD:-change-me}"
+      database_root_password="${FAKE_RENDER_DATABASE_ROOT_PASSWORD:-change-me}"
+      api_database_user="${FAKE_RENDER_API_DATABASE_USER:-${database_user}}"
+      api_database_password="${FAKE_RENDER_API_DATABASE_PASSWORD:-${database_password}}"
+      ddl_auto="${FAKE_RENDER_DDL_AUTO:-validate}"
+      flyway_environment=
+      if [[ -n "${FAKE_RENDER_FLYWAY_ENABLED:-}" ]]; then
+        flyway_environment=',"SPRING_FLYWAY_ENABLED":"'"${FAKE_RENDER_FLYWAY_ENABLED}"'"'
+      fi
+      datasource_url="${FAKE_RENDER_DATASOURCE_URL:-jdbc:mysql://db:3306/${database_name}?sslMode=DISABLED&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}"
+      mysql_command_json="${FAKE_RENDER_MYSQL_COMMAND_JSON:-[\"--character-set-server=utf8mb4\",\"--collation-server=utf8mb4_0900_ai_ci\"]}"
+      db_entrypoint_json="${FAKE_RENDER_DB_ENTRYPOINT_JSON:-null}"
+      upload_root="${FAKE_RENDER_UPLOAD_ROOT:-/data/post-images}"
+      api_extra_volume="${FAKE_RENDER_API_EXTRA_VOLUME:-}"
+      api_extra_hosts_json="${FAKE_RENDER_API_EXTRA_HOSTS_JSON:-null}"
+      api_application_attachment="${FAKE_RENDER_API_APPLICATION_ATTACHMENT_JSON:-null}"
+      redis_command_json="${FAKE_RENDER_REDIS_COMMAND_JSON:-[\"redis-server\",\"--appendonly\",\"yes\",\"--appendfsync\",\"everysec\"]}"
+      jwt_secret="${FAKE_RENDER_JWT_SECRET:-change-me}"
+      smtp_host="${FAKE_RENDER_SMTP_HOST-smtp.gmail.com}"
+      smtp_password="${FAKE_RENDER_SMTP_PASSWORD:-}"
+      api_extra_environment="${FAKE_RENDER_API_EXTRA_ENVIRONMENT:-}"
+      api_configs_json="${FAKE_RENDER_API_CONFIGS_JSON:-null}"
+      api_secrets_json="${FAKE_RENDER_API_SECRETS_JSON:-null}"
+      api_env_file_json="${FAKE_RENDER_API_ENV_FILE_JSON:-null}"
+      api_command_json="${FAKE_RENDER_API_COMMAND_JSON:-null}"
+      api_entrypoint_json="${FAKE_RENDER_API_ENTRYPOINT_JSON:-null}"
+      application_json='{"name":"cubing-hub_application","ipam":{},"internal":true}'
+      application_json="${FAKE_RENDER_APPLICATION_JSON:-${application_json}}"
+      outbound_json='{"name":"cubing-hub_outbound","driver":"bridge","ipam":{}}'
+      outbound_json="${FAKE_RENDER_OUTBOUND_JSON:-${outbound_json}}"
+      edge_json='{"name":"edge","external":true,"ipam":{}}'
+      edge_json="${FAKE_RENDER_EDGE_JSON:-${edge_json}}"
+      mysql_volume_extra="${FAKE_RENDER_MYSQL_VOLUME_EXTRA:-}"
+      edge_alias="${FAKE_RENDER_EDGE_ALIAS:-cubing-hub-web}"
+      db_healthcheck='{"test":["CMD-SHELL","mysqladmin ping -h 127.0.0.1 -u root --password=\"$${MYSQL_ROOT_PASSWORD}\" --silent"],"interval":"10s","timeout":"5s","retries":12,"start_period":"30s"}'
+      db_healthcheck="${FAKE_RENDER_DB_HEALTHCHECK_JSON:-${db_healthcheck}}"
+      redis_healthcheck='{"test":["CMD","redis-cli","ping"],"interval":"10s","timeout":"5s","retries":12,"start_period":"10s"}'
+      redis_healthcheck="${FAKE_RENDER_REDIS_HEALTHCHECK_JSON:-${redis_healthcheck}}"
+      web_healthcheck='{"test":["CMD-SHELL","wget --header='\''Host: api.cubing-hub.com'\'' -qO- http://127.0.0.1/actuator/health | grep -q '\''\"status\":\"UP\"'\''"],"interval":"10s","timeout":"5s","retries":12,"start_period":"40s"}'
+      web_healthcheck="${FAKE_RENDER_WEB_HEALTHCHECK_JSON:-${web_healthcheck}}"
+      if [[ "${FAKE_DISABLE_WEB_HEALTHCHECK:-false}" == true ]]; then
+        web_healthcheck='{"disable":true}'
+      fi
+      web_profiles='[]'
+      if [[ "${FAKE_RENDER_WEB_PROFILE:-false}" == true ]]; then
+        web_profiles='["optional"]'
+      fi
+      web_restart="${FAKE_RENDER_RESTART_POLICY:-unless-stopped}"
+      web_scale="${FAKE_RENDER_WEB_SCALE:-1}"
+      web_command_json="${FAKE_RENDER_WEB_COMMAND_JSON:-null}"
+      web_entrypoint_json="${FAKE_RENDER_WEB_ENTRYPOINT_JSON:-null}"
+      api_privileged=false
+      api_ports_json=null
+      api_pid_json=null
+      if [[ -n "${FAKE_VALIDATION_TARGET_API_IMAGE:-}" ]] \
+        && [[ "${API_IMAGE:-}" == "${FAKE_VALIDATION_TARGET_API_IMAGE}" ]]
+      then
+        api_image="${FAKE_CANDIDATE_API_IMAGE:-${api_image}}"
+        database_name="${FAKE_CANDIDATE_DATABASE_NAME:-${database_name}}"
+        db_image="${FAKE_CANDIDATE_DB_IMAGE:-${db_image}}"
+        upload_source="${FAKE_CANDIDATE_UPLOAD_SOURCE:-${upload_source}}"
+        real_ip_source="${FAKE_CANDIDATE_REAL_IP_SOURCE:-${real_ip_source}}"
+        api_extra_volume="${FAKE_CANDIDATE_API_EXTRA_VOLUME:-${api_extra_volume}}"
+        api_extra_hosts_json="${FAKE_CANDIDATE_API_EXTRA_HOSTS_JSON:-${api_extra_hosts_json}}"
+        api_extra_environment="${FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT:-${api_extra_environment}}"
+        api_configs_json="${FAKE_CANDIDATE_API_CONFIGS_JSON:-${api_configs_json}}"
+        api_secrets_json="${FAKE_CANDIDATE_API_SECRETS_JSON:-${api_secrets_json}}"
+        api_env_file_json="${FAKE_CANDIDATE_API_ENV_FILE_JSON:-${api_env_file_json}}"
+        api_command_json="${FAKE_CANDIDATE_API_COMMAND_JSON:-${api_command_json}}"
+        api_entrypoint_json="${FAKE_CANDIDATE_API_ENTRYPOINT_JSON:-${api_entrypoint_json}}"
+        application_json="${FAKE_CANDIDATE_APPLICATION_JSON:-${application_json}}"
+        outbound_json="${FAKE_CANDIDATE_OUTBOUND_JSON:-${outbound_json}}"
+        edge_json="${FAKE_CANDIDATE_EDGE_JSON:-${edge_json}}"
+        mysql_volume_extra="${FAKE_CANDIDATE_MYSQL_VOLUME_EXTRA:-${mysql_volume_extra}}"
+        web_restart="${FAKE_CANDIDATE_WEB_RESTART:-${web_restart}}"
+        web_command_json="${FAKE_CANDIDATE_WEB_COMMAND_JSON:-${web_command_json}}"
+        web_entrypoint_json="${FAKE_CANDIDATE_WEB_ENTRYPOINT_JSON:-${web_entrypoint_json}}"
+        db_healthcheck="${FAKE_CANDIDATE_DB_HEALTHCHECK_JSON:-${db_healthcheck}}"
+        redis_healthcheck="${FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON:-${redis_healthcheck}}"
+        web_healthcheck="${FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON:-${web_healthcheck}}"
+        api_privileged="${FAKE_CANDIDATE_API_PRIVILEGED:-${api_privileged}}"
+        api_ports_json="${FAKE_CANDIDATE_API_PORTS_JSON:-${api_ports_json}}"
+        api_pid_json="${FAKE_CANDIDATE_API_PID_JSON:-${api_pid_json}}"
+        mysql_command_json="${FAKE_CANDIDATE_MYSQL_COMMAND_JSON:-${mysql_command_json}}"
+        db_entrypoint_json="${FAKE_CANDIDATE_DB_ENTRYPOINT_JSON:-${db_entrypoint_json}}"
+        redis_command_json="${FAKE_CANDIDATE_REDIS_COMMAND_JSON:-${redis_command_json}}"
+        ddl_auto="${FAKE_CANDIDATE_DDL_AUTO:-${ddl_auto}}"
+      fi
+      printf \
+        '{"name":"cubing-hub","services":{"db":{"image":"%s","restart":"unless-stopped","entrypoint":%s,"environment":{"MYSQL_DATABASE":"%s","MYSQL_USER":"%s","MYSQL_PASSWORD":"%s","MYSQL_ROOT_PASSWORD":"%s"},"command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"mysql-data","target":"/var/lib/mysql","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"redis":{"image":"%s","restart":"unless-stopped","command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"redis-data","target":"/data","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"api":{"image":"%s","command":%s,"entrypoint":%s,"privileged":%s,"ports":%s,"pid":%s,"restart":"unless-stopped","init":true,"read_only":true,"pids_limit":256,"security_opt":["no-new-privileges:true"],"tmpfs":["/tmp:size=128m,mode=1777"],"extra_hosts":%s,"configs":%s,"secrets":%s,"env_file":%s,"environment":{"SPRING_PROFILES_ACTIVE":"prod","SPRING_DATASOURCE_URL":"%s","DB_USERNAME":"%s","DB_PASSWORD":"%s","REDIS_HOST":"redis","REDIS_PORT":"6379","JWT_SECRET":"%s","JWT_EXPIRATION":"1800000","JWT_REFRESH_EXPIRATION":"604800000","CORS_ALLOWED_ORIGINS":"https://cubing-hub.com,https://www.cubing-hub.com","SPRING_JPA_HIBERNATE_DDL_AUTO":"%s"%s,"AUTH_REFRESH_COOKIE_SECURE":"true","SMTP_HOST":"%s","SMTP_PORT":"587","SMTP_USERNAME":"","SMTP_PASSWORD":"%s","SMTP_AUTH":"true","SMTP_STARTTLS_ENABLE":"true","SMTP_FROM_ADDRESS":"","FEEDBACK_DISCORD_WEBHOOK_URL":"","RANKING_REDIS_REBUILD_MODE":"disabled","MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE":"health","MONITORING_PROMETHEUS_PERMIT_ALL":"false","POST_IMAGES_LOCAL_ROOT_PATH":"%s","POST_IMAGES_KEY_PREFIX":"community/posts","POST_IMAGES_PUBLIC_BASE_URL":"https://api.cubing-hub.com/uploads"%s},"networks":{"application":%s,"outbound":null},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}%s],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"web":{"image":"%s","command":%s,"entrypoint":%s,"restart":"%s","init":true,"read_only":true,"pids_limit":100,"security_opt":["no-new-privileges:true"],"tmpfs":["/var/cache/nginx:size=32m,mode=0755","/var/run:size=4m,mode=0755","/tmp:size=16m,mode=1777"],"scale":%s,"profiles":%s,"healthcheck":%s,"networks":{"application":null,"edge":{"aliases":["%s"]}},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images","read_only":true},{"type":"bind","source":"%s","target":"/etc/nginx/conf.d/00-cloudflare-real-ip.conf","read_only":true}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}}},"networks":{"application":%s,"outbound":%s,"edge":%s},"volumes":{"mysql-data":{"name":"cubing-hub_mysql-data"%s},"redis-data":{"name":"cubing-hub_redis-data"}}}\n' \
+        "${db_image}" \
+        "${db_entrypoint_json}" \
+        "${database_name}" \
+        "${database_user}" \
+        "${database_password}" \
+        "${database_root_password}" \
+        "${mysql_command_json}" \
+        "${db_healthcheck}" \
+        "${redis_image}" \
+        "${redis_command_json}" \
+        "${redis_healthcheck}" \
+        "${api_image}" \
+        "${api_command_json}" \
+        "${api_entrypoint_json}" \
+        "${api_privileged}" \
+        "${api_ports_json}" \
+        "${api_pid_json}" \
+        "${api_extra_hosts_json}" \
+        "${api_configs_json}" \
+        "${api_secrets_json}" \
+        "${api_env_file_json}" \
+        "${datasource_url}" \
+        "${api_database_user}" \
+        "${api_database_password}" \
+        "${jwt_secret}" \
+        "${ddl_auto}" \
+        "${flyway_environment}" \
+        "${smtp_host}" \
+        "${smtp_password}" \
+        "${upload_root}" \
+        "${api_extra_environment}" \
+        "${api_application_attachment}" \
+        "${upload_source}" \
+        "${api_extra_volume}" \
+        "${web_image}" \
+        "${web_command_json}" \
+        "${web_entrypoint_json}" \
+        "${web_restart}" \
+        "${web_scale}" \
+        "${web_profiles}" \
+        "${web_healthcheck}" \
+        "${edge_alias}" \
+        "${upload_source}" \
+        "${real_ip_source}" \
+        "${application_json}" \
+        "${outbound_json}" \
+        "${edge_json}" \
+        "${mysql_volume_extra}"
+    elif [[ "${arguments}" == *" ps --status running --services "* ]]; then
+      printf 'db\nredis\napi\nweb\n'
+    fi
+    ;;
+  *)
+    printf 'Unexpected mock Docker command: %s\n' "${command_name}" >&2
+    exit 1
+    ;;
+esac

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -131,6 +131,8 @@ case "${command_name}" in
       api_env_file_json="${FAKE_RENDER_API_ENV_FILE_JSON:-null}"
       api_command_json="${FAKE_RENDER_API_COMMAND_JSON:-null}"
       api_entrypoint_json="${FAKE_RENDER_API_ENTRYPOINT_JSON:-null}"
+      api_user_json=null
+      api_tmpfs_json='["/tmp:size=128m,mode=1777"]'
       application_json='{"name":"cubing-hub_application","ipam":{},"internal":true}'
       application_json="${FAKE_RENDER_APPLICATION_JSON:-${application_json}}"
       outbound_json='{"name":"cubing-hub_outbound","driver":"bridge","ipam":{}}'
@@ -175,6 +177,8 @@ case "${command_name}" in
         api_env_file_json="${FAKE_CANDIDATE_API_ENV_FILE_JSON:-${api_env_file_json}}"
         api_command_json="${FAKE_CANDIDATE_API_COMMAND_JSON:-${api_command_json}}"
         api_entrypoint_json="${FAKE_CANDIDATE_API_ENTRYPOINT_JSON:-${api_entrypoint_json}}"
+        api_user_json="${FAKE_CANDIDATE_API_USER_JSON:-${api_user_json}}"
+        api_tmpfs_json="${FAKE_CANDIDATE_API_TMPFS_JSON:-${api_tmpfs_json}}"
         application_json="${FAKE_CANDIDATE_APPLICATION_JSON:-${application_json}}"
         outbound_json="${FAKE_CANDIDATE_OUTBOUND_JSON:-${outbound_json}}"
         edge_json="${FAKE_CANDIDATE_EDGE_JSON:-${edge_json}}"
@@ -194,7 +198,7 @@ case "${command_name}" in
         ddl_auto="${FAKE_CANDIDATE_DDL_AUTO:-${ddl_auto}}"
       fi
       printf \
-        '{"name":"cubing-hub","services":{"db":{"image":"%s","restart":"unless-stopped","entrypoint":%s,"environment":{"MYSQL_DATABASE":"%s","MYSQL_USER":"%s","MYSQL_PASSWORD":"%s","MYSQL_ROOT_PASSWORD":"%s"},"command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"mysql-data","target":"/var/lib/mysql","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"redis":{"image":"%s","restart":"unless-stopped","command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"redis-data","target":"/data","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"api":{"image":"%s","command":%s,"entrypoint":%s,"privileged":%s,"ports":%s,"pid":%s,"restart":"unless-stopped","init":true,"read_only":true,"pids_limit":256,"security_opt":["no-new-privileges:true"],"tmpfs":["/tmp:size=128m,mode=1777"],"extra_hosts":%s,"configs":%s,"secrets":%s,"env_file":%s,"environment":{"SPRING_PROFILES_ACTIVE":"prod","SPRING_DATASOURCE_URL":"%s","DB_USERNAME":"%s","DB_PASSWORD":"%s","REDIS_HOST":"redis","REDIS_PORT":"6379","JWT_SECRET":"%s","JWT_EXPIRATION":"1800000","JWT_REFRESH_EXPIRATION":"604800000","CORS_ALLOWED_ORIGINS":"https://cubing-hub.com,https://www.cubing-hub.com","SPRING_JPA_HIBERNATE_DDL_AUTO":"%s"%s,"AUTH_REFRESH_COOKIE_SECURE":"true","SMTP_HOST":"%s","SMTP_PORT":"587","SMTP_USERNAME":"","SMTP_PASSWORD":"%s","SMTP_AUTH":"true","SMTP_STARTTLS_ENABLE":"true","SMTP_FROM_ADDRESS":"","FEEDBACK_DISCORD_WEBHOOK_URL":"","RANKING_REDIS_REBUILD_MODE":"disabled","MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE":"health","MONITORING_PROMETHEUS_PERMIT_ALL":"false","POST_IMAGES_LOCAL_ROOT_PATH":"%s","POST_IMAGES_KEY_PREFIX":"community/posts","POST_IMAGES_PUBLIC_BASE_URL":"https://api.cubing-hub.com/uploads"%s},"networks":{"application":%s,"outbound":null},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}%s],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"web":{"image":"%s","command":%s,"entrypoint":%s,"restart":"%s","init":true,"read_only":true,"pids_limit":100,"security_opt":["no-new-privileges:true"],"tmpfs":["/var/cache/nginx:size=32m,mode=0755","/var/run:size=4m,mode=0755","/tmp:size=16m,mode=1777"],"scale":%s,"profiles":%s,"healthcheck":%s,"networks":{"application":null,"edge":{"aliases":["%s"]}},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images","read_only":true},{"type":"bind","source":"%s","target":"/etc/nginx/conf.d/00-cloudflare-real-ip.conf","read_only":true}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}}},"networks":{"application":%s,"outbound":%s,"edge":%s},"volumes":{"mysql-data":{"name":"cubing-hub_mysql-data"%s},"redis-data":{"name":"cubing-hub_redis-data"}}}\n' \
+        '{"name":"cubing-hub","services":{"db":{"image":"%s","restart":"unless-stopped","entrypoint":%s,"environment":{"MYSQL_DATABASE":"%s","MYSQL_USER":"%s","MYSQL_PASSWORD":"%s","MYSQL_ROOT_PASSWORD":"%s"},"command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"mysql-data","target":"/var/lib/mysql","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"redis":{"image":"%s","restart":"unless-stopped","command":%s,"healthcheck":%s,"networks":{"application":null},"volumes":[{"type":"volume","source":"redis-data","target":"/data","volume":{}}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"api":{"image":"%s","command":%s,"entrypoint":%s,"user":%s,"privileged":%s,"ports":%s,"pid":%s,"restart":"unless-stopped","init":true,"read_only":true,"pids_limit":256,"security_opt":["no-new-privileges:true"],"tmpfs":%s,"extra_hosts":%s,"configs":%s,"secrets":%s,"env_file":%s,"environment":{"SPRING_PROFILES_ACTIVE":"prod","SPRING_DATASOURCE_URL":"%s","DB_USERNAME":"%s","DB_PASSWORD":"%s","REDIS_HOST":"redis","REDIS_PORT":"6379","JWT_SECRET":"%s","JWT_EXPIRATION":"1800000","JWT_REFRESH_EXPIRATION":"604800000","CORS_ALLOWED_ORIGINS":"https://cubing-hub.com,https://www.cubing-hub.com","SPRING_JPA_HIBERNATE_DDL_AUTO":"%s"%s,"AUTH_REFRESH_COOKIE_SECURE":"true","SMTP_HOST":"%s","SMTP_PORT":"587","SMTP_USERNAME":"","SMTP_PASSWORD":"%s","SMTP_AUTH":"true","SMTP_STARTTLS_ENABLE":"true","SMTP_FROM_ADDRESS":"","FEEDBACK_DISCORD_WEBHOOK_URL":"","RANKING_REDIS_REBUILD_MODE":"disabled","MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE":"health","MONITORING_PROMETHEUS_PERMIT_ALL":"false","POST_IMAGES_LOCAL_ROOT_PATH":"%s","POST_IMAGES_KEY_PREFIX":"community/posts","POST_IMAGES_PUBLIC_BASE_URL":"https://api.cubing-hub.com/uploads"%s},"networks":{"application":%s,"outbound":null},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}%s],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}},"web":{"image":"%s","command":%s,"entrypoint":%s,"restart":"%s","init":true,"read_only":true,"pids_limit":100,"security_opt":["no-new-privileges:true"],"tmpfs":["/var/cache/nginx:size=32m,mode=0755","/var/run:size=4m,mode=0755","/tmp:size=16m,mode=1777"],"scale":%s,"profiles":%s,"healthcheck":%s,"networks":{"application":null,"edge":{"aliases":["%s"]}},"volumes":[{"type":"bind","source":"%s","target":"/data/post-images","read_only":true},{"type":"bind","source":"%s","target":"/etc/nginx/conf.d/00-cloudflare-real-ip.conf","read_only":true}],"logging":{"driver":"json-file","options":{"max-size":"10m","max-file":"3"}}}},"networks":{"application":%s,"outbound":%s,"edge":%s},"volumes":{"mysql-data":{"name":"cubing-hub_mysql-data"%s},"redis-data":{"name":"cubing-hub_redis-data"}}}\n' \
         "${db_image}" \
         "${db_entrypoint_json}" \
         "${database_name}" \
@@ -209,9 +213,11 @@ case "${command_name}" in
         "${api_image}" \
         "${api_command_json}" \
         "${api_entrypoint_json}" \
+        "${api_user_json}" \
         "${api_privileged}" \
         "${api_ports_json}" \
         "${api_pid_json}" \
+        "${api_tmpfs_json}" \
         "${api_extra_hosts_json}" \
         "${api_configs_json}" \
         "${api_secrets_json}" \

--- a/homeserver/scripts/fixtures/mock-cubing-hub-lockf.py
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-lockf.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+
+import fcntl
+import sys
+
+
+if sys.argv[1:] != ["-s", "-t", "0", "9"]:
+    raise SystemExit(64)
+
+try:
+    fcntl.flock(9, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    raise SystemExit(75)

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -226,15 +226,15 @@ test("should_validateOnlyProtectedRuntimeInvariants_when_composeChanges", () => 
   }
   assert.match(
     deployScript,
-    /db healthcheck must retain mysqladmin ping against loopback/,
+    /healthcheck test differs from the active verified configuration/,
   );
   assert.match(
     deployScript,
-    /redis healthcheck must retain redis-cli ping/,
+    /user differs from the active verified configuration/,
   );
   assert.match(
     deployScript,
-    /web healthcheck must retain loopback API readiness, status UP, and Host semantics/,
+    /tmpfs target set differs from the active verified configuration/,
   );
   assert.equal(deployScript.match(/--no-env-resolution/g)?.length, 1);
   assert.doesNotMatch(deployScript, /RUNTIME_CONFIG_VALIDATION_ROLE/);

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -9,6 +9,7 @@ const [
   deployScript,
   restrictedWrapper,
   backupScript,
+  backupBootstrap,
   frontendDockerfile,
   launchAgent,
   dockerIgnore,
@@ -22,6 +23,7 @@ const [
   read("./deploy-home-server.sh"),
   read("./deploy-home-server-ci.sh"),
   read("./backup-home-server.sh"),
+  read("./backup-home-server-bootstrap.sh"),
   read("../docker/frontend.Dockerfile"),
   read("../launchd/com.cubinghub-backup.plist.example"),
   read("../../.dockerignore"),
@@ -113,8 +115,9 @@ test("should_documentPinnedSystemPython_when_operationsScriptsRequireIt", () => 
   assert.match(deployScript, /readonly PYTHON_BIN=\/usr\/bin\/python3/);
   assert.match(backupScript, /readonly PYTHON_BIN=\/usr\/bin\/python3/);
   assert.match(setupGuide, /test -x \/usr\/bin\/python3/);
+  assert.match(setupGuide, /test -x \/usr\/bin\/lockf/);
   assert.match(setupGuide, /\/usr\/bin\/python3 --version/);
-  assert.match(setupGuide, /Homebrew Python이나 임의 PATH로 대체하지/);
+  assert.match(setupGuide, /Homebrew 도구나 임의[\s\S]*PATH로 대체하지/);
 });
 
 test("should_bootstrapEmptyDataServicesAndBackupOnlyBeforeUpdates", () => {
@@ -133,7 +136,7 @@ test("should_bootstrapEmptyDataServicesAndBackupOnlyBeforeUpdates", () => {
   );
   const firstDataStart = deployScript.indexOf('    db redis\n');
   const backupCondition = deployScript.indexOf(
-    'if [[ -n "${previous_sha}" ]]; then\n  "${BACKUP_SCRIPT}"',
+    'if [[ -n "${previous_sha}" ]]; then\n  if [[ ! -x "${active_backup_script}"',
   );
   const imageWrite = deployScript.indexOf(
     'write_image_env "${new_api_image}" "${new_web_image}"',
@@ -266,15 +269,82 @@ test("should_validateOnlyProtectedRuntimeInvariants_when_composeChanges", () => 
 test("should_packageOnlyAllowlistedRuntimeConfigFiles_when_configChanges", () => {
   assert.match(
     runtimeConfigDockerfile,
-    /FROM scratch[\s\S]*COPY homeserver\/docker-compose\.yml \/runtime\/compose\.yaml[\s\S]*COPY homeserver\/nginx\/cloudflare-edge-real-ip\.conf/,
+    /FROM scratch[\s\S]*COPY homeserver\/docker-compose\.yml \/runtime\/compose\.yaml[\s\S]*COPY homeserver\/nginx\/cloudflare-edge-real-ip\.conf[\s\S]*COPY --chmod=0700 homeserver\/scripts\/deploy-home-server\.sh \/runtime\/scripts\/deploy-cubing-hub\.sh[\s\S]*COPY --chmod=0700 homeserver\/scripts\/backup-home-server\.sh \/runtime\/scripts\/backup-cubing-hub\.sh/,
   );
+  assert.doesNotMatch(runtimeConfigDockerfile, /deploy-home-server-ci/);
   assert.match(
     runtimeConfigDetector,
-    /homeserver\/docker-compose\.yml[\s\S]*homeserver\/nginx\/cloudflare-edge-real-ip\.conf[\s\S]*homeserver\/runtime-config\.Dockerfile/,
+    /\.dockerignore[\s\S]*homeserver\/docker-compose\.yml[\s\S]*homeserver\/nginx\/cloudflare-edge-real-ip\.conf[\s\S]*homeserver\/scripts\/backup-home-server\.sh[\s\S]*homeserver\/scripts\/deploy-home-server\.sh[\s\S]*homeserver\/runtime-config\.Dockerfile/,
   );
   assert.match(runtimeConfigDetector, /git diff --quiet/);
   assert.match(runtimeConfigDetector, /printf 'keep\\n'/);
   assert.match(runtimeConfigDetector, /printf 'update\\n'/);
+  assert.match(dockerIgnore, /^homeserver\/scripts\/\*$/m);
+  assert.match(
+    dockerIgnore,
+    /^!homeserver\/scripts\/deploy-home-server\.sh$/m,
+  );
+  assert.match(
+    dockerIgnore,
+    /^!homeserver\/scripts\/backup-home-server\.sh$/m,
+  );
+});
+
+test("should_executeOnlyVerifiedReleaseScripts_when_runtimeConfigChanges", () => {
+  for (const script of [deployScript, backupScript]) {
+    assert.match(
+      script,
+      /scripts\/backup-cubing-hub\.sh[\s\S]*scripts\/deploy-cubing-hub\.sh/,
+    );
+    assert.match(script, /runtime config script mode must be 700/);
+    assert.match(script, /\/bin\/bash -n "\$\{script\}"/);
+    assert.match(
+      script,
+      /runtime_config_content_sha256[\s\S]*scripts\/backup-cubing-hub\.sh[\s\S]*scripts\/deploy-cubing-hub\.sh/,
+    );
+  }
+
+  assert.match(
+    restrictedWrapper,
+    /runtime config entry allowlist does not match/,
+  );
+  assert.match(
+    restrictedWrapper,
+    /validate_release "\$\{release_temp\}" synced[\s\S]*exec "\$\{candidate_script\}"/,
+  );
+  assert.match(
+    deployScript,
+    /active_backup_script="\$\{candidate_release\}\/scripts\/backup-cubing-hub\.sh"[\s\S]*"\$\{active_backup_script\}"/,
+  );
+  assert.match(
+    backupBootstrap,
+    /readonly LEGACY_BACKUP_SCRIPT=\/Users\/homeserver\/Server\/scripts\/backup\/backup-cubing-hub\.sh/,
+  );
+  assert.match(
+    backupBootstrap,
+    /runtime config entry allowlist does not match[\s\S]*exec "\$\{release_dir\}\/scripts\/backup-cubing-hub\.sh"/,
+  );
+  for (const bootstrap of [restrictedWrapper, backupBootstrap]) {
+    assert.match(
+      bootstrap,
+      /readonly LOCKF_BIN=\/usr\/bin\/lockf/,
+    );
+    assert.match(
+      bootstrap,
+      /readonly OPERATION_LOCK="\$\{APP_DIR\}\/\.cubing-hub-operation\.lock"/,
+    );
+    assert.match(bootstrap, /"\$\{LOCKF_BIN\}" -s -t 0 9/);
+    assert.match(
+      bootstrap,
+      /Another Cubing Hub deploy or backup operation is already running/,
+    );
+  }
+  assert.equal(restrictedWrapper.match(/<&3 3<&-/g)?.length, 2);
+  assert.match(
+    backupBootstrap,
+    /RUNTIME_CONFIG_PENDING[\s\S]*an incomplete runtime config transaction requires recovery/,
+  );
+  assert.doesNotMatch(runtimeConfigDockerfile, /bootstrap|deploy-home-server-ci/);
 });
 
 test("should_validateBackupBeforeKeepingThreeSuccessfulSnapshots", () => {
@@ -339,7 +409,7 @@ test("should_excludeCredentialsAndGeneratedFilesFromDockerBuildContext", () => {
 test("should_runScheduledBackupFromRepositoryIndependentPath", () => {
   assert.match(
     launchAgent,
-    /\/Users\/homeserver\/Server\/scripts\/backup\/backup-cubing-hub\.sh/,
+    /\/Users\/homeserver\/Server\/scripts\/backup\/backup-cubing-hub-bootstrap\.sh/,
   );
   assert.doesNotMatch(launchAgent, /__REPO_DIR__|cd /);
 });

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -12,6 +12,9 @@ const [
   frontendDockerfile,
   launchAgent,
   dockerIgnore,
+  runtimeConfigDockerfile,
+  runtimeConfigDetector,
+  setupGuide,
 ] = await Promise.all([
   read("../docker-compose.yml"),
   read("../docker-compose.admin.yml"),
@@ -22,6 +25,9 @@ const [
   read("../docker/frontend.Dockerfile"),
   read("../launchd/com.cubinghub-backup.plist.example"),
   read("../../.dockerignore"),
+  read("../runtime-config.Dockerfile"),
+  read("./detect-runtime-config-change.sh"),
+  read("../docs/mac-mini-server-setup.md"),
 ]);
 
 test("should_isolateDataServicesAndGiveOnlyApiOutboundAccess_when_productionRuns", () => {
@@ -94,13 +100,21 @@ test("should_hardenApplicationContainersAndKeepSecretsExternal", () => {
 test("should_allowOnlyRestrictedDeployCommand_when_ciConnectsOverSsh", () => {
   assert.match(
     restrictedWrapper,
-    /\^deploy-cubing-hub\[\[:space:\]\]\(\[0-9a-fA-F\]\{40\}\)\[\[:space:\]\]\(\[A-Za-z0-9_-\]\+\)\$/,
+    /deploy-cubing-hub-v2[\s\S]*keep[\s\S]*deploy-cubing-hub-v2[\s\S]*update/,
   );
   assert.doesNotMatch(restrictedWrapper, /eval|bash -c|sh -c/);
   assert.match(
     restrictedWrapper,
     /\/Users\/homeserver\/Server\/scripts\/deploy\/deploy-cubing-hub\.sh/,
   );
+});
+
+test("should_documentPinnedSystemPython_when_operationsScriptsRequireIt", () => {
+  assert.match(deployScript, /readonly PYTHON_BIN=\/usr\/bin\/python3/);
+  assert.match(backupScript, /readonly PYTHON_BIN=\/usr\/bin\/python3/);
+  assert.match(setupGuide, /test -x \/usr\/bin\/python3/);
+  assert.match(setupGuide, /\/usr\/bin\/python3 --version/);
+  assert.match(setupGuide, /Homebrew Python이나 임의 PATH로 대체하지/);
 });
 
 test("should_bootstrapEmptyDataServicesAndBackupOnlyBeforeUpdates", () => {
@@ -148,10 +162,119 @@ test("should_rollbackBothImagesWithoutDeletingPersistentData", () => {
     deployScript,
     /Database migration is not rolled back automatically/,
   );
+  assert.match(
+    deployScript,
+    /active_compose_file="\$\{current_compose_file\}"/,
+  );
+  assert.match(deployScript, /RUNTIME_CONFIG_PENDING/);
+  assert.match(deployScript, /Compose project name must remain cubing-hub/);
+  assert.match(deployScript, /MySQL persistent volume contract is invalid/);
+  assert.match(deployScript, /Redis persistent volume contract is invalid/);
+  assert.match(
+    deployScript,
+    /write_pending_state[\s\S]*"\$\{previous_sha:-\$\{ZERO_SHA\}\}"/,
+  );
   assert.doesNotMatch(
     deployScript,
     /down[^\n]*(?:--volumes|-v)|volume rm|system prune/,
   );
+});
+
+test("should_validateOnlyProtectedRuntimeInvariants_when_composeChanges", () => {
+  assert.match(
+    deployScript,
+    /validation_baseline_compose_file="\$\{current_compose_file\}"/,
+  );
+  assert.match(deployScript, /--project-name "\$\{PROJECT_NAME\}"/);
+  assert.match(
+    deployScript,
+    /current runtime config pointer does not match verified state/,
+  );
+  assert.match(
+    deployScript,
+    /image changes require a separate data-service procedure/,
+  );
+  assert.match(
+    deployScript,
+    /for field in \("command", "entrypoint"\)/,
+  );
+  assert.match(
+    deployScript,
+    /API data-sensitive environment changes require a separate migration procedure/,
+  );
+  assert.match(
+    deployScript,
+    /db MYSQL environment changes require a separate data-service procedure/,
+  );
+  assert.match(deployScript, /"DB_USERNAME"/);
+  assert.match(deployScript, /"DB_PASSWORD"/);
+  assert.match(deployScript, /"REDIS_HOST"/);
+  assert.match(deployScript, /"REDIS_PORT"/);
+  assert.match(deployScript, /"RANKING_REDIS_REBUILD_MODE"/);
+  assert.match(deployScript, /"POST_IMAGES_"/);
+  assert.match(deployScript, /"SPRING_APPLICATION_JSON"/);
+  assert.match(deployScript, /"SPRING_CONFIG_"/);
+  assert.match(deployScript, /"SPRING_PROFILES_"/);
+  assert.match(deployScript, /"SPRING_SQL_INIT_"/);
+  for (const javaOption of [
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "_JAVA_OPTIONS",
+    "JAVA_OPTS",
+  ]) {
+    assert.match(deployScript, new RegExp(`"${javaOption}"`));
+  }
+  assert.match(
+    deployScript,
+    /db healthcheck must retain mysqladmin ping against loopback/,
+  );
+  assert.match(
+    deployScript,
+    /redis healthcheck must retain redis-cli ping/,
+  );
+  assert.match(
+    deployScript,
+    /web healthcheck must retain loopback API readiness, status UP, and Host semantics/,
+  );
+  assert.equal(deployScript.match(/--no-env-resolution/g)?.length, 1);
+  assert.doesNotMatch(deployScript, /RUNTIME_CONFIG_VALIDATION_ROLE/);
+  assert.doesNotMatch(deployScript, /candidate_source/);
+  assert.match(
+    deployScript,
+    /must not mount configs, secrets, or env files/,
+  );
+  assert.match(deployScript, /service\.get\("extra_hosts"\)/);
+  assert.match(deployScript, /service\.get\("external_links"\)/);
+  assert.match(deployScript, /service\.get\("links"\)/);
+  assert.match(deployScript, /must not override protected service hostnames/);
+  assert.match(deployScript, /for name in \("api", "web"\)/);
+  assert.match(deployScript, /for field in \("command", "entrypoint"\)/);
+  assert.match(deployScript, /must not override its image/);
+  assert.match(deployScript, /must not publish host ports/);
+  assert.match(deployScript, /must not receive host or Docker privileges/);
+  assert.match(deployScript, /must not share the host namespace/);
+  assert.match(deployScript, /application network must remain project-private and internal/);
+  assert.match(deployScript, /Nginx must mount the candidate release real-IP configuration/);
+  assert.match(deployScript, /deployment_service_set_is_healthy/);
+  assert.doesNotMatch(deployScript, /expected_full_api_environment/);
+  assert.doesNotMatch(deployScript, /expected_healthchecks/);
+  assert.doesNotMatch(deployScript, /expected_hardening/);
+  assert.doesNotMatch(deployScript, /restart policy must remain/);
+  assert.doesNotMatch(deployScript, /logging rotation contract/);
+});
+
+test("should_packageOnlyAllowlistedRuntimeConfigFiles_when_configChanges", () => {
+  assert.match(
+    runtimeConfigDockerfile,
+    /FROM scratch[\s\S]*COPY homeserver\/docker-compose\.yml \/runtime\/compose\.yaml[\s\S]*COPY homeserver\/nginx\/cloudflare-edge-real-ip\.conf/,
+  );
+  assert.match(
+    runtimeConfigDetector,
+    /homeserver\/docker-compose\.yml[\s\S]*homeserver\/nginx\/cloudflare-edge-real-ip\.conf[\s\S]*homeserver\/runtime-config\.Dockerfile/,
+  );
+  assert.match(runtimeConfigDetector, /git diff --quiet/);
+  assert.match(runtimeConfigDetector, /printf 'keep\\n'/);
+  assert.match(runtimeConfigDetector, /printf 'update\\n'/);
 });
 
 test("should_validateBackupBeforeKeepingThreeSuccessfulSnapshots", () => {

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -16,6 +16,7 @@ const [
   runtimeConfigDockerfile,
   runtimeConfigDetector,
   setupGuide,
+  runbook,
 ] = await Promise.all([
   read("../docker-compose.yml"),
   read("../docker-compose.admin.yml"),
@@ -30,6 +31,7 @@ const [
   read("../runtime-config.Dockerfile"),
   read("./detect-runtime-config-change.sh"),
   read("../docs/mac-mini-server-setup.md"),
+  read("../docs/home-server-runbook.md"),
 ]);
 
 test("should_isolateDataServicesAndGiveOnlyApiOutboundAccess_when_productionRuns", () => {
@@ -279,6 +281,10 @@ test("should_packageOnlyAllowlistedRuntimeConfigFiles_when_configChanges", () =>
   assert.match(runtimeConfigDetector, /git diff --quiet/);
   assert.match(runtimeConfigDetector, /printf 'keep\\n'/);
   assert.match(runtimeConfigDetector, /printf 'update\\n'/);
+  assert.doesNotMatch(
+    runtimeConfigDetector,
+    /deploy-home-server-ci|backup-home-server-bootstrap/,
+  );
   assert.match(dockerIgnore, /^homeserver\/scripts\/\*$/m);
   assert.match(
     dockerIgnore,
@@ -317,6 +323,10 @@ test("should_executeOnlyVerifiedReleaseScripts_when_runtimeConfigChanges", () =>
     /active_backup_script="\$\{candidate_release\}\/scripts\/backup-cubing-hub\.sh"[\s\S]*"\$\{active_backup_script\}"/,
   );
   assert.match(
+    deployScript,
+    /if \[\[ "\$\{legacy_mode\}" == true && ! -x "\$\{BACKUP_SCRIPT\}" \]\]; then/,
+  );
+  assert.match(
     backupBootstrap,
     /readonly LEGACY_BACKUP_SCRIPT=\/Users\/homeserver\/Server\/scripts\/backup\/backup-cubing-hub\.sh/,
   );
@@ -345,6 +355,14 @@ test("should_executeOnlyVerifiedReleaseScripts_when_runtimeConfigChanges", () =>
     /RUNTIME_CONFIG_PENDING[\s\S]*an incomplete runtime config transaction requires recovery/,
   );
   assert.doesNotMatch(runtimeConfigDockerfile, /bootstrap|deploy-home-server-ci/);
+  assert.match(
+    setupGuide,
+    /현재 운영 서버를 v2로 전환할 때는 이 worker를[\s\S]*branch 원본으로 교체하지 않고 stable deploy\/backup bootstrap 두 개만/,
+  );
+  assert.match(
+    runbook,
+    /deploy-home-server\.sh.*backup-home-server\.sh.*사전 설치하거나 branch 원본으로 교체하지 않는다/s,
+  );
 });
 
 test("should_validateBackupBeforeKeepingThreeSuccessfulSnapshots", () => {

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -61,6 +61,7 @@ prepare_script() {
   /usr/bin/sed \
     -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${mock_docker}#" \
     -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+    -e "s#readonly BACKUP_BOOTSTRAP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_BOOTSTRAP_SCRIPT=${target_script}#" \
     -e "s#readonly BACKUP_ROOT=/Users/homeserver/Server/backups/cubing-hub#readonly BACKUP_ROOT=${backup_root}#" \
     "${SOURCE_SCRIPT}" >"${target_script}"
   /bin/chmod 700 "${target_script}"
@@ -73,11 +74,21 @@ runtime_content_sha256() {
     /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
     /usr/bin/shasum -a 256 \
       "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if [[ -f "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+      && [[ -f "${release_dir}/scripts/deploy-cubing-hub.sh" ]]
+    then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
 }
 
 prepare_runtime_state() {
   local app_dir="$1"
+  local runtime_backup_script="$2"
+  local include_scripts="${3:-true}"
   local release_dir="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
   local content_sha
 
@@ -85,6 +96,18 @@ prepare_runtime_state() {
   printf 'name: cubing-hub\nservices: {}\n' >"${release_dir}/compose.yaml"
   printf 'set_real_ip_from 192.0.2.0/24;\n' \
     >"${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  if [[ "${include_scripts}" == true ]]; then
+    /bin/mkdir -p "${release_dir}/scripts"
+    /bin/cp \
+      "${runtime_backup_script}" \
+      "${release_dir}/scripts/backup-cubing-hub.sh"
+    /bin/cp \
+      "${SCRIPT_DIR}/deploy-home-server.sh" \
+      "${release_dir}/scripts/deploy-cubing-hub.sh"
+    /bin/chmod 700 \
+      "${release_dir}/scripts/backup-cubing-hub.sh" \
+      "${release_dir}/scripts/deploy-cubing-hub.sh"
+  fi
   content_sha="$(runtime_content_sha256 "${release_dir}")"
 
   {
@@ -118,8 +141,8 @@ v2_post_images="${test_root}/v2-post-images"
 v2_script="${test_root}/v2-backup.sh"
 prepare_app "${v2_app}" "${v2_post_images}"
 /bin/mkdir -p "${v2_backups}"
-prepare_runtime_state "${v2_app}"
 prepare_script "${v2_app}" "${v2_backups}" "${v2_script}"
+prepare_runtime_state "${v2_app}" "${v2_script}"
 
 COMPOSE_PROJECT_NAME=ambient-project \
 POST_IMAGES_HOST_DIR="${test_root}/ambient-post-images" \
@@ -132,16 +155,36 @@ expected_release="${v2_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
 /usr/bin/grep -Fq -- "--file ${expected_release}/compose.yaml" "${docker_log}"
 test "$(find "${v2_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 1
 
+legacy_v2_app="${test_root}/legacy-v2-app"
+legacy_v2_backups="${test_root}/legacy-v2-backups"
+legacy_v2_post_images="${test_root}/legacy-v2-post-images"
+legacy_v2_script="${test_root}/legacy-v2-backup.sh"
+prepare_app "${legacy_v2_app}" "${legacy_v2_post_images}"
+/bin/mkdir -p "${legacy_v2_backups}"
+prepare_script \
+  "${legacy_v2_app}" \
+  "${legacy_v2_backups}" \
+  "${legacy_v2_script}"
+prepare_runtime_state "${legacy_v2_app}" "${legacy_v2_script}" false
+
+: >"${docker_log}"
+DOCKER_LOG="${docker_log}" \
+MOCK_POST_IMAGES_DIR="${legacy_v2_post_images}" \
+  "${legacy_v2_script}" >/dev/null
+legacy_v2_release="${legacy_v2_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+/usr/bin/grep -Fq -- "--file ${legacy_v2_release}/compose.yaml" "${docker_log}"
+test "$(find "${legacy_v2_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 1
+
 unsafe_app="${test_root}/unsafe-app"
 unsafe_backups="${test_root}/unsafe-backups"
 unsafe_post_images="${test_root}/unsafe-post-images"
 unsafe_script="${test_root}/unsafe-backup.sh"
 prepare_app "${unsafe_app}" "${unsafe_post_images}"
 /bin/mkdir -p "${unsafe_backups}"
-prepare_runtime_state "${unsafe_app}"
+prepare_script "${unsafe_app}" "${unsafe_backups}" "${unsafe_script}"
+prepare_runtime_state "${unsafe_app}" "${unsafe_script}"
 /bin/rm -f -- "${unsafe_app}/runtime-config/current"
 /bin/ln -s releases/not-the-verified-release "${unsafe_app}/runtime-config/current"
-prepare_script "${unsafe_app}" "${unsafe_backups}" "${unsafe_script}"
 
 if DOCKER_LOG="${docker_log}" \
   MOCK_POST_IMAGES_DIR="${unsafe_post_images}" \
@@ -158,10 +201,10 @@ tampered_post_images="${test_root}/tampered-post-images"
 tampered_script="${test_root}/tampered-backup.sh"
 prepare_app "${tampered_app}" "${tampered_post_images}"
 /bin/mkdir -p "${tampered_backups}"
-prepare_runtime_state "${tampered_app}"
+prepare_script "${tampered_app}" "${tampered_backups}" "${tampered_script}"
+prepare_runtime_state "${tampered_app}" "${tampered_script}"
 printf '\n# tampered after verification\n' \
   >>"${tampered_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}/compose.yaml"
-prepare_script "${tampered_app}" "${tampered_backups}" "${tampered_script}"
 
 if DOCKER_LOG="${docker_log}" \
   MOCK_POST_IMAGES_DIR="${tampered_post_images}" \
@@ -178,15 +221,15 @@ symlink_state_post_images="${test_root}/symlink-state-post-images"
 symlink_state_script="${test_root}/symlink-state-backup.sh"
 prepare_app "${symlink_state_app}" "${symlink_state_post_images}"
 /bin/mkdir -p "${symlink_state_backups}"
-prepare_runtime_state "${symlink_state_app}"
-/bin/mv \
-  "${symlink_state_app}/runtime-config/state" \
-  "${symlink_state_app}/runtime-config/state.target"
-/bin/ln -s state.target "${symlink_state_app}/runtime-config/state"
 prepare_script \
   "${symlink_state_app}" \
   "${symlink_state_backups}" \
   "${symlink_state_script}"
+prepare_runtime_state "${symlink_state_app}" "${symlink_state_script}"
+/bin/mv \
+  "${symlink_state_app}/runtime-config/state" \
+  "${symlink_state_app}/runtime-config/state.target"
+/bin/ln -s state.target "${symlink_state_app}/runtime-config/state"
 
 if DOCKER_LOG="${docker_log}" \
   MOCK_POST_IMAGES_DIR="${symlink_state_post_images}" \

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly SCRIPT_DIR="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+  pwd -P
+)"
+readonly SOURCE_SCRIPT="${SCRIPT_DIR}/backup-home-server.sh"
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+readonly APPLICATION_SHA=1111111111111111111111111111111111111111
+readonly PREVIOUS_SHA=2222222222222222222222222222222222222222
+readonly CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly CONFIG_SHA=3333333333333333333333333333333333333333
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-backup-test.XXXXXX")"
+
+cleanup() {
+  if [[ "$(basename "${test_root}")" == cubing-backup-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+mock_docker="${test_root}/docker"
+docker_log="${test_root}/docker.log"
+
+{
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'set -Eeuo pipefail' \
+    'printf "%s\n" "$*" >>"${DOCKER_LOG}"' \
+    'if [[ " $* " != *" --project-name cubing-hub "* ]]; then' \
+    '  printf "Compose project name was not pinned: %s\n" "$*" >&2' \
+    '  exit 1' \
+    'elif [[ " $* " == *" config --format json "* ]]; then' \
+    '  if [[ -n "${POST_IMAGES_HOST_DIR+x}" ]]; then' \
+    '    printf "ambient POST_IMAGES_HOST_DIR reached Compose rendering\n" >&2' \
+    '    exit 1' \
+    '  fi' \
+    '  printf '\''{"services":{"api":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]},"web":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]}}}\n'\'' "${MOCK_POST_IMAGES_DIR}" "${MOCK_POST_IMAGES_DIR}"' \
+    'elif [[ " $* " == *" ps --status running --services "* ]]; then' \
+    '  printf "db\n"' \
+    'elif [[ " $* " == *"mysqldump"* ]]; then' \
+    '  printf "%s\n" "-- mock MySQL dump"' \
+    'elif [[ " $* " == *" exec -T db /bin/sh -ceu "* ]]; then' \
+    '  :' \
+    'else' \
+    '  printf "unexpected Docker invocation: %s\n" "$*" >&2' \
+    '  exit 1' \
+    'fi'
+} >"${mock_docker}"
+/bin/chmod 700 "${mock_docker}"
+
+prepare_script() {
+  local app_dir="$1"
+  local backup_root="$2"
+  local target_script="$3"
+
+  /usr/bin/sed \
+    -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${mock_docker}#" \
+    -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+    -e "s#readonly BACKUP_ROOT=/Users/homeserver/Server/backups/cubing-hub#readonly BACKUP_ROOT=${backup_root}#" \
+    "${SOURCE_SCRIPT}" >"${target_script}"
+  /bin/chmod 700 "${target_script}"
+}
+
+runtime_content_sha256() {
+  local release_dir="$1"
+
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+prepare_runtime_state() {
+  local app_dir="$1"
+  local release_dir="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+  local content_sha
+
+  /bin/mkdir -p "${release_dir}/nginx"
+  printf 'name: cubing-hub\nservices: {}\n' >"${release_dir}/compose.yaml"
+  printf 'set_real_ip_from 192.0.2.0/24;\n' \
+    >"${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  content_sha="$(runtime_content_sha256 "${release_dir}")"
+
+  {
+    printf 'APPLICATION_REVISION=%s\n' "${APPLICATION_SHA}"
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${PREVIOUS_SHA}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${ZERO_DIGEST}"
+    printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' "${content_sha}"
+    printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+    printf 'RUNTIME_CONFIG_REVISION=%s\n' "${CONFIG_SHA}"
+  } >"${app_dir}/runtime-config/state"
+  printf 'RUNTIME_CONFIG_V2=initialized\n' \
+    >"${app_dir}/.runtime-config-v2-initialized"
+  /bin/chmod 400 "${app_dir}/.runtime-config-v2-initialized"
+  /bin/ln -s \
+    "releases/${CONFIG_DIGEST#sha256:}" \
+    "${app_dir}/runtime-config/current"
+}
+
+prepare_app() {
+  local app_dir="$1"
+  local post_images_dir="$2"
+
+  /bin/mkdir -p "${app_dir}" "${post_images_dir}"
+  printf 'API_IMAGE=example-api\nWEB_IMAGE=example-web\nPOST_IMAGES_HOST_DIR=%s\n' \
+    "${post_images_dir}" >"${app_dir}/.env"
+}
+
+v2_app="${test_root}/v2-app"
+v2_backups="${test_root}/v2-backups"
+v2_post_images="${test_root}/v2-post-images"
+v2_script="${test_root}/v2-backup.sh"
+prepare_app "${v2_app}" "${v2_post_images}"
+/bin/mkdir -p "${v2_backups}"
+prepare_runtime_state "${v2_app}"
+prepare_script "${v2_app}" "${v2_backups}" "${v2_script}"
+
+COMPOSE_PROJECT_NAME=ambient-project \
+POST_IMAGES_HOST_DIR="${test_root}/ambient-post-images" \
+DOCKER_LOG="${docker_log}" \
+MOCK_POST_IMAGES_DIR="${v2_post_images}" \
+  "${v2_script}" >/dev/null
+expected_release="${v2_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+/usr/bin/grep -Fq -- "--project-name cubing-hub" "${docker_log}"
+/usr/bin/grep -Fq -- "--project-directory ${expected_release}" "${docker_log}"
+/usr/bin/grep -Fq -- "--file ${expected_release}/compose.yaml" "${docker_log}"
+test "$(find "${v2_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 1
+
+unsafe_app="${test_root}/unsafe-app"
+unsafe_backups="${test_root}/unsafe-backups"
+unsafe_post_images="${test_root}/unsafe-post-images"
+unsafe_script="${test_root}/unsafe-backup.sh"
+prepare_app "${unsafe_app}" "${unsafe_post_images}"
+/bin/mkdir -p "${unsafe_backups}"
+prepare_runtime_state "${unsafe_app}"
+/bin/rm -f -- "${unsafe_app}/runtime-config/current"
+/bin/ln -s releases/not-the-verified-release "${unsafe_app}/runtime-config/current"
+prepare_script "${unsafe_app}" "${unsafe_backups}" "${unsafe_script}"
+
+if DOCKER_LOG="${docker_log}" \
+  MOCK_POST_IMAGES_DIR="${unsafe_post_images}" \
+  "${unsafe_script}" >/dev/null 2>&1
+then
+  printf 'backup unexpectedly accepted a current pointer that disagrees with state\n' >&2
+  exit 1
+fi
+test "$(find "${unsafe_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 0
+
+tampered_app="${test_root}/tampered-app"
+tampered_backups="${test_root}/tampered-backups"
+tampered_post_images="${test_root}/tampered-post-images"
+tampered_script="${test_root}/tampered-backup.sh"
+prepare_app "${tampered_app}" "${tampered_post_images}"
+/bin/mkdir -p "${tampered_backups}"
+prepare_runtime_state "${tampered_app}"
+printf '\n# tampered after verification\n' \
+  >>"${tampered_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}/compose.yaml"
+prepare_script "${tampered_app}" "${tampered_backups}" "${tampered_script}"
+
+if DOCKER_LOG="${docker_log}" \
+  MOCK_POST_IMAGES_DIR="${tampered_post_images}" \
+  "${tampered_script}" >/dev/null 2>&1
+then
+  printf 'backup unexpectedly accepted a tampered runtime release\n' >&2
+  exit 1
+fi
+test "$(find "${tampered_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 0
+
+symlink_state_app="${test_root}/symlink-state-app"
+symlink_state_backups="${test_root}/symlink-state-backups"
+symlink_state_post_images="${test_root}/symlink-state-post-images"
+symlink_state_script="${test_root}/symlink-state-backup.sh"
+prepare_app "${symlink_state_app}" "${symlink_state_post_images}"
+/bin/mkdir -p "${symlink_state_backups}"
+prepare_runtime_state "${symlink_state_app}"
+/bin/mv \
+  "${symlink_state_app}/runtime-config/state" \
+  "${symlink_state_app}/runtime-config/state.target"
+/bin/ln -s state.target "${symlink_state_app}/runtime-config/state"
+prepare_script \
+  "${symlink_state_app}" \
+  "${symlink_state_backups}" \
+  "${symlink_state_script}"
+
+if DOCKER_LOG="${docker_log}" \
+  MOCK_POST_IMAGES_DIR="${symlink_state_post_images}" \
+  "${symlink_state_script}" >/dev/null 2>&1
+then
+  printf 'backup unexpectedly accepted a symlink runtime state\n' >&2
+  exit 1
+fi
+test "$(find "${symlink_state_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 0
+
+orphan_app="${test_root}/orphan-app"
+orphan_backups="${test_root}/orphan-backups"
+orphan_post_images="${test_root}/orphan-post-images"
+orphan_script="${test_root}/orphan-backup.sh"
+prepare_app "${orphan_app}" "${orphan_post_images}"
+/bin/mkdir -p \
+  "${orphan_app}/runtime-config/releases/orphan-release" \
+  "${orphan_backups}"
+printf 'name: cubing-hub\nservices: {}\n' >"${orphan_app}/compose.yaml"
+printf 'RUNTIME_CONFIG_V2=initialized\n' \
+  >"${orphan_app}/.runtime-config-v2-initialized"
+prepare_script "${orphan_app}" "${orphan_backups}" "${orphan_script}"
+
+if DOCKER_LOG="${docker_log}" \
+  MOCK_POST_IMAGES_DIR="${orphan_post_images}" \
+  "${orphan_script}" >/dev/null 2>&1
+then
+  printf 'backup unexpectedly accepted orphan runtime releases without state\n' >&2
+  exit 1
+fi
+test "$(find "${orphan_backups}" -name 'cubing-hub-production-*' -type d | wc -l | tr -d ' ')" = 0
+
+legacy_app="${test_root}/legacy-app"
+legacy_backups="${test_root}/legacy-backups"
+legacy_post_images="${test_root}/legacy-post-images"
+legacy_script="${test_root}/legacy-backup.sh"
+prepare_app "${legacy_app}" "${legacy_post_images}"
+/bin/mkdir -p \
+  "${legacy_app}/runtime-config/releases/bootstrap-candidate" \
+  "${legacy_backups}"
+printf 'name: cubing-hub\nservices: {}\n' >"${legacy_app}/compose.yaml"
+printf 'candidate release retained before first successful v2 state\n' \
+  >"${legacy_app}/runtime-config/releases/bootstrap-candidate/candidate"
+prepare_script "${legacy_app}" "${legacy_backups}" "${legacy_script}"
+
+: >"${docker_log}"
+DOCKER_LOG="${docker_log}" \
+MOCK_POST_IMAGES_DIR="${legacy_post_images}" \
+  "${legacy_script}" >/dev/null
+/usr/bin/grep -Fq -- "--project-name cubing-hub" "${docker_log}"
+/usr/bin/grep -Fq -- "--project-directory ${legacy_app}" "${docker_log}"
+/usr/bin/grep -Fq -- "--file ${legacy_app}/compose.yaml" "${docker_log}"
+
+printf 'Cubing Hub production backup selection tests passed\n'

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -80,6 +80,8 @@ run_deploy() {
         FAKE_CANDIDATE_API_PORTS_JSON="${FAKE_CANDIDATE_API_PORTS_JSON:-}" \
         FAKE_CANDIDATE_API_PRIVILEGED="${FAKE_CANDIDATE_API_PRIVILEGED:-}" \
         FAKE_CANDIDATE_API_SECRETS_JSON="${FAKE_CANDIDATE_API_SECRETS_JSON:-}" \
+        FAKE_CANDIDATE_API_TMPFS_JSON="${FAKE_CANDIDATE_API_TMPFS_JSON:-}" \
+        FAKE_CANDIDATE_API_USER_JSON="${FAKE_CANDIDATE_API_USER_JSON:-}" \
         FAKE_CANDIDATE_APPLICATION_JSON="${FAKE_CANDIDATE_APPLICATION_JSON:-}" \
         FAKE_CANDIDATE_DATABASE_NAME="${FAKE_CANDIDATE_DATABASE_NAME:-}" \
         FAKE_CANDIDATE_DB_ENTRYPOINT_JSON="${FAKE_CANDIDATE_DB_ENTRYPOINT_JSON:-}" \
@@ -443,9 +445,7 @@ test ! -e "${pending_file}"
 
 FAKE_CONFIG_REVISION="${REVISION_THREE}" \
 FAKE_CANDIDATE_WEB_RESTART=always \
-FAKE_CANDIDATE_DB_HEALTHCHECK_JSON='{"test":["CMD","mysqladmin","--host=localhost","ping","--silent"],"interval":"30s","timeout":"3s","retries":3}' \
-FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON='{"test":["CMD-SHELL","redis-cli --raw PING | grep PONG"],"interval":"30s","timeout":"3s","retries":3}' \
-FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD-SHELL","curl -fsS -H Host:api.cubing-hub.com http://localhost/actuator/health | grep -qi status.*UP"],"interval":"30s","timeout":"3s","retries":3}' \
+FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON='{"test":["CMD","redis-cli","ping"],"interval":"30s","timeout":"3s","retries":3}' \
 FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"FEATURE_FLAG":"enabled"' \
   run_deploy \
     "${REVISION_THREE}" \
@@ -528,6 +528,10 @@ FAKE_CANDIDATE_API_PORTS_JSON='[{"mode":"ingress","target":8080,"published":"808
   expect_protected_failure "published API host port"
 FAKE_CANDIDATE_API_PID_JSON='"host"' \
   expect_protected_failure "host PID namespace"
+FAKE_CANDIDATE_API_USER_JSON='"00:1000"' \
+  expect_protected_failure "API process user drift"
+FAKE_CANDIDATE_API_TMPFS_JSON='["/tmp:size=128m,mode=1777","/app:size=32m"]' \
+  expect_protected_failure "API tmpfs target drift"
 FAKE_CANDIDATE_API_COMMAND_JSON='["override"]' \
   expect_protected_failure "API command override"
 FAKE_CANDIDATE_API_ENTRYPOINT_JSON='["override"]' \
@@ -546,8 +550,8 @@ FAKE_CANDIDATE_DB_HEALTHCHECK_JSON='{"test":["CMD","mysqladmin","ping"],"interva
   expect_protected_failure "database healthcheck without loopback"
 FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON='{"test":["CMD","true"],"interval":"30s","timeout":"3s","retries":3}' \
   expect_protected_failure "Redis healthcheck without ping"
-FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD","true"],"interval":"30s","timeout":"3s","retries":3}' \
-  expect_protected_failure "healthcheck probe substitution"
+FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD-SHELL","true # wget --header=Host:api.cubing-hub.com http://127.0.0.1/actuator/health status UP"],"interval":"30s","timeout":"3s","retries":3}' \
+  expect_protected_failure "always-success healthcheck probe substitution"
 FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD-SHELL","curl -fsS http://localhost/actuator/health | grep -qi status.*UP"],"interval":"30s","timeout":"3s","retries":3}' \
   expect_protected_failure "Web readiness healthcheck without Host"
 FAKE_CANDIDATE_API_CONFIGS_JSON='[{"source":"prod-env","target":"/app/prod.env"}]' \

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -1,0 +1,577 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+PROJECT_ROOT="$(
+  CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
+)"
+SOURCE_SCRIPT="${PROJECT_ROOT}/homeserver/scripts/deploy-home-server.sh"
+MOCK_DOCKER="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh"
+
+REVISION_ONE=1111111111111111111111111111111111111111
+REVISION_TWO=2222222222222222222222222222222222222222
+REVISION_THREE=3333333333333333333333333333333333333333
+CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+CONFIG_DIGEST_TWO=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+CONFIG_DIGEST_THREE=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-hub-deploy-test.XXXXXX")"
+cleanup() {
+  if [[ "$(/usr/bin/basename "${test_root}")" == cubing-hub-deploy-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+app_dir="${test_root}/app"
+test_script="${test_root}/deploy-cubing-hub.sh"
+backup_script="${test_root}/backup.sh"
+runtime_compose="${test_root}/runtime-compose.yaml"
+runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
+/bin/mkdir -p "${app_dir}"
+/bin/cp "${PROJECT_ROOT}/homeserver/docker-compose.yml" "${app_dir}/compose.yaml"
+/bin/cp "${PROJECT_ROOT}/homeserver/docker-compose.yml" "${runtime_compose}"
+/bin/cp \
+  "${PROJECT_ROOT}/homeserver/nginx/cloudflare-edge-real-ip.conf" \
+  "${runtime_real_ip}"
+/bin/cp "${PROJECT_ROOT}/homeserver/.env.example" "${app_dir}/.env"
+
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_TWO}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.updated"
+/bin/mv "${app_dir}/.env.updated" "${app_dir}/.env"
+
+printf '#!/bin/bash\nexit 0\n' >"${backup_script}"
+/bin/chmod 700 "${backup_script}"
+
+/usr/bin/sed \
+  -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
+  -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+  -e "s#readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_SCRIPT=${backup_script}#" \
+  "${SOURCE_SCRIPT}" \
+  >"${test_script}"
+/bin/chmod 700 "${test_script}" "${MOCK_DOCKER}"
+
+run_deploy() {
+  local target_revision="$1"
+
+  printf 'test-token' \
+    | /usr/bin/env \
+        FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
+        FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
+        FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
+        FAKE_REVISION_ONE="${REVISION_ONE}" \
+        FAKE_REVISION_TWO="${REVISION_TWO}" \
+        FAKE_REVISION_THREE="${REVISION_THREE}" \
+        FAKE_VALIDATION_TARGET_API_IMAGE="ghcr.io/xxh3898/cubing-hub-api:${target_revision}" \
+        FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
+        FAKE_FAIL_CP="${FAKE_FAIL_CP:-false}" \
+        FAKE_FAIL_APP_UP_ONCE_FILE="${FAKE_FAIL_APP_UP_ONCE_FILE:-}" \
+        FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT="${FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT:-}" \
+        FAKE_CANDIDATE_API_EXTRA_HOSTS_JSON="${FAKE_CANDIDATE_API_EXTRA_HOSTS_JSON:-}" \
+        FAKE_CANDIDATE_API_EXTRA_VOLUME="${FAKE_CANDIDATE_API_EXTRA_VOLUME:-}" \
+        FAKE_CANDIDATE_API_CONFIGS_JSON="${FAKE_CANDIDATE_API_CONFIGS_JSON:-}" \
+        FAKE_CANDIDATE_API_COMMAND_JSON="${FAKE_CANDIDATE_API_COMMAND_JSON:-}" \
+        FAKE_CANDIDATE_API_ENTRYPOINT_JSON="${FAKE_CANDIDATE_API_ENTRYPOINT_JSON:-}" \
+        FAKE_CANDIDATE_API_ENV_FILE_JSON="${FAKE_CANDIDATE_API_ENV_FILE_JSON:-}" \
+        FAKE_CANDIDATE_API_IMAGE="${FAKE_CANDIDATE_API_IMAGE:-}" \
+        FAKE_CANDIDATE_API_PID_JSON="${FAKE_CANDIDATE_API_PID_JSON:-}" \
+        FAKE_CANDIDATE_API_PORTS_JSON="${FAKE_CANDIDATE_API_PORTS_JSON:-}" \
+        FAKE_CANDIDATE_API_PRIVILEGED="${FAKE_CANDIDATE_API_PRIVILEGED:-}" \
+        FAKE_CANDIDATE_API_SECRETS_JSON="${FAKE_CANDIDATE_API_SECRETS_JSON:-}" \
+        FAKE_CANDIDATE_APPLICATION_JSON="${FAKE_CANDIDATE_APPLICATION_JSON:-}" \
+        FAKE_CANDIDATE_DATABASE_NAME="${FAKE_CANDIDATE_DATABASE_NAME:-}" \
+        FAKE_CANDIDATE_DB_ENTRYPOINT_JSON="${FAKE_CANDIDATE_DB_ENTRYPOINT_JSON:-}" \
+        FAKE_CANDIDATE_DB_HEALTHCHECK_JSON="${FAKE_CANDIDATE_DB_HEALTHCHECK_JSON:-}" \
+        FAKE_CANDIDATE_DB_IMAGE="${FAKE_CANDIDATE_DB_IMAGE:-}" \
+        FAKE_CANDIDATE_DDL_AUTO="${FAKE_CANDIDATE_DDL_AUTO:-}" \
+        FAKE_CANDIDATE_MYSQL_COMMAND_JSON="${FAKE_CANDIDATE_MYSQL_COMMAND_JSON:-}" \
+        FAKE_CANDIDATE_MYSQL_VOLUME_EXTRA="${FAKE_CANDIDATE_MYSQL_VOLUME_EXTRA:-}" \
+        FAKE_CANDIDATE_REAL_IP_SOURCE="${FAKE_CANDIDATE_REAL_IP_SOURCE:-}" \
+        FAKE_CANDIDATE_REDIS_COMMAND_JSON="${FAKE_CANDIDATE_REDIS_COMMAND_JSON:-}" \
+        FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON="${FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON:-}" \
+        FAKE_CANDIDATE_UPLOAD_SOURCE="${FAKE_CANDIDATE_UPLOAD_SOURCE:-}" \
+        FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON="${FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON:-}" \
+        FAKE_CANDIDATE_WEB_COMMAND_JSON="${FAKE_CANDIDATE_WEB_COMMAND_JSON:-}" \
+        FAKE_CANDIDATE_WEB_ENTRYPOINT_JSON="${FAKE_CANDIDATE_WEB_ENTRYPOINT_JSON:-}" \
+        FAKE_CANDIDATE_WEB_RESTART="${FAKE_CANDIDATE_WEB_RESTART:-}" \
+        /bin/bash "${test_script}" "$@"
+}
+
+run_recovery() {
+  /usr/bin/env \
+    FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
+    FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
+    FAKE_CONFIG_REVISION="${REVISION_ONE}" \
+    FAKE_REVISION_ONE="${REVISION_ONE}" \
+    FAKE_REVISION_TWO="${REVISION_TWO}" \
+    FAKE_REVISION_THREE="${REVISION_THREE}" \
+    /bin/bash "${test_script}" recover
+}
+
+bootstrap_candidate="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+state_file="${app_dir}/runtime-config/state"
+current_link="${app_dir}/runtime-config/current"
+initialization_marker="${app_dir}/.runtime-config-v2-initialized"
+bootstrap_failure_marker="${test_root}/fail-bootstrap-app-up-once"
+bootstrap_docker_log="${test_root}/bootstrap-docker.log"
+: >"${bootstrap_docker_log}"
+
+set +e
+FAKE_DOCKER_LOG="${bootstrap_docker_log}" \
+FAKE_FAIL_APP_UP_ONCE_FILE="${bootstrap_failure_marker}" \
+  run_deploy \
+    "${REVISION_ONE}" \
+    update \
+    "${CONFIG_DIGEST}" \
+    test-user \
+    >/dev/null 2>&1
+bootstrap_failure_exit_code="$?"
+set -e
+if [[ "${bootstrap_failure_exit_code}" -ne 1 ]]; then
+  printf 'Interrupted first v2 deployment must fail after rollback\n' >&2
+  exit 1
+fi
+test -f "${bootstrap_failure_marker}"
+test -d "${bootstrap_candidate}"
+test ! -e "${state_file}"
+test ! -e "${current_link}"
+test ! -e "${initialization_marker}"
+test ! -e "${app_dir}/runtime-config/pending"
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
+  "${app_dir}/.env"
+bootstrap_up_log="${test_root}/bootstrap-up.log"
+/usr/bin/grep '^compose .* up ' "${bootstrap_docker_log}" >"${bootstrap_up_log}"
+bootstrap_up_count="$(/usr/bin/wc -l <"${bootstrap_up_log}" | /usr/bin/tr -d ' ')"
+test "${bootstrap_up_count}" -eq 2
+/usr/bin/sed -n '1p' "${bootstrap_up_log}" \
+  | /usr/bin/grep -Fq -- \
+      "--file ${bootstrap_candidate}/compose.yaml up "
+/usr/bin/sed -n '2p' "${bootstrap_up_log}" \
+  | /usr/bin/grep -Fq -- \
+      "--file ${app_dir}/compose.yaml up "
+
+FAKE_FAIL_APP_UP_ONCE_FILE="${bootstrap_failure_marker}" \
+run_deploy \
+  "${REVISION_ONE}" \
+  update \
+  "${CONFIG_DIGEST}" \
+  test-user
+
+test -f "${state_file}"
+test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST}" "${state_file}"
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_REVISION=${REVISION_ONE}" "${state_file}"
+test -L "${current_link}"
+test ! -e "${app_dir}/runtime-config/pending"
+
+/bin/mv "${state_file}" "${state_file}.both-missing"
+/bin/mv "${current_link}" "${current_link}.both-missing"
+set +e
+run_deploy \
+  "${REVISION_TWO}" \
+  update \
+  "${CONFIG_DIGEST_TWO}" \
+  test-user \
+  >/dev/null 2>&1
+missing_initialized_state_exit_code="$?"
+run_deploy "${REVISION_TWO}" test-user >/dev/null 2>&1
+legacy_missing_initialized_state_exit_code="$?"
+set -e
+if [[ "${missing_initialized_state_exit_code}" -ne 1 ]] \
+  || [[ "${legacy_missing_initialized_state_exit_code}" -ne 1 ]]
+then
+  printf 'Initialized runtime config must not fallback after state deletion\n' >&2
+  exit 1
+fi
+/bin/mv "${state_file}.both-missing" "${state_file}"
+/bin/mv "${current_link}.both-missing" "${current_link}"
+
+/bin/mv "${state_file}" "${state_file}.missing"
+set +e
+run_deploy \
+  "${REVISION_TWO}" \
+  update \
+  "${CONFIG_DIGEST_TWO}" \
+  test-user \
+  >/dev/null 2>&1
+missing_state_exit_code="$?"
+set -e
+if [[ "${missing_state_exit_code}" -ne 1 ]]; then
+  printf 'Deployment with a current pointer but missing state must fail\n' >&2
+  exit 1
+fi
+/bin/mv "${state_file}.missing" "${state_file}"
+
+/bin/ln -s missing-pending "${app_dir}/runtime-config/pending"
+set +e
+run_deploy "${REVISION_TWO}" keep test-user >/dev/null 2>&1
+dangling_pending_exit_code="$?"
+set -e
+if [[ "${dangling_pending_exit_code}" -ne 1 ]]; then
+  printf 'Deployment with a dangling pending symlink must require recovery\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${app_dir}/runtime-config/pending"
+
+/bin/mv "${current_link}" "${current_link}.valid"
+/bin/ln -s "releases/missing" "${current_link}"
+set +e
+run_deploy "${REVISION_TWO}" keep test-user >/dev/null 2>&1
+stale_current_exit_code="$?"
+set -e
+if [[ "${stale_current_exit_code}" -ne 1 ]]; then
+  printf 'Deployment with a stale current pointer must fail closed\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${current_link}"
+/bin/mv "${current_link}.valid" "${current_link}"
+
+set +e
+run_deploy "${REVISION_TWO}" test-user >/dev/null 2>&1
+legacy_after_v2_exit_code="$?"
+set -e
+if [[ "${legacy_after_v2_exit_code}" -ne 1 ]]; then
+  printf 'Legacy Cubing Hub deploy must be disabled after v2 state initialization\n' >&2
+  exit 1
+fi
+
+/bin/mv "${app_dir}/compose.yaml" "${app_dir}/compose.yaml.legacy"
+run_deploy "${REVISION_TWO}" keep test-user
+/bin/mv "${app_dir}/compose.yaml.legacy" "${app_dir}/compose.yaml"
+
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
+  "${app_dir}/.env"
+/usr/bin/grep -Fxq "APPLICATION_REVISION=${REVISION_TWO}" "${state_file}"
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST}" "${state_file}"
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_REVISION=${REVISION_ONE}" "${state_file}"
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
+  = "releases/${CONFIG_DIGEST#sha256:}"
+if /usr/bin/find "${app_dir}/runtime-config/releases" -name '.current.*' | /usr/bin/grep -q .; then
+  printf 'Atomic current pointer update left an internal temporary symlink\n' >&2
+  exit 1
+fi
+
+pending_file="${app_dir}/runtime-config/pending"
+{
+  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_THREE}"
+  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+} >"${pending_file}"
+/bin/chmod 600 "${pending_file}"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_THREE}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.interrupted"
+/bin/mv "${app_dir}/.env.interrupted" "${app_dir}/.env"
+
+set +e
+run_deploy "${REVISION_ONE}" test-user >/dev/null 2>&1
+legacy_pending_exit_code="$?"
+set -e
+if [[ "${legacy_pending_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
+  printf 'Legacy Cubing Hub deploy must preserve and reject pending transaction\n' >&2
+  exit 1
+fi
+
+/bin/mv "${state_file}" "${state_file}.real"
+/bin/ln -s "$(/usr/bin/basename "${state_file}.real")" "${state_file}"
+set +e
+run_recovery >/dev/null 2>&1
+symlink_state_recovery_exit_code="$?"
+set -e
+if [[ "${symlink_state_recovery_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
+  printf 'Recovery with a symlink state must fail and preserve pending\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${state_file}"
+/bin/mv "${state_file}.real" "${state_file}"
+
+/bin/mv "${app_dir}/compose.yaml" "${app_dir}/compose.yaml.legacy"
+/bin/rm -f -- "${initialization_marker}" "${current_link}"
+run_recovery
+/bin/mv "${app_dir}/compose.yaml.legacy" "${app_dir}/compose.yaml"
+
+test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized
+test "$(/usr/bin/readlink "${current_link}")" \
+  = "releases/${CONFIG_DIGEST#sha256:}"
+test ! -e "${pending_file}"
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
+  "${app_dir}/.env"
+/usr/bin/grep -Fxq "APPLICATION_REVISION=${REVISION_TWO}" "${state_file}"
+
+{
+  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+} >"${pending_file}"
+/bin/chmod 600 "${pending_file}"
+run_recovery
+test ! -e "${pending_file}"
+
+release_one="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+release_two="${app_dir}/runtime-config/releases/${CONFIG_DIGEST_TWO#sha256:}"
+/bin/cp -R "${release_one}" "${release_two}"
+original_content_sha="$(/usr/bin/sed -n 's/^RUNTIME_CONFIG_CONTENT_SHA256=//p' "${state_file}")"
+target_content_sha="$(
+  {
+    /usr/bin/shasum -a 256 "${release_two}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_two}/nginx/cloudflare-edge-real-ip.conf"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+)"
+{
+  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
+  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_THREE}"
+  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST_TWO}"
+} >"${pending_file}"
+/usr/bin/sed \
+  -e "s#^APPLICATION_REVISION=.*#APPLICATION_REVISION=${REVISION_THREE}#" \
+  -e "s#^RUNTIME_CONFIG_DIGEST=.*#RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST_TWO}#" \
+  -e "s#^RUNTIME_CONFIG_CONTENT_SHA256=.*#RUNTIME_CONFIG_CONTENT_SHA256=${target_content_sha}#" \
+  "${state_file}" >"${state_file}.target"
+/bin/mv "${state_file}.target" "${state_file}"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_THREE}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.target"
+/bin/mv "${app_dir}/.env.target" "${app_dir}/.env"
+
+/bin/cp "${state_file}" "${state_file}.valid"
+/usr/bin/sed \
+  -e 's#^RUNTIME_CONFIG_REVISION=.*#RUNTIME_CONFIG_REVISION=garbage#' \
+  "${state_file}.valid" >"${state_file}"
+set +e
+run_recovery >/dev/null 2>&1
+invalid_state_recovery_exit_code="$?"
+set -e
+if [[ "${invalid_state_recovery_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
+  printf 'Recovery with invalid state values must fail and preserve pending\n' >&2
+  exit 1
+fi
+/bin/mv "${state_file}.valid" "${state_file}"
+
+set +e
+run_recovery >/dev/null 2>&1
+mismatched_predecessor_exit_code="$?"
+set -e
+if [[ "${mismatched_predecessor_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
+  printf 'Completed target recovery with a mismatched predecessor must fail\n' >&2
+  exit 1
+fi
+/usr/bin/sed \
+  -e "s#^PREVIOUS_APPLICATION_REVISION=.*#PREVIOUS_APPLICATION_REVISION=${REVISION_TWO}#" \
+  -e "s#^PREVIOUS_RUNTIME_CONFIG_DIGEST=.*#PREVIOUS_RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST}#" \
+  "${state_file}" >"${state_file}.matched"
+/bin/mv "${state_file}.matched" "${state_file}"
+
+/bin/rm -f -- "${initialization_marker}"
+test ! -e "${initialization_marker}"
+set +e
+FAKE_SERVICE_HEALTH=unhealthy run_recovery >/dev/null 2>&1
+unhealthy_completed_target_exit_code="$?"
+set -e
+if [[ "${unhealthy_completed_target_exit_code}" -ne 1 ]] \
+  || [[ ! -f "${pending_file}" ]] \
+  || [[ -e "${initialization_marker}" ]]
+then
+  printf 'Completed target recovery must preserve pending while services are unhealthy\n' >&2
+  exit 1
+fi
+run_recovery
+
+test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
+  = "releases/${CONFIG_DIGEST_TWO#sha256:}"
+test ! -e "${pending_file}"
+
+/usr/bin/sed \
+  -e "s#^APPLICATION_REVISION=.*#APPLICATION_REVISION=${REVISION_TWO}#" \
+  -e "s#^RUNTIME_CONFIG_DIGEST=.*#RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST}#" \
+  -e "s#^RUNTIME_CONFIG_CONTENT_SHA256=.*#RUNTIME_CONFIG_CONTENT_SHA256=${original_content_sha}#" \
+  "${state_file}" >"${state_file}.restored"
+/bin/mv "${state_file}.restored" "${state_file}"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_TWO}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.restored"
+/bin/mv "${app_dir}/.env.restored" "${app_dir}/.env"
+/bin/rm -f -- "${app_dir}/runtime-config/current"
+/bin/ln -s "releases/${CONFIG_DIGEST#sha256:}" "${app_dir}/runtime-config/current"
+
+printf 'UNKNOWN=value\n' >"${pending_file}"
+set +e
+run_recovery >/dev/null 2>&1
+recovery_exit_code="$?"
+set -e
+if [[ "${recovery_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
+  printf 'Invalid pending recovery must fail closed\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${pending_file}"
+
+set +e
+FAKE_SERVICE_HEALTH=unhealthy \
+FAKE_CONFIG_REVISION="${REVISION_THREE}" \
+  run_deploy \
+    "${REVISION_THREE}" \
+    update \
+    "${CONFIG_DIGEST_TWO}" \
+    test-user \
+    >/dev/null 2>&1
+unhealthy_deployment_exit_code="$?"
+set -e
+if [[ "${unhealthy_deployment_exit_code}" -ne 1 ]] \
+  || [[ ! -f "${pending_file}" ]]
+then
+  printf 'Deployment must retain pending state when actual services are unhealthy\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq "APPLICATION_REVISION=${REVISION_TWO}" "${state_file}"
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
+  "${app_dir}/.env"
+run_recovery
+test ! -e "${pending_file}"
+
+FAKE_CONFIG_REVISION="${REVISION_THREE}" \
+FAKE_CANDIDATE_WEB_RESTART=always \
+FAKE_CANDIDATE_DB_HEALTHCHECK_JSON='{"test":["CMD","mysqladmin","--host=localhost","ping","--silent"],"interval":"30s","timeout":"3s","retries":3}' \
+FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON='{"test":["CMD-SHELL","redis-cli --raw PING | grep PONG"],"interval":"30s","timeout":"3s","retries":3}' \
+FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD-SHELL","curl -fsS -H Host:api.cubing-hub.com http://localhost/actuator/health | grep -qi status.*UP"],"interval":"30s","timeout":"3s","retries":3}' \
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"FEATURE_FLAG":"enabled"' \
+  run_deploy \
+    "${REVISION_THREE}" \
+    update \
+    "${CONFIG_DIGEST_TWO}" \
+    test-user
+
+/usr/bin/grep -Fxq "APPLICATION_REVISION=${REVISION_THREE}" "${state_file}"
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST_TWO}" "${state_file}"
+test "$(/usr/bin/readlink "${current_link}")" \
+  = "releases/${CONFIG_DIGEST_TWO#sha256:}"
+
+expect_protected_failure() {
+  local label="$1"
+  local exit_code
+
+  set +e
+  FAKE_CONFIG_REVISION="${REVISION_ONE}" \
+    run_deploy \
+      "${REVISION_ONE}" \
+      update \
+      "${CONFIG_DIGEST_THREE}" \
+      test-user \
+      >/dev/null 2>&1
+  exit_code="$?"
+  set -e
+
+  if [[ "${exit_code}" -ne 1 ]]; then
+    printf '%s must be rejected by the protected runtime boundary\n' "${label}" >&2
+    exit 1
+  fi
+  test ! -e "${pending_file}"
+  /usr/bin/grep -Fxq \
+    "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}" \
+    "${app_dir}/.env"
+}
+
+FAKE_CANDIDATE_DB_IMAGE=mysql:8.4 \
+  expect_protected_failure "data-service image drift"
+FAKE_CANDIDATE_DB_ENTRYPOINT_JSON='["sh","-c","rm -rf /var/lib/mysql"]' \
+  expect_protected_failure "database entrypoint drift"
+FAKE_CANDIDATE_REDIS_COMMAND_JSON='["redis-server","--appendonly","no"]' \
+  expect_protected_failure "Redis command drift"
+FAKE_CANDIDATE_DATABASE_NAME=cubing_hub_alternate \
+  expect_protected_failure "database MYSQL environment drift"
+FAKE_CANDIDATE_DDL_AUTO=create-drop \
+  expect_protected_failure "data-sensitive API environment drift"
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"SPRING_PROFILES_INCLUDE":"migration"' \
+  expect_protected_failure "Spring profile environment drift"
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"SPRING_SQL_INIT_MODE":"always"' \
+  expect_protected_failure "Spring SQL initialization drift"
+for protected_api_environment_name in \
+  SPRING_APPLICATION_JSON \
+  SPRING_CONFIG_IMPORT \
+  JAVA_TOOL_OPTIONS \
+  JDK_JAVA_OPTIONS \
+  _JAVA_OPTIONS \
+  JAVA_OPTS
+do
+  FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=",\"${protected_api_environment_name}\":\"override\"" \
+    expect_protected_failure "${protected_api_environment_name} drift"
+done
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"DB_USERNAME":"alternate-user"' \
+  expect_protected_failure "API database credential identity drift"
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"REDIS_HOST":"outside.invalid"' \
+  expect_protected_failure "API Redis identity drift"
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"RANKING_REDIS_REBUILD_MODE":"enabled"' \
+  expect_protected_failure "ranking Redis mode drift"
+FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"POST_IMAGES_PUBLIC_BASE_URL":"https://example.invalid/uploads"' \
+  expect_protected_failure "post image identity drift"
+FAKE_CANDIDATE_MYSQL_VOLUME_EXTRA=',"driver_opts":{"type":"tmpfs"}' \
+  expect_protected_failure "data-volume identity drift"
+FAKE_CANDIDATE_UPLOAD_SOURCE=/Users/homeserver/Server/data/cubing-hub/alternate \
+  expect_protected_failure "upload bind drift"
+FAKE_CANDIDATE_APPLICATION_JSON='{"name":"cubing-hub_application","ipam":{},"internal":false}' \
+  expect_protected_failure "application network boundary drift"
+FAKE_CANDIDATE_API_PRIVILEGED=true \
+  expect_protected_failure "privileged API service"
+FAKE_CANDIDATE_API_PORTS_JSON='[{"mode":"ingress","target":8080,"published":"8080","protocol":"tcp"}]' \
+  expect_protected_failure "published API host port"
+FAKE_CANDIDATE_API_PID_JSON='"host"' \
+  expect_protected_failure "host PID namespace"
+FAKE_CANDIDATE_API_COMMAND_JSON='["override"]' \
+  expect_protected_failure "API command override"
+FAKE_CANDIDATE_API_ENTRYPOINT_JSON='["override"]' \
+  expect_protected_failure "API entrypoint override"
+FAKE_CANDIDATE_WEB_COMMAND_JSON='["override"]' \
+  expect_protected_failure "Web command override"
+FAKE_CANDIDATE_WEB_ENTRYPOINT_JSON='["override"]' \
+  expect_protected_failure "Web entrypoint override"
+FAKE_CANDIDATE_API_EXTRA_HOSTS_JSON='["db:203.0.113.10"]' \
+  expect_protected_failure "protected service hostname override"
+FAKE_CANDIDATE_API_EXTRA_VOLUME=',{"type":"bind","source":"/var/run/docker.sock","target":"/var/run/docker.sock"}' \
+  expect_protected_failure "Docker socket bind"
+FAKE_CANDIDATE_API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:unexpected \
+  expect_protected_failure "API image substitution"
+FAKE_CANDIDATE_DB_HEALTHCHECK_JSON='{"test":["CMD","mysqladmin","ping"],"interval":"30s","timeout":"3s","retries":3}' \
+  expect_protected_failure "database healthcheck without loopback"
+FAKE_CANDIDATE_REDIS_HEALTHCHECK_JSON='{"test":["CMD","true"],"interval":"30s","timeout":"3s","retries":3}' \
+  expect_protected_failure "Redis healthcheck without ping"
+FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD","true"],"interval":"30s","timeout":"3s","retries":3}' \
+  expect_protected_failure "healthcheck probe substitution"
+FAKE_CANDIDATE_WEB_HEALTHCHECK_JSON='{"test":["CMD-SHELL","curl -fsS http://localhost/actuator/health | grep -qi status.*UP"],"interval":"30s","timeout":"3s","retries":3}' \
+  expect_protected_failure "Web readiness healthcheck without Host"
+FAKE_CANDIDATE_API_CONFIGS_JSON='[{"source":"prod-env","target":"/app/prod.env"}]' \
+  expect_protected_failure "Compose config host-file bypass"
+FAKE_CANDIDATE_API_SECRETS_JSON='[{"source":"prod-secret","target":"/run/secrets/prod"}]' \
+  expect_protected_failure "Compose secret host-file bypass"
+FAKE_CANDIDATE_API_ENV_FILE_JSON='["/Users/homeserver/Server/apps/cubing-hub/.env"]' \
+  expect_protected_failure "Compose env-file host-file bypass"
+FAKE_CANDIDATE_REAL_IP_SOURCE=/tmp/stale/cloudflare-edge-real-ip.conf \
+  expect_protected_failure "non-candidate Nginx bind"
+
+release_dir="${app_dir}/runtime-config/releases/${CONFIG_DIGEST_TWO#sha256:}"
+printf '\n# tampered\n' >>"${release_dir}/compose.yaml"
+
+set +e
+run_deploy "${REVISION_ONE}" keep test-user >/dev/null 2>&1
+tampered_release_exit_code="$?"
+set -e
+if [[ "${tampered_release_exit_code}" -ne 1 ]]; then
+  printf 'Tampered active runtime config must fail closed\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}" \
+  "${app_dir}/.env"
+
+printf 'Cubing Hub focused deploy v2 tests passed\n'

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -14,6 +14,7 @@ REVISION_THREE=3333333333333333333333333333333333333333
 CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 CONFIG_DIGEST_TWO=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 CONFIG_DIGEST_THREE=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+CONFIG_DIGEST_FIVE=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 
 test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-hub-deploy-test.XXXXXX")"
 cleanup() {
@@ -26,6 +27,7 @@ trap cleanup EXIT INT TERM
 app_dir="${test_root}/app"
 test_script="${test_root}/deploy-cubing-hub.sh"
 backup_script="${test_root}/backup.sh"
+backup_log="${test_root}/backup.log"
 runtime_compose="${test_root}/runtime-compose.yaml"
 runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
 /bin/mkdir -p "${app_dir}"
@@ -42,8 +44,12 @@ runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
   "${app_dir}/.env" >"${app_dir}/.env.updated"
 /bin/mv "${app_dir}/.env.updated" "${app_dir}/.env"
 
-printf '#!/bin/bash\nexit 0\n' >"${backup_script}"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "%s\n" "${BASH_SOURCE[0]}" >>"${FAKE_BACKUP_LOG}"' \
+  >"${backup_script}"
 /bin/chmod 700 "${backup_script}"
+: >"${backup_log}"
 
 /usr/bin/sed \
   -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
@@ -60,7 +66,16 @@ run_deploy() {
     | /usr/bin/env \
         FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
         FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
+        FAKE_RUNTIME_BACKUP_SCRIPT="${FAKE_RUNTIME_BACKUP_SCRIPT:-${backup_script}}" \
+        FAKE_RUNTIME_DEPLOY_SCRIPT="${FAKE_RUNTIME_DEPLOY_SCRIPT:-${test_script}}" \
+        FAKE_RUNTIME_EXTRA_DIR="${FAKE_RUNTIME_EXTRA_DIR:-false}" \
+        FAKE_RUNTIME_EXTRA_FILE="${FAKE_RUNTIME_EXTRA_FILE:-false}" \
+        FAKE_RUNTIME_INSECURE_SCRIPT_MODE="${FAKE_RUNTIME_INSECURE_SCRIPT_MODE:-false}" \
+        FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX="${FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX:-false}" \
+        FAKE_RUNTIME_SYMLINK="${FAKE_RUNTIME_SYMLINK:-false}" \
+        FAKE_BACKUP_LOG="${backup_log}" \
         FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
+        FAKE_CONFIG_PROJECT="${FAKE_CONFIG_PROJECT:-cubing-hub}" \
         FAKE_REVISION_ONE="${REVISION_ONE}" \
         FAKE_REVISION_TWO="${REVISION_TWO}" \
         FAKE_REVISION_THREE="${REVISION_THREE}" \
@@ -168,6 +183,42 @@ test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized
 /usr/bin/grep -Fxq "RUNTIME_CONFIG_REVISION=${REVISION_ONE}" "${state_file}"
 test -L "${current_link}"
 test ! -e "${app_dir}/runtime-config/pending"
+/usr/bin/tail -n 1 "${backup_log}" \
+  | /usr/bin/grep -Fxq \
+      "${bootstrap_candidate}/scripts/backup-cubing-hub.sh"
+
+legacy_v2_scripts="${test_root}/legacy-v2-scripts"
+/bin/mv "${bootstrap_candidate}/scripts" "${legacy_v2_scripts}"
+legacy_v2_content_sha="$(
+  {
+    /usr/bin/shasum -a 256 "${bootstrap_candidate}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${bootstrap_candidate}/nginx/cloudflare-edge-real-ip.conf"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+)"
+/usr/bin/sed \
+  -e "s#^RUNTIME_CONFIG_CONTENT_SHA256=.*#RUNTIME_CONFIG_CONTENT_SHA256=${legacy_v2_content_sha}#" \
+  "${state_file}" >"${state_file}.legacy-v2"
+/bin/mv "${state_file}.legacy-v2" "${state_file}"
+run_deploy "${REVISION_ONE}" keep test-user
+test "$(/usr/bin/readlink "${current_link}")" \
+  = "releases/${CONFIG_DIGEST#sha256:}"
+/bin/mv "${legacy_v2_scripts}" "${bootstrap_candidate}/scripts"
+restored_v2_content_sha="$(
+  {
+    /usr/bin/shasum -a 256 "${bootstrap_candidate}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${bootstrap_candidate}/nginx/cloudflare-edge-real-ip.conf"
+    /usr/bin/shasum -a 256 \
+      "${bootstrap_candidate}/scripts/backup-cubing-hub.sh"
+    /usr/bin/shasum -a 256 \
+      "${bootstrap_candidate}/scripts/deploy-cubing-hub.sh"
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+)"
+/usr/bin/sed \
+  -e "s#^RUNTIME_CONFIG_CONTENT_SHA256=.*#RUNTIME_CONFIG_CONTENT_SHA256=${restored_v2_content_sha}#" \
+  "${state_file}" >"${state_file}.restored-v2"
+/bin/mv "${state_file}.restored-v2" "${state_file}"
 
 /bin/mv "${state_file}" "${state_file}.both-missing"
 /bin/mv "${current_link}" "${current_link}.both-missing"
@@ -326,6 +377,10 @@ target_content_sha="$(
     /usr/bin/shasum -a 256 "${release_two}/compose.yaml"
     /usr/bin/shasum -a 256 \
       "${release_two}/nginx/cloudflare-edge-real-ip.conf"
+    /usr/bin/shasum -a 256 \
+      "${release_two}/scripts/backup-cubing-hub.sh"
+    /usr/bin/shasum -a 256 \
+      "${release_two}/scripts/deploy-cubing-hub.sh"
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
 )"
 {
@@ -457,6 +512,58 @@ FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT=',"FEATURE_FLAG":"enabled"' \
 /usr/bin/grep -Fxq "RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST_TWO}" "${state_file}"
 test "$(/usr/bin/readlink "${current_link}")" \
   = "releases/${CONFIG_DIGEST_TWO#sha256:}"
+
+verified_state_sha="$(
+  /usr/bin/shasum -a 256 "${state_file}" | /usr/bin/awk '{print $1}'
+)"
+verified_env_sha="$(
+  /usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}'
+)"
+verified_current_target="$(
+  /usr/bin/readlink "${current_link}"
+)"
+
+expect_artifact_preflight_failure() {
+  local label="$1"
+  local exit_code
+
+  set +e
+  FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
+    run_deploy \
+      "${REVISION_ONE}" \
+      update \
+      "${CONFIG_DIGEST_FIVE}" \
+      test-user \
+      >/dev/null 2>&1
+  exit_code="$?"
+  set -e
+
+  if [[ "${exit_code}" -ne 1 ]]; then
+    printf '%s must fail before the deployment transaction starts\n' "${label}" >&2
+    exit 1
+  fi
+  test ! -e "${pending_file}"
+  test "$(/usr/bin/readlink "${current_link}")" = "${verified_current_target}"
+  test "$(/usr/bin/shasum -a 256 "${state_file}" | /usr/bin/awk '{print $1}')" \
+    = "${verified_state_sha}"
+  test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" \
+    = "${verified_env_sha}"
+}
+
+FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX=true \
+  expect_artifact_preflight_failure "invalid candidate deploy syntax"
+FAKE_RUNTIME_INSECURE_SCRIPT_MODE=true \
+  expect_artifact_preflight_failure "insecure candidate script mode"
+FAKE_RUNTIME_EXTRA_FILE=true \
+  expect_artifact_preflight_failure "unexpected artifact file"
+FAKE_RUNTIME_EXTRA_DIR=true \
+  expect_artifact_preflight_failure "unexpected artifact directory"
+FAKE_RUNTIME_SYMLINK=true \
+  expect_artifact_preflight_failure "artifact symlink"
+FAKE_CONFIG_PROJECT=other-project \
+  expect_artifact_preflight_failure "runtime artifact project mismatch"
+FAKE_CONFIG_REVISION="${REVISION_TWO}" \
+  expect_artifact_preflight_failure "runtime artifact revision mismatch"
 
 expect_protected_failure() {
   local label="$1"

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT INT TERM
 app_dir="${test_root}/app"
 test_script="${test_root}/deploy-cubing-hub.sh"
 backup_script="${test_root}/backup.sh"
+runtime_backup_script="${test_root}/runtime-backup.sh"
 backup_log="${test_root}/backup.log"
 runtime_compose="${test_root}/runtime-compose.yaml"
 runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
@@ -48,7 +49,8 @@ printf '%s\n' \
   '#!/bin/bash' \
   'printf "%s\n" "${BASH_SOURCE[0]}" >>"${FAKE_BACKUP_LOG}"' \
   >"${backup_script}"
-/bin/chmod 700 "${backup_script}"
+/bin/cp "${backup_script}" "${runtime_backup_script}"
+/bin/chmod 700 "${backup_script}" "${runtime_backup_script}"
 : >"${backup_log}"
 
 /usr/bin/sed \
@@ -66,7 +68,7 @@ run_deploy() {
     | /usr/bin/env \
         FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
         FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
-        FAKE_RUNTIME_BACKUP_SCRIPT="${FAKE_RUNTIME_BACKUP_SCRIPT:-${backup_script}}" \
+        FAKE_RUNTIME_BACKUP_SCRIPT="${FAKE_RUNTIME_BACKUP_SCRIPT:-${runtime_backup_script}}" \
         FAKE_RUNTIME_DEPLOY_SCRIPT="${FAKE_RUNTIME_DEPLOY_SCRIPT:-${test_script}}" \
         FAKE_RUNTIME_EXTRA_DIR="${FAKE_RUNTIME_EXTRA_DIR:-false}" \
         FAKE_RUNTIME_EXTRA_FILE="${FAKE_RUNTIME_EXTRA_FILE:-false}" \
@@ -135,6 +137,9 @@ bootstrap_failure_marker="${test_root}/fail-bootstrap-app-up-once"
 bootstrap_docker_log="${test_root}/bootstrap-docker.log"
 : >"${bootstrap_docker_log}"
 
+# The first v2 update must use the artifact worker without requiring the fixed
+# pre-v2 backup fallback to be executable.
+/bin/chmod 600 "${backup_script}"
 set +e
 FAKE_DOCKER_LOG="${bootstrap_docker_log}" \
 FAKE_FAIL_APP_UP_ONCE_FILE="${bootstrap_failure_marker}" \
@@ -186,6 +191,7 @@ test ! -e "${app_dir}/runtime-config/pending"
 /usr/bin/tail -n 1 "${backup_log}" \
   | /usr/bin/grep -Fxq \
       "${bootstrap_candidate}/scripts/backup-cubing-hub.sh"
+/bin/chmod 700 "${backup_script}"
 
 legacy_v2_scripts="${test_root}/legacy-v2-scripts"
 /bin/mv "${bootstrap_candidate}/scripts" "${legacy_v2_scripts}"

--- a/homeserver/scripts/test-detect-runtime-config-change.sh
+++ b/homeserver/scripts/test-detect-runtime-config-change.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly PROJECT_ROOT="$(
+  CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
+)"
+readonly DETECTOR="${PROJECT_ROOT}/homeserver/scripts/detect-runtime-config-change.sh"
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-runtime-detector-test.XXXXXX")"
+
+cleanup() {
+  if [[ "$(/usr/bin/basename "${test_root}")" == cubing-runtime-detector-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+git -C "${test_root}" init --quiet
+git -C "${test_root}" config user.email test@example.invalid
+git -C "${test_root}" config user.name "Runtime Config Test"
+
+for path in \
+  .dockerignore \
+  homeserver/docker-compose.yml \
+  homeserver/nginx/cloudflare-edge-real-ip.conf \
+  homeserver/runtime-config.Dockerfile \
+  homeserver/scripts/backup-home-server.sh \
+  homeserver/scripts/deploy-home-server.sh \
+  frontend/src/app.jsx
+do
+  /bin/mkdir -p "$(/usr/bin/dirname "${test_root}/${path}")"
+  printf 'base\n' >"${test_root}/${path}"
+done
+
+git -C "${test_root}" add .
+git -C "${test_root}" commit --quiet -m base
+before_sha="$(git -C "${test_root}" rev-parse HEAD)"
+
+assert_mode_after_change() {
+  local expected_mode="$1"
+  local changed_path="$2"
+  local changed_sha
+  local actual_mode
+
+  printf 'changed\n' >>"${test_root}/${changed_path}"
+  git -C "${test_root}" add "${changed_path}"
+  git -C "${test_root}" commit --quiet -m "change ${changed_path}"
+  changed_sha="$(git -C "${test_root}" rev-parse HEAD)"
+  actual_mode="$(
+    (
+      cd "${test_root}"
+      /bin/bash "${DETECTOR}" "${before_sha}" "${changed_sha}" false
+    )
+  )"
+  if [[ "${actual_mode}" != "${expected_mode}" ]]; then
+    printf 'Expected %s for %s, got %s\n' \
+      "${expected_mode}" \
+      "${changed_path}" \
+      "${actual_mode}" \
+      >&2
+    exit 1
+  fi
+
+  before_sha="${changed_sha}"
+}
+
+for runtime_path in \
+  .dockerignore \
+  homeserver/docker-compose.yml \
+  homeserver/nginx/cloudflare-edge-real-ip.conf \
+  homeserver/runtime-config.Dockerfile \
+  homeserver/scripts/backup-home-server.sh \
+  homeserver/scripts/deploy-home-server.sh
+do
+  assert_mode_after_change update "${runtime_path}"
+done
+
+assert_mode_after_change keep frontend/src/app.jsx
+
+test "$(
+  cd "${test_root}"
+  /bin/bash "${DETECTOR}" \
+    0000000000000000000000000000000000000000 \
+    "${before_sha}" \
+    false
+)" = update
+
+test "$(
+  cd "${test_root}"
+  /bin/bash "${DETECTOR}" "${before_sha}" "${before_sha}" true
+)" = update
+
+printf 'Cubing Hub runtime config detector tests passed\n'

--- a/homeserver/scripts/test-runtime-script-bootstrap.sh
+++ b/homeserver/scripts/test-runtime-script-bootstrap.sh
@@ -1,0 +1,516 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly PROJECT_ROOT="$(
+  CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
+)"
+readonly DEPLOY_BOOTSTRAP_SOURCE="${PROJECT_ROOT}/homeserver/scripts/deploy-home-server-ci.sh"
+readonly BACKUP_BOOTSTRAP_SOURCE="${PROJECT_ROOT}/homeserver/scripts/backup-home-server-bootstrap.sh"
+readonly MOCK_DOCKER="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh"
+readonly MOCK_LOCKF="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-lockf.py"
+readonly REVISION_ONE=1111111111111111111111111111111111111111
+readonly REVISION_TWO=2222222222222222222222222222222222222222
+readonly LEGACY_CONFIG_REVISION=3333333333333333333333333333333333333333
+readonly LEGACY_CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly CONFIG_DIGEST=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+readonly INVALID_CONFIG_DIGEST=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-script-bootstrap-test.XXXXXX")"
+
+cleanup() {
+  if [[ "$(/usr/bin/basename "${test_root}")" == cubing-script-bootstrap-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+app_dir="${test_root}/app"
+deploy_bootstrap="${test_root}/deploy-cubing-hub-ci.sh"
+backup_bootstrap="${test_root}/backup-cubing-hub-bootstrap.sh"
+legacy_deploy_script="${test_root}/legacy-deploy.sh"
+legacy_backup_script="${test_root}/legacy-backup.sh"
+runtime_compose="${test_root}/runtime-compose.yaml"
+runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
+runtime_deploy_script="${test_root}/runtime-deploy.sh"
+runtime_backup_script="${test_root}/runtime-backup.sh"
+candidate_log="${test_root}/candidate.log"
+backup_marker="${test_root}/backup.marker"
+legacy_backup_marker="${test_root}/legacy-backup.marker"
+signal_ready="${test_root}/signal.ready"
+signal_marker="${test_root}/signal.marker"
+backup_lock_ready="${test_root}/backup-lock.ready"
+backup_lock_signal_marker="${test_root}/backup-lock-signal.marker"
+docker_log="${test_root}/docker.log"
+operation_lock="${app_dir}/.cubing-hub-operation.lock"
+
+lockf_bin=/usr/bin/lockf
+if [[ "${CUBING_TEST_FORCE_MOCK_LOCKF:-false}" == true ]] \
+  || [[ ! -x "${lockf_bin}" ]]
+then
+  lockf_bin="${MOCK_LOCKF}"
+fi
+
+/bin/mkdir -p "${app_dir}/runtime-config/releases"
+printf 'API_IMAGE=unchanged\nWEB_IMAGE=unchanged\n' >"${app_dir}/.env"
+printf 'name: cubing-hub\nservices: {}\n' >"${runtime_compose}"
+printf 'set_real_ip_from 192.0.2.0/24;\n' >"${runtime_real_ip}"
+
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -Eeuo pipefail' \
+  'if [[ "${1:-}" == recover ]]; then' \
+  '  printf "recover\n" >>"${FAKE_CANDIDATE_LOG}"' \
+  '  exit "${FAKE_CANDIDATE_EXIT_CODE:-0}"' \
+  'fi' \
+  'if { : <&3; } 2>/dev/null; then' \
+  '  exit 66' \
+  'fi' \
+  'token="$(/bin/cat)"' \
+  'if [[ "${token}" != test-token ]]; then' \
+  '  exit 65' \
+  'fi' \
+  'printf "%s\n" "$*" >>"${FAKE_CANDIDATE_LOG}"' \
+  'if [[ "${FAKE_CANDIDATE_WAIT:-false}" == true ]]; then' \
+  '  : >"${FAKE_SIGNAL_READY}"' \
+  '  trap '\''printf "term\n" >"${FAKE_SIGNAL_MARKER}"; exit 143'\'' TERM' \
+  '  while :; do /bin/sleep 1; done' \
+  'fi' \
+  'exit "${FAKE_CANDIDATE_EXIT_CODE:-0}"' \
+  >"${runtime_deploy_script}"
+
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -Eeuo pipefail' \
+  'printf "candidate\n" >>"${FAKE_BACKUP_MARKER}"' \
+  'if [[ "${FAKE_BACKUP_WAIT:-false}" == true ]]; then' \
+  '  : >"${FAKE_BACKUP_LOCK_READY}"' \
+  '  trap '\''printf "term\n" >"${FAKE_BACKUP_LOCK_SIGNAL_MARKER}"; exit 143'\'' TERM' \
+  '  while :; do /bin/sleep 1; done' \
+  'fi' \
+  >"${runtime_backup_script}"
+
+printf '%s\n' \
+  '#!/bin/bash' \
+  'exit 0' \
+  >"${legacy_deploy_script}"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "legacy\n" >>"${FAKE_LEGACY_BACKUP_MARKER}"' \
+  >"${legacy_backup_script}"
+
+/bin/chmod 700 \
+  "${runtime_deploy_script}" \
+  "${runtime_backup_script}" \
+  "${legacy_deploy_script}" \
+  "${legacy_backup_script}" \
+  "${MOCK_DOCKER}" \
+  "${MOCK_LOCKF}"
+
+/usr/bin/sed \
+  -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
+  -e "s#readonly LOCKF_BIN=/usr/bin/lockf#readonly LOCKF_BIN=${lockf_bin}#" \
+  -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+  -e "s#readonly LEGACY_DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh#readonly LEGACY_DEPLOY_SCRIPT=${legacy_deploy_script}#" \
+  "${DEPLOY_BOOTSTRAP_SOURCE}" >"${deploy_bootstrap}"
+/usr/bin/sed \
+  -e "s#readonly LOCKF_BIN=/usr/bin/lockf#readonly LOCKF_BIN=${lockf_bin}#" \
+  -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+  -e "s#readonly LEGACY_BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly LEGACY_BACKUP_SCRIPT=${legacy_backup_script}#" \
+  "${BACKUP_BOOTSTRAP_SOURCE}" >"${backup_bootstrap}"
+/bin/chmod 700 "${deploy_bootstrap}" "${backup_bootstrap}"
+
+runtime_content_sha256() {
+  local release_dir="$1"
+  {
+    /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+    /usr/bin/shasum -a 256 \
+      "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+    if [[ -f "${release_dir}/scripts/backup-cubing-hub.sh" ]] \
+      && [[ -f "${release_dir}/scripts/deploy-cubing-hub.sh" ]]
+    then
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/backup-cubing-hub.sh"
+      /usr/bin/shasum -a 256 \
+        "${release_dir}/scripts/deploy-cubing-hub.sh"
+    fi
+  } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+write_verified_state() {
+  local config_digest="$1"
+  local config_revision="$2"
+  local release_dir="$3"
+  local content_sha
+
+  content_sha="$(runtime_content_sha256 "${release_dir}")"
+  {
+    printf 'APPLICATION_REVISION=%s\n' "${REVISION_ONE}"
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${ZERO_DIGEST}"
+    printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' "${content_sha}"
+    printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${config_digest}"
+    printf 'RUNTIME_CONFIG_REVISION=%s\n' "${config_revision}"
+  } >"${app_dir}/runtime-config/state"
+  /bin/chmod 600 "${app_dir}/runtime-config/state"
+  if [[ ! -e "${app_dir}/.runtime-config-v2-initialized" ]]; then
+    printf 'RUNTIME_CONFIG_V2=initialized\n' \
+      >"${app_dir}/.runtime-config-v2-initialized"
+    /bin/chmod 400 "${app_dir}/.runtime-config-v2-initialized"
+  fi
+  /bin/rm -f -- "${app_dir}/runtime-config/current"
+  /bin/ln -s \
+    "releases/${config_digest#sha256:}" \
+    "${app_dir}/runtime-config/current"
+}
+
+legacy_release="${app_dir}/runtime-config/releases/${LEGACY_CONFIG_DIGEST#sha256:}"
+/bin/mkdir -p "${legacy_release}/nginx"
+/bin/cp "${runtime_compose}" "${legacy_release}/compose.yaml"
+/bin/cp \
+  "${runtime_real_ip}" \
+  "${legacy_release}/nginx/cloudflare-edge-real-ip.conf"
+write_verified_state \
+  "${LEGACY_CONFIG_DIGEST}" \
+  "${LEGACY_CONFIG_REVISION}" \
+  "${legacy_release}"
+
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}"
+/usr/bin/grep -Fxq legacy "${legacy_backup_marker}"
+test ! -e "${backup_marker}"
+legacy_backup_count="$(
+  /usr/bin/wc -l <"${legacy_backup_marker}" | /usr/bin/tr -d ' '
+)"
+
+run_update() {
+  printf 'test-token' \
+    | /usr/bin/env \
+        SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_ONE} update ${CONFIG_DIGEST} test-user" \
+        FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
+        FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
+        FAKE_RUNTIME_BACKUP_SCRIPT="${runtime_backup_script}" \
+        FAKE_RUNTIME_DEPLOY_SCRIPT="${runtime_deploy_script}" \
+        FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
+        FAKE_CONFIG_PROJECT="${FAKE_CONFIG_PROJECT:-cubing-hub}" \
+        FAKE_RUNTIME_EXTRA_DIR="${FAKE_RUNTIME_EXTRA_DIR:-false}" \
+        FAKE_RUNTIME_EXTRA_FILE="${FAKE_RUNTIME_EXTRA_FILE:-false}" \
+        FAKE_RUNTIME_INSECURE_SCRIPT_MODE="${FAKE_RUNTIME_INSECURE_SCRIPT_MODE:-false}" \
+        FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX="${FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX:-false}" \
+        FAKE_RUNTIME_SYMLINK="${FAKE_RUNTIME_SYMLINK:-false}" \
+        FAKE_CANDIDATE_EXIT_CODE="${FAKE_CANDIDATE_EXIT_CODE:-0}" \
+        FAKE_CANDIDATE_LOG="${candidate_log}" \
+        FAKE_BACKUP_MARKER="${backup_marker}" \
+        FAKE_SIGNAL_READY="${signal_ready}" \
+        FAKE_SIGNAL_MARKER="${signal_marker}" \
+        FAKE_DOCKER_LOG="${docker_log}" \
+        /bin/bash "${deploy_bootstrap}"
+}
+
+state_sha_before="$(
+  /usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" \
+    | /usr/bin/awk '{print $1}'
+)"
+env_sha_before="$(
+  /usr/bin/shasum -a 256 "${app_dir}/.env" \
+    | /usr/bin/awk '{print $1}'
+)"
+current_before="$(
+  /usr/bin/readlink "${app_dir}/runtime-config/current"
+)"
+
+set +e
+FAKE_CANDIDATE_EXIT_CODE=73 run_update >/dev/null 2>&1
+candidate_failure_exit_code="$?"
+set -e
+if [[ "${candidate_failure_exit_code}" -ne 73 ]]; then
+  printf 'Deploy bootstrap must preserve the candidate exit code\n' >&2
+  exit 1
+fi
+candidate_release="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
+test -d "${candidate_release}"
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" \
+  = "${state_sha_before}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" \
+  = "${env_sha_before}"
+test ! -e "${app_dir}/runtime-config/pending"
+
+run_update
+/usr/bin/grep -Fxq \
+  "${REVISION_ONE} update ${CONFIG_DIGEST} test-user" \
+  "${candidate_log}"
+
+write_verified_state "${CONFIG_DIGEST}" "${REVISION_ONE}" "${candidate_release}"
+
+printf 'test-token' \
+  | /usr/bin/env \
+      SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_TWO} keep test-user" \
+      FAKE_CANDIDATE_LOG="${candidate_log}" \
+      FAKE_BACKUP_MARKER="${backup_marker}" \
+      FAKE_SIGNAL_READY="${signal_ready}" \
+      FAKE_SIGNAL_MARKER="${signal_marker}" \
+      /bin/bash "${deploy_bootstrap}"
+/usr/bin/grep -Fxq "${REVISION_TWO} keep test-user" "${candidate_log}"
+
+/usr/bin/env \
+  FAKE_CANDIDATE_LOG="${candidate_log}" \
+  /bin/bash "${deploy_bootstrap}" recover
+/usr/bin/grep -Fxq recover "${candidate_log}"
+
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}"
+/usr/bin/grep -Fxq candidate "${backup_marker}"
+test "$(
+  /usr/bin/wc -l <"${legacy_backup_marker}" | /usr/bin/tr -d ' '
+)" = "${legacy_backup_count}"
+
+assert_preflight_failure() {
+  local label="$1"
+  local candidate_count_before
+  local exit_code
+
+  candidate_count_before="$(/usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' ')"
+  set +e
+  printf 'test-token' \
+    | /usr/bin/env \
+        SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_ONE} update ${INVALID_CONFIG_DIGEST} test-user" \
+        FAKE_RUNTIME_COMPOSE="${runtime_compose}" \
+        FAKE_RUNTIME_REAL_IP="${runtime_real_ip}" \
+        FAKE_RUNTIME_BACKUP_SCRIPT="${runtime_backup_script}" \
+        FAKE_RUNTIME_DEPLOY_SCRIPT="${runtime_deploy_script}" \
+        FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
+        FAKE_CONFIG_PROJECT="${FAKE_CONFIG_PROJECT:-cubing-hub}" \
+        FAKE_RUNTIME_EXTRA_DIR="${FAKE_RUNTIME_EXTRA_DIR:-false}" \
+        FAKE_RUNTIME_EXTRA_FILE="${FAKE_RUNTIME_EXTRA_FILE:-false}" \
+        FAKE_RUNTIME_INSECURE_SCRIPT_MODE="${FAKE_RUNTIME_INSECURE_SCRIPT_MODE:-false}" \
+        FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX="${FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX:-false}" \
+        FAKE_RUNTIME_SYMLINK="${FAKE_RUNTIME_SYMLINK:-false}" \
+        FAKE_CANDIDATE_LOG="${candidate_log}" \
+        FAKE_DOCKER_LOG="${docker_log}" \
+        /bin/bash "${deploy_bootstrap}" \
+        >/dev/null 2>&1
+  exit_code="$?"
+  set -e
+  if [[ "${exit_code}" -ne 1 ]]; then
+    printf '%s must fail before candidate execution\n' "${label}" >&2
+    exit 1
+  fi
+  test "$(/usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' ')" \
+    = "${candidate_count_before}"
+  test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
+    = "releases/${CONFIG_DIGEST#sha256:}"
+  test ! -e "${app_dir}/runtime-config/pending"
+}
+
+FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX=true \
+  assert_preflight_failure "invalid candidate deploy syntax"
+FAKE_RUNTIME_INSECURE_SCRIPT_MODE=true \
+  assert_preflight_failure "insecure candidate script mode"
+FAKE_RUNTIME_EXTRA_FILE=true \
+  assert_preflight_failure "unexpected artifact file"
+FAKE_RUNTIME_EXTRA_DIR=true \
+  assert_preflight_failure "unexpected artifact directory"
+FAKE_RUNTIME_SYMLINK=true \
+  assert_preflight_failure "artifact symlink"
+FAKE_CONFIG_PROJECT=other-project \
+  assert_preflight_failure "runtime artifact project mismatch"
+FAKE_CONFIG_REVISION="${REVISION_TWO}" \
+  assert_preflight_failure "runtime artifact revision mismatch"
+
+set +e
+SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_ONE} keep test-user; touch ${test_root}/injected" \
+  /bin/bash "${deploy_bootstrap}" >/dev/null 2>&1
+injection_exit_code="$?"
+/bin/bash "${deploy_bootstrap}" recover extra >/dev/null 2>&1
+extra_argument_exit_code="$?"
+set -e
+if [[ "${injection_exit_code}" -ne 64 || "${extra_argument_exit_code}" -ne 64 ]]; then
+  printf 'Deploy bootstrap must reject command injection and extra arguments\n' >&2
+  exit 1
+fi
+test ! -e "${test_root}/injected"
+
+state_sha_before_signal="$(
+  /usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" \
+    | /usr/bin/awk '{print $1}'
+)"
+env_sha_before_signal="$(
+  /usr/bin/shasum -a 256 "${app_dir}/.env" \
+    | /usr/bin/awk '{print $1}'
+)"
+set +e
+printf 'test-token' \
+  | /usr/bin/env \
+      SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_TWO} keep test-user" \
+      FAKE_CANDIDATE_WAIT=true \
+      FAKE_CANDIDATE_LOG="${candidate_log}" \
+      FAKE_BACKUP_MARKER="${backup_marker}" \
+      FAKE_SIGNAL_READY="${signal_ready}" \
+      FAKE_SIGNAL_MARKER="${signal_marker}" \
+      /bin/bash "${deploy_bootstrap}" &
+signal_pid="$!"
+set -e
+
+ready_attempt=0
+while [[ ! -f "${signal_ready}" && "${ready_attempt}" -lt 50 ]]; do
+  /bin/sleep 0.1
+  ready_attempt=$((ready_attempt + 1))
+done
+if [[ ! -f "${signal_ready}" ]]; then
+  printf 'Candidate did not become ready for the signal test\n' >&2
+  exit 1
+fi
+
+backup_count_before_contention="$(
+  /usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' '
+)"
+set +e
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}" >/dev/null 2>&1
+backup_contention_exit_code="$?"
+set -e
+if [[ "${backup_contention_exit_code}" -ne 75 ]]; then
+  printf 'Scheduled backup must fail while deploy holds the common lock\n' >&2
+  exit 1
+fi
+test "$(
+  /usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' '
+)" = "${backup_count_before_contention}"
+
+/bin/kill -TERM "${signal_pid}"
+set +e
+wait "${signal_pid}"
+signal_exit_code="$?"
+set -e
+if [[ "${signal_exit_code}" -ne 143 ]]; then
+  printf 'Deploy bootstrap must transfer TERM handling to the candidate\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq term "${signal_marker}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" \
+  = "${state_sha_before_signal}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" \
+  = "${env_sha_before_signal}"
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
+  = "releases/${CONFIG_DIGEST#sha256:}"
+
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  FAKE_BACKUP_WAIT=true \
+  FAKE_BACKUP_LOCK_READY="${backup_lock_ready}" \
+  FAKE_BACKUP_LOCK_SIGNAL_MARKER="${backup_lock_signal_marker}" \
+  /bin/bash "${backup_bootstrap}" &
+backup_lock_pid="$!"
+
+ready_attempt=0
+while [[ ! -f "${backup_lock_ready}" && "${ready_attempt}" -lt 50 ]]; do
+  /bin/sleep 0.1
+  ready_attempt=$((ready_attempt + 1))
+done
+if [[ ! -f "${backup_lock_ready}" ]]; then
+  printf 'Backup did not become ready for the common lock test\n' >&2
+  exit 1
+fi
+
+candidate_count_before_contention="$(
+  /usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' '
+)"
+docker_count_before_contention="$(
+  /usr/bin/wc -l <"${docker_log}" | /usr/bin/tr -d ' '
+)"
+set +e
+printf 'test-token' \
+  | /usr/bin/env \
+      SSH_ORIGINAL_COMMAND="deploy-cubing-hub-v2 ${REVISION_TWO} keep test-user" \
+      FAKE_CANDIDATE_LOG="${candidate_log}" \
+      FAKE_BACKUP_MARKER="${backup_marker}" \
+      FAKE_SIGNAL_READY="${signal_ready}" \
+      FAKE_SIGNAL_MARKER="${signal_marker}" \
+      /bin/bash "${deploy_bootstrap}" \
+      >/dev/null 2>&1
+deploy_contention_exit_code="$?"
+set -e
+if [[ "${deploy_contention_exit_code}" -ne 75 ]]; then
+  printf 'Deploy must fail while scheduled backup holds the common lock\n' >&2
+  exit 1
+fi
+test "$(
+  /usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' '
+)" = "${candidate_count_before_contention}"
+test "$(
+  /usr/bin/wc -l <"${docker_log}" | /usr/bin/tr -d ' '
+)" = "${docker_count_before_contention}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" \
+  = "${state_sha_before_signal}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" \
+  = "${env_sha_before_signal}"
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
+  = "releases/${CONFIG_DIGEST#sha256:}"
+
+/bin/kill -TERM "${backup_lock_pid}"
+set +e
+wait "${backup_lock_pid}"
+backup_lock_signal_exit_code="$?"
+set -e
+if [[ "${backup_lock_signal_exit_code}" -ne 143 ]]; then
+  printf 'Backup bootstrap must transfer TERM handling to the worker\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq term "${backup_lock_signal_marker}"
+
+/usr/bin/python3 -c '
+import os
+import stat
+import sys
+
+raise SystemExit(
+    0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o600 else 1
+)
+' "${operation_lock}"
+
+backup_count_before_pending="$(
+  /usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' '
+)"
+printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_TWO}" \
+  >"${app_dir}/runtime-config/pending"
+set +e
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}" >/dev/null 2>&1
+pending_backup_exit_code="$?"
+set -e
+if [[ "${pending_backup_exit_code}" -ne 1 ]]; then
+  printf 'Scheduled backup must fail while runtime recovery is pending\n' >&2
+  exit 1
+fi
+test "$(
+  /usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' '
+)" = "${backup_count_before_pending}"
+/bin/unlink "${app_dir}/runtime-config/pending"
+
+/bin/unlink "${operation_lock}"
+/bin/ln -s "${app_dir}/runtime-config/state" "${operation_lock}"
+set +e
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}" >/dev/null 2>&1
+unsafe_lock_exit_code="$?"
+set -e
+if [[ "${unsafe_lock_exit_code}" -ne 1 ]]; then
+  printf 'Unsafe common lock path must fail closed\n' >&2
+  exit 1
+fi
+
+printf 'Cubing Hub runtime script bootstrap tests passed\n'

--- a/homeserver/scripts/workflow-config.test.mjs
+++ b/homeserver/scripts/workflow-config.test.mjs
@@ -59,7 +59,7 @@ test("should_publishOnlyFullShaArm64ImagesToGhcr", () => {
   );
   assert.equal(
     countMatches(deployWorkflow, /platforms: linux\/arm64/g),
-    2,
+    3,
   );
   assert.match(
     deployWorkflow,
@@ -68,6 +68,18 @@ test("should_publishOnlyFullShaArm64ImagesToGhcr", () => {
   assert.match(
     deployWorkflow,
     /tags: \$\{\{ env\.WEB_IMAGE_NAME \}\}:\$\{\{ github\.sha \}\}/,
+  );
+  assert.match(
+    deployWorkflow,
+    /RUNTIME_CONFIG_IMAGE_NAME: ghcr\.io\/xxh3898\/cubing-hub-runtime-config/,
+  );
+  assert.match(
+    deployWorkflow,
+    /if: steps\.runtime-config-mode\.outputs\.mode == 'update'/,
+  );
+  assert.match(
+    deployWorkflow,
+    /deployments\?environment=production[\s\S]*steps\.deployed-base\.outputs\.sha/,
   );
   assert.doesNotMatch(deployWorkflow, /:latest|:main/);
   assert.doesNotMatch(deployWorkflow, /Docker Hub|DOCKERHUB|setup-qemu/);
@@ -89,6 +101,7 @@ test("should_applyLeastPrivilegePermissionsPerJob", () => {
 
   assert.match(publish, /actions: read/);
   assert.match(publish, /contents: read/);
+  assert.match(publish, /deployments: read/);
   assert.match(publish, /packages: write/);
   assert.doesNotMatch(publish, /id-token: write/);
 
@@ -109,26 +122,47 @@ test("should_useTailscaleOidcAndRestrictedSshForDeployment", () => {
   assert.match(deployWorkflow, /ping: home-mini/);
   assert.match(
     deployWorkflow,
-    /"deploy-cubing-hub \$\{GITHUB_SHA\} \$\{GITHUB_ACTOR\}"/,
+    /deploy_command="deploy-cubing-hub-v2 \$\{GITHUB_SHA\} keep \$\{GITHUB_ACTOR\}"/,
   );
   assert.match(deployWorkflow, /StrictHostKeyChecking=yes/);
   assert.doesNotMatch(deployWorkflow, /ssh-keyscan|StrictHostKeyChecking=no/);
 });
 
 test("should_pinEveryExternalActionToFullCommitSha", () => {
+  const expectedDockerBuildAction =
+    "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a";
+  const externalActions = [];
+  const quotedKeyAction = `example/action@${"a".repeat(40)}`;
+  const quotedValueAction = `example/quoted-action@${"b".repeat(40)}`;
+
+  assert.deepEqual(
+    actionReferences(
+      `steps:\n  - "uses": ${quotedKeyAction}\n  - 'uses': "${quotedValueAction}"\n`,
+    ),
+    [quotedKeyAction, quotedValueAction],
+  );
+  assert.throws(
+    () => actionReferences("steps:\n  - { uses: example/action@v1 }\n"),
+    /Unsupported uses syntax/,
+  );
+
   for (const workflow of [
     validateWorkflow,
     deployWorkflow,
     benchmarkWorkflow,
   ]) {
-    for (const line of workflow.matchAll(/^\s*uses:\s*(\S+)/gm)) {
-      const action = line[1];
+    for (const action of actionReferences(workflow)) {
       if (action.startsWith("./")) {
         continue;
       }
+      externalActions.push(action);
       assert.match(action, /^[^@]+@[0-9a-f]{40}$/);
+      if (action.startsWith("docker/build-push-action@")) {
+        assert.equal(action, expectedDockerBuildAction);
+      }
     }
   }
+  assert.ok(externalActions.length > 0);
 });
 
 test("should_haveNoActiveAwsEc2OrSelfHostedDeploymentPath", () => {
@@ -160,4 +194,27 @@ function workflowJob(workflow, jobId) {
 
 function countMatches(value, pattern) {
   return [...value.matchAll(pattern)].length;
+}
+
+function actionReferences(workflow) {
+  const possibleUsesKey = /(?:^|[\s{,-])(?:"uses"|'uses'|uses)\s*:/;
+  const actionReference =
+    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(?:"([^"]+)"|'([^']+)'|(\S+))(?:\s+#.*)?\s*$/;
+  const actions = [];
+
+  for (const line of workflow.split("\n")) {
+    const match = actionReference.exec(line);
+    if (match) {
+      actions.push(match[1] ?? match[2] ?? match[3]);
+      continue;
+    }
+    if (
+      !line.trimStart().startsWith("#") &&
+      possibleUsesKey.test(line)
+    ) {
+      assert.fail(`Unsupported uses syntax: ${line.trim()}`);
+    }
+  }
+
+  return actions;
 }


### PR DESCRIPTION
## 변경 사항

- Compose와 정적 운영 파일이 바뀐 배포에서만 immutable runtime-config image를 발행합니다.
- exact digest artifact, v2 state/current/pending, initialization marker와 verified recovery를 구현했습니다.
- active release 기반 backup과 MySQL, Redis, upload, network, process, health 보호 경계를 적용했습니다.
- deploy, backup, workflow focused test와 공식 배포·운영 문서를 추가했습니다.

## 변경 이유

애플리케이션 배포와 운영 설정 동기화를 분리하면서도 검증된 application/config pair만 commit하고 실패 시 이전 pair로 복구하기 위한 변경입니다.

## 검증

- macOS `/bin/bash` 3.2 syntax와 deploy/backup focused test 통과
- Docker Node 20 Nginx/operations/workflow test 26개 통과
- production/admin Compose render 통과
- `git diff --check` 통과
- 기존 `/AGENTS.md` ignore와 미추적 상태 확인

## 배포 전 주의

- 변경된 deploy/backup script는 runtime-config artifact가 자동 교체하지 않습니다.
- `main` 병합 전에 운영 고정 경로에 timestamp backup, checksum, mode, Bash preflight를 거쳐 사전 설치해야 합니다.
- 실제 운영 동기화와 배포는 별도 승인 후 진행합니다.
