### PR TITLE
feat: HomeOps 운영 이벤트 연동 추가

### DIFF
--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -41,6 +41,8 @@ backup을 시작하지 않는다. Persistent mode `600` lock file은 삭제하�
 
 ## 백업 실행
 
+Backup worker는 HomeOps에 실제 경로가 아닌 `cubing-hub/data/...` logical identifier와 결과 metadata만 전달한다. HomeOps는 backup을 실행하거나 archive를 읽지 않으며, event 전송 실패는 검증된 backup 생성과 retention을 차단하지 않는다.
+
 ```bash
 /Users/homeserver/Server/scripts/backup/backup-cubing-hub-bootstrap.sh
 ```

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -14,6 +14,8 @@
 
 ## CI 배포
 
+배포 worker는 실제 적용을 시작할 때와 종료할 때 HomeOps runtime-config의 고정 event reporter에 `RUNNING` 및 `SUCCESS`/`FAILED`/`ROLLED_BACK` metadata를 전달한다. Reporter는 HomeOps `.env`의 전용 ingestion secret과 `smoke.origin`을 읽고 전송 전 local spool에 기록한다. HomeOps 또는 reporter가 unavailable이어도 Cubing Hub 배포·rollback 판정은 바뀌지 않는다. Reporter·secret·spool 설치와 운영 활성화는 HomeOps runbook의 별도 승인 절차다.
+
 GitHub Actions는 GHCR token을 stdin으로 전달하고 forced-command SSH에서
 아래 논리 명령만 호출한다.
 

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -167,8 +167,9 @@ lifecycle을 `FAILED`로 닫을 수 있다. v2 worker는 검증된 previous/targ
 context만 남고 operational `pending`이 없다면 recovery는 운영 service를
 변경하지 않고 event만 종료한다. Legacy worker에는 이 별도 context를 적용하지
 않는다. 다음 정상 v2 배포도 유효한 context-only lifecycle을 먼저 `FAILED`로
-종료할 수 있으며, context 검증·정리에 실패하면 새 telemetry만 생략하고 배포
-자체는 계속한다.
+종료할 수 있으며, operational `pending`이 유효한 상태에서 별도 context가
+malformed이거나 target SHA가 다르면 그 context는 보존하고 새 recovery telemetry만
+생략한 채 operational recovery를 계속한다.
 
 새 pending state도 중단 시점의 HomeOps deployment event key와 시작 시각을
 보존한다. Operational pending이 있으면 recovery는 남아 있는 lifecycle을
@@ -177,6 +178,12 @@ context 원자 저장에 실패하면 새 telemetry event는 시작하지 않지
 transaction recovery는 계속한다. Target pair 확정은 `SUCCESS`, previous pair
 또는 bootstrap 복원은 `ROLLED_BACK`, recovery 실패는 `FAILED`로 기록한다.
 기존 4-key pending state도 telemetry context 없이 계속 복구할 수 있다.
+
+Operational `pending`의 생성 시점은 mutation 위험에 맞춘다. first deployment는
+DB/Redis bootstrap이 첫 mutation이므로 그 전에 pending을 쓴다. 기존 update는
+DB running-service preflight와 predeploy logical backup이 read-only/backup 단계이므로
+그 성공 뒤, one-shot migration 직전에 pending을 쓴다. 따라서 기존 update의 DB
+미기동 또는 backup 실패는 이후 deploy를 막는 stale pending을 남기지 않는다.
 
 - 성공 state가 이미 target pair라면 `.env`와 실행 service를 검증한 뒤
   검증된 target release로 stale `current` pointer를 원자 조정하고 pending

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -158,11 +158,25 @@ script로 recovery를 전달한다. Recovery는 pending key와 SHA/digest 형식
 마지막 검증 state, Compose·Nginx·deploy/backup script allowlist와 content
 hash를 먼저 대조한다.
 
-새 pending state는 중단 시점의 HomeOps deployment event key와 시작 시각도
-보존한다. Recovery는 남아 있는 lifecycle을 `FAILED`로 닫고 고유한 recovery
-lifecycle을 시작한다. Target pair 확정은 `SUCCESS`, previous pair 또는
-bootstrap 복원은 `ROLLED_BACK`, recovery 실패는 `FAILED`로 기록한다. 기존
-4-key pending state도 telemetry context 없이 계속 복구할 수 있다.
+배포 worker는 `RUNNING` 전송 전에
+`runtime-config/homeops-deployment`에 event key, 시작 시각, target SHA를
+원자 저장한다. 따라서 application/runtime image pull처럼 transaction pending
+생성 전 단계에서 host restart 또는 `SIGKILL`이 발생해도 `recover`가 중단
+lifecycle을 `FAILED`로 닫을 수 있다. v2 worker는 검증된 previous/target pair를
+담은 operational `pending`을 첫 data-service mutation보다 먼저 저장한다. 이
+context만 남고 operational `pending`이 없다면 recovery는 운영 service를
+변경하지 않고 event만 종료한다. Legacy worker에는 이 별도 context를 적용하지
+않는다. 다음 정상 v2 배포도 유효한 context-only lifecycle을 먼저 `FAILED`로
+종료할 수 있으며, context 검증·정리에 실패하면 새 telemetry만 생략하고 배포
+자체는 계속한다.
+
+새 pending state도 중단 시점의 HomeOps deployment event key와 시작 시각을
+보존한다. Operational pending이 있으면 recovery는 남아 있는 lifecycle을
+`FAILED`로 닫고 고유한 recovery lifecycle을 시작한다. Recovery lifecycle용
+context 원자 저장에 실패하면 새 telemetry event는 시작하지 않지만 실제
+transaction recovery는 계속한다. Target pair 확정은 `SUCCESS`, previous pair
+또는 bootstrap 복원은 `ROLLED_BACK`, recovery 실패는 `FAILED`로 기록한다.
+기존 4-key pending state도 telemetry context 없이 계속 복구할 수 있다.
 
 - 성공 state가 이미 target pair라면 `.env`와 실행 service를 검증한 뒤
   검증된 target release로 stale `current` pointer를 원자 조정하고 pending

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -158,6 +158,12 @@ script로 recovery를 전달한다. Recovery는 pending key와 SHA/digest 형식
 마지막 검증 state, Compose·Nginx·deploy/backup script allowlist와 content
 hash를 먼저 대조한다.
 
+새 pending state는 중단 시점의 HomeOps deployment event key와 시작 시각도
+보존한다. Recovery는 남아 있는 lifecycle을 `FAILED`로 닫고 고유한 recovery
+lifecycle을 시작한다. Target pair 확정은 `SUCCESS`, previous pair 또는
+bootstrap 복원은 `ROLLED_BACK`, recovery 실패는 `FAILED`로 기록한다. 기존
+4-key pending state도 telemetry context 없이 계속 복구할 수 있다.
+
 - 성공 state가 이미 target pair라면 `.env`와 실행 service를 검증한 뒤
   검증된 target release로 stale `current` pointer를 원자 조정하고 pending
   marker를 정리한다.

--- a/homeserver/scripts/backup-home-server.sh
+++ b/homeserver/scripts/backup-home-server.sh
@@ -6,6 +6,7 @@ umask 077
 
 readonly DOCKER_BIN=/usr/local/bin/docker
 readonly PYTHON_BIN=/usr/bin/python3
+readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
 readonly PROJECT_NAME=cubing-hub
 readonly LEGACY_COMPOSE_FILE="${APP_DIR}/compose.yaml"
@@ -23,6 +24,49 @@ readonly BACKUP_RETENTION_COUNT=3
 work_dir=
 final_dir=
 active_compose_file=
+homeops_backup_started_at=
+homeops_backup_event_key=
+
+report_homeops_backup() {
+  local status="$1"
+  local finished_at="$2"
+  local logical_location="${3:-}"
+  local size_bytes="${4:-}"
+  local payload
+
+  if [[ -z "${homeops_backup_event_key}" ]]; then
+    return
+  fi
+  if [[ ! -f "${HOMEOPS_EVENT_REPORTER}" || -L "${HOMEOPS_EVENT_REPORTER}" || ! -x "${HOMEOPS_EVENT_REPORTER}" ]]; then
+    printf 'HomeOps backup event reporter is unavailable\n' >&2
+    return
+  fi
+  payload="$(
+    "${PYTHON_BIN}" - \
+      "${homeops_backup_event_key}" "${status}" "${homeops_backup_started_at}" \
+      "${finished_at}" "${logical_location}" "${size_bytes}" <<'PY'
+import json, sys
+event_key, status, started_at, finished_at, logical_location, size_bytes = sys.argv[1:]
+print(json.dumps({
+    "eventKey": event_key,
+    "project": "cubing-hub",
+    "databaseType": "MYSQL",
+    "logicalLocation": logical_location or None,
+    "status": status,
+    "startedAt": started_at,
+    "finishedAt": finished_at or None,
+    "sizeBytes": int(size_bytes) if size_bytes else None,
+    "failureSummary": "backup worker exited unsuccessfully" if status == "FAILED" else None,
+}, separators=(",", ":")))
+PY
+  )" || {
+    printf 'HomeOps backup event payload could not be generated\n' >&2
+    return
+  }
+  if ! printf '%s' "${payload}" | "${HOMEOPS_EVENT_REPORTER}" backups; then
+    printf 'HomeOps backup event could not be retained\n' >&2
+  fi
+}
 
 usage() {
   printf 'Usage: backup-cubing-hub.sh\n' >&2
@@ -34,9 +78,25 @@ fail() {
 }
 
 cleanup() {
+  local exit_status="$?"
+  local finished_at
+  local logical_location=
+  local size_bytes=
+
+  if [[ -n "${homeops_backup_event_key}" ]]; then
+    finished_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    if [[ "${exit_status}" -eq 0 && -n "${final_dir}" && -d "${final_dir}" ]]; then
+      logical_location="cubing-hub/data/$(/usr/bin/basename "${final_dir}")"
+      size_bytes="$(/usr/bin/du -sk "${final_dir}" | /usr/bin/awk '{ print $1 * 1024 }')"
+      report_homeops_backup SUCCESS "${finished_at}" "${logical_location}" "${size_bytes}"
+    else
+      report_homeops_backup FAILED "${finished_at}" "" ""
+    fi
+  fi
   if [[ -n "${work_dir}" && -d "${work_dir}" ]]; then
     printf 'Partial backup remains for inspection: %s\n' "${work_dir}" >&2
   fi
+  return "${exit_status}"
 }
 
 trap cleanup EXIT
@@ -309,6 +369,9 @@ fi
 /bin/mkdir -p "${BACKUP_ROOT}"
 
 timestamp="$(/bin/date -u '+%Y%m%dT%H%M%SZ')"
+homeops_backup_started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+homeops_backup_event_key="cubing-hub:backup:${timestamp}"
+report_homeops_backup RUNNING "" "cubing-hub/data/cubing-hub-production-${timestamp}" ""
 work_dir="$(
   /usr/bin/mktemp -d "${BACKUP_ROOT}/.cubing-hub-backup.XXXXXX"
 )"

--- a/homeserver/scripts/backup-home-server.sh
+++ b/homeserver/scripts/backup-home-server.sh
@@ -179,6 +179,12 @@ if [[ ! -x "${PYTHON_BIN}" ]]; then
   fail "Python is not executable: ${PYTHON_BIN}"
 fi
 
+started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+timestamp="$(/bin/date -u '+%Y%m%dT%H%M%SZ')"
+homeops_backup_started_at="${started_at}"
+homeops_backup_event_key="cubing-hub:backup:${timestamp}"
+report_homeops_backup RUNNING "" "cubing-hub/data/cubing-hub-production-${timestamp}" "" || true
+
 validate_heartbeat_url() {
   local value="$1"
 
@@ -528,11 +534,6 @@ fi
 
 prepare_private_directory "${BACKUP_ROOT}"
 
-started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
-timestamp="$(/bin/date -u '+%Y%m%dT%H%M%SZ')"
-homeops_backup_started_at="${started_at}"
-homeops_backup_event_key="cubing-hub:backup:${timestamp}"
-report_homeops_backup RUNNING "" "cubing-hub/data/cubing-hub-production-${timestamp}" "" || true
 work_dir="$(
   /usr/bin/mktemp -d "${BACKUP_ROOT}/.cubing-hub-backup.XXXXXX"
 )"

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 
 readonly DOCKER_BIN=/usr/local/bin/docker
 readonly PYTHON_BIN=/usr/bin/python3
+readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
 readonly PROJECT_NAME=cubing-hub
 readonly LEGACY_COMPOSE_FILE="${APP_DIR}/compose.yaml"
@@ -190,10 +191,72 @@ initialization_temp=
 config_container_id=
 prepared_release=
 logged_in=false
+homeops_deployment_started_at=
+homeops_deployment_event_key=
+homeops_rollback_succeeded=false
+
+report_homeops_deployment() {
+  local status="$1"
+  local finished_at="$2"
+  local payload
+
+  if [[ -z "${homeops_deployment_event_key}" ]]; then
+    return
+  fi
+  if [[ ! -f "${HOMEOPS_EVENT_REPORTER}" || -L "${HOMEOPS_EVENT_REPORTER}" || ! -x "${HOMEOPS_EVENT_REPORTER}" ]]; then
+    printf 'HomeOps deployment event reporter is unavailable\n' >&2
+    return
+  fi
+  payload="$(
+    "${PYTHON_BIN}" - \
+      "${homeops_deployment_event_key}" \
+      "${normalized_sha}" \
+      "${previous_sha:-}" \
+      "${status}" \
+      "${homeops_deployment_started_at}" \
+      "${finished_at}" <<'PY'
+import json, sys
+event_key, commit_sha, previous_sha, status, started_at, finished_at = sys.argv[1:]
+print(json.dumps({
+    "eventKey": event_key,
+    "project": "cubing-hub",
+    "environment": "production",
+    "branch": "main",
+    "commitSha": commit_sha,
+    "imageTag": commit_sha,
+    "previousCommitSha": previous_sha or None,
+    "status": status,
+    "startedAt": started_at,
+    "finishedAt": finished_at or None,
+    "failureStage": "deploy-worker" if status == "FAILED" else None,
+    "failureSummary": "deployment worker exited unsuccessfully" if status == "FAILED" else None,
+    "actor": "home-server-deploy",
+    "rollback": status == "ROLLED_BACK",
+}, separators=(",", ":")))
+PY
+  )" || {
+    printf 'HomeOps deployment event payload could not be generated\n' >&2
+    return
+  }
+  if ! printf '%s' "${payload}" | "${HOMEOPS_EVENT_REPORTER}" deployments; then
+    printf 'HomeOps deployment event could not be retained\n' >&2
+  fi
+}
 
 # ShellCheck cannot infer that trap invokes this cleanup function.
 # shellcheck disable=SC2329
 cleanup() {
+  local exit_status="$?"
+
+  if [[ -n "${homeops_deployment_event_key}" ]]; then
+    if [[ "${exit_status}" -eq 0 ]]; then
+      report_homeops_deployment SUCCESS "$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    elif [[ "${homeops_rollback_succeeded}" == true ]]; then
+      report_homeops_deployment ROLLED_BACK "$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    else
+      report_homeops_deployment FAILED "$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    fi
+  fi
   registry_token=
 
   if [[ -n "${env_temp}" && -e "${env_temp}" ]]; then
@@ -232,6 +295,7 @@ cleanup() {
   if [[ "$(/usr/bin/basename "${docker_config_dir}")" == cubing-hub-docker-config.* ]]; then
     /bin/rm -rf -- "${docker_config_dir}"
   fi
+  return "${exit_status}"
 }
 
 trap cleanup EXIT
@@ -1395,6 +1459,10 @@ if ! /usr/bin/grep -qx db <<<"${running_services}"; then
     db redis
 fi
 
+homeops_deployment_started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
+report_homeops_deployment RUNNING ""
+
 if [[ -n "${previous_sha}" ]]; then
   if [[ ! -x "${active_backup_script}" || -L "${active_backup_script}" ]]; then
     fail "verified production backup script is missing or unsafe"
@@ -1465,6 +1533,7 @@ if [[ -n "${previous_sha}" ]]; then
       if [[ "${legacy_mode}" == false ]]; then
         /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
       fi
+      homeops_rollback_succeeded=true
       printf 'Application image rollback succeeded: %s\n' "${previous_sha}" >&2
     fi
   else

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 
 readonly DOCKER_BIN=/usr/local/bin/docker
 readonly PYTHON_BIN=/usr/bin/python3
+readonly RM_BIN=/bin/rm
 readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py
 readonly CURL_BIN=/usr/bin/curl
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
@@ -257,23 +258,16 @@ PY
 # shellcheck disable=SC2329
 cleanup() {
   local exit_status="$?"
+  local cleanup_failed=false
   local finished_at=
 
-  if [[ -n "${homeops_deployment_event_key}" ]]; then
-    if ! finished_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"; then
-      printf 'HomeOps deployment completion time could not be generated\n' >&2
-    elif [[ "${exit_status}" -eq 0 ]]; then
-      report_homeops_deployment SUCCESS "${finished_at}" || true
-    elif [[ "${homeops_rollback_succeeded}" == true ]]; then
-      report_homeops_deployment ROLLED_BACK "${finished_at}" || true
-    else
-      report_homeops_deployment FAILED "${finished_at}" || true
-    fi
-  fi
   registry_token=
 
-  if [[ -n "${env_temp}" && -e "${env_temp}" ]]; then
-    /bin/unlink "${env_temp}"
+  if [[ -n "${env_temp}" && -e "${env_temp}" ]] \
+    && ! "${RM_BIN}" -f -- "${env_temp}"
+  then
+    printf 'Deployment cleanup failed to remove temporary environment file\n' >&2
+    cleanup_failed=true
   fi
 
   if [[ -n "${config_container_id}" ]]; then
@@ -286,15 +280,21 @@ cleanup() {
     "${current_link_temp}" \
     "${initialization_temp}"
   do
-    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]]; then
-      /bin/rm -f -- "${cleanup_path}"
+    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]] \
+      && ! "${RM_BIN}" -f -- "${cleanup_path}"
+    then
+      printf 'Deployment cleanup failed to remove temporary runtime-config path\n' >&2
+      cleanup_failed=true
     fi
   done
 
   if [[ -n "${release_temp}" && -d "${release_temp}" ]] \
     && [[ "$(/usr/bin/basename "${release_temp}")" == .tmp.* ]]
   then
-    /bin/rm -rf -- "${release_temp}"
+    if ! "${RM_BIN}" -rf -- "${release_temp}"; then
+      printf 'Deployment cleanup failed to remove temporary runtime-config release\n' >&2
+      cleanup_failed=true
+    fi
   fi
 
   if [[ "${logged_in}" == true ]]; then
@@ -306,7 +306,26 @@ cleanup() {
   fi
 
   if [[ "$(/usr/bin/basename "${docker_config_dir}")" == cubing-hub-docker-config.* ]]; then
-    /bin/rm -rf -- "${docker_config_dir}"
+    if ! "${RM_BIN}" -rf -- "${docker_config_dir}"; then
+      printf 'Deployment cleanup failed to remove temporary Docker credentials\n' >&2
+      cleanup_failed=true
+    fi
+  fi
+
+  if [[ "${cleanup_failed}" == true && "${exit_status}" -eq 0 ]]; then
+    exit_status=1
+  fi
+
+  if [[ -n "${homeops_deployment_event_key}" ]]; then
+    if ! finished_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"; then
+      printf 'HomeOps deployment completion time could not be generated\n' >&2
+    elif [[ "${exit_status}" -eq 0 ]]; then
+      report_homeops_deployment SUCCESS "${finished_at}" || true
+    elif [[ "${homeops_rollback_succeeded}" == true ]]; then
+      report_homeops_deployment ROLLED_BACK "${finished_at}" || true
+    else
+      report_homeops_deployment FAILED "${finished_at}" || true
+    fi
   fi
   return "${exit_status}"
 }
@@ -1368,6 +1387,9 @@ normalized_sha="$(
   printf '%s' "${commit_sha}" \
     | /usr/bin/tr '[:upper:]' '[:lower:]'
 )"
+homeops_deployment_started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
+report_homeops_deployment RUNNING "" || true
 new_api_image="${API_IMAGE_REPOSITORY}:${normalized_sha}"
 new_web_image="${WEB_IMAGE_REPOSITORY}:${normalized_sha}"
 current_api_image="$(read_env_value API_IMAGE)"
@@ -1540,10 +1562,6 @@ if ! /usr/bin/grep -qx db <<<"${running_services}"; then
     --wait-timeout "${HEALTH_TIMEOUT_SECONDS}" \
     db redis
 fi
-
-homeops_deployment_started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
-homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
-report_homeops_deployment RUNNING "" || true
 
 if [[ -n "${previous_sha}" ]]; then
   if [[ ! -x "${active_backup_script}" || -L "${active_backup_script}" ]]; then

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -1071,7 +1071,7 @@ remove_homeops_context_if_owned() {
   fi
   persisted_event_key="$(
     read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
-  )" || return
+  )" || return 0
   if [[ "${persisted_event_key}" != "${homeops_deployment_event_key}" ]]; then
     return
   fi
@@ -1227,6 +1227,7 @@ initialize_homeops_recovery_event() {
   local context_event_key=
   local context_started_at=
   local context_target_sha=
+  local context_is_usable=true
 
   validate_pending_state
   recovery_previous_sha="$(read_pending_value PREVIOUS_APPLICATION_REVISION)"
@@ -1259,22 +1260,27 @@ initialize_homeops_recovery_event() {
 
   if [[ -e "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" || -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]; then
     if ! validate_homeops_context; then
-      fail "HomeOps deployment context is invalid"
-    fi
-    context_event_key="$(
+      printf 'HomeOps deployment context is invalid; continuing operational recovery without new telemetry\n' >&2
+      context_is_usable=false
+    elif ! context_event_key="$(
       read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
-    )"
-    context_started_at="$(
-      read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT
-    )"
-    context_target_sha="$(
-      read_homeops_context_value TARGET_APPLICATION_REVISION
-    )"
-    if [[ "${context_target_sha}" != "${recovery_target_sha}" ]]; then
-      fail "HomeOps deployment context does not match the pending target"
+    )" \
+      || ! context_started_at="$(
+        read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT
+      )" \
+      || ! context_target_sha="$(
+        read_homeops_context_value TARGET_APPLICATION_REVISION
+      )"
+    then
+      printf 'HomeOps deployment context could not be read; continuing operational recovery without new telemetry\n' >&2
+      context_is_usable=false
+    elif [[ "${context_target_sha}" != "${recovery_target_sha}" ]]; then
+      printf 'HomeOps deployment context does not match the pending target; continuing operational recovery without new telemetry\n' >&2
+      context_is_usable=false
+    else
+      persisted_event_key="${context_event_key}"
+      persisted_started_at="${context_started_at}"
     fi
-    persisted_event_key="${context_event_key}"
-    persisted_started_at="${context_started_at}"
   fi
 
   if ! recovery_started_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
@@ -1295,7 +1301,11 @@ initialize_homeops_recovery_event() {
   fi
 
   recovery_event_key="cubing-hub:deploy-recovery:${recovery_target_sha}:${recovery_started_at}:$$"
-  if write_homeops_context \
+  if [[ "${context_is_usable}" == false ]]; then
+    printf 'HomeOps recovery context is unusable; continuing operational recovery without new telemetry\n' >&2
+    homeops_deployment_event_key=
+    homeops_deployment_started_at=
+  elif write_homeops_context \
     "${recovery_event_key}" \
     "${recovery_started_at}" \
     "${recovery_target_sha}"
@@ -1304,7 +1314,7 @@ initialize_homeops_recovery_event() {
     homeops_deployment_started_at="${recovery_started_at}"
     report_homeops_deployment RUNNING "" || true
   else
-    printf 'HomeOps recovery context could not be retained; continuing operational recovery\n' >&2
+    printf 'HomeOps recovery context could not be retained; continuing operational recovery without new telemetry\n' >&2
     homeops_deployment_event_key=
     homeops_deployment_started_at=
   fi
@@ -1836,7 +1846,7 @@ validation_baseline_compose_file=
 validation_baseline_api_image=
 validation_baseline_web_image=
 
-if [[ "${legacy_mode}" == false ]]; then
+if [[ "${legacy_mode}" == false && -z "${previous_sha}" ]]; then
   previous_config_digest="${current_config_digest:-${ZERO_DIGEST}}"
   write_pending_state \
     "${previous_sha:-${ZERO_SHA}}" \
@@ -1886,6 +1896,17 @@ if [[ -n "${previous_sha}" ]]; then
   else
     "${active_backup_script}" --trigger predeploy
   fi
+fi
+
+if [[ "${legacy_mode}" == false && -n "${previous_sha}" ]]; then
+  previous_config_digest="${current_config_digest:-${ZERO_DIGEST}}"
+  write_pending_state \
+    "${previous_sha}" \
+    "${previous_config_digest}" \
+    "${normalized_sha}" \
+    "${candidate_config_digest}" \
+    "${homeops_deployment_event_key}" \
+    "${homeops_deployment_started_at}"
 fi
 
 active_compose_file="${candidate_compose_file}"

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 readonly DOCKER_BIN=/usr/local/bin/docker
 readonly PYTHON_BIN=/usr/bin/python3
 readonly RM_BIN=/bin/rm
+readonly DATE_BIN=/bin/date
 readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py
 readonly CURL_BIN=/usr/bin/curl
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
@@ -317,7 +318,7 @@ cleanup() {
   fi
 
   if [[ -n "${homeops_deployment_event_key}" ]]; then
-    if ! finished_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"; then
+    if ! finished_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
       printf 'HomeOps deployment completion time could not be generated\n' >&2
     elif [[ "${exit_status}" -eq 0 ]]; then
       report_homeops_deployment SUCCESS "${finished_at}" || true
@@ -1387,9 +1388,13 @@ normalized_sha="$(
   printf '%s' "${commit_sha}" \
     | /usr/bin/tr '[:upper:]' '[:lower:]'
 )"
-homeops_deployment_started_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
-homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
-report_homeops_deployment RUNNING "" || true
+if ! homeops_deployment_started_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
+  printf 'HomeOps deployment start time could not be generated\n' >&2
+  homeops_deployment_started_at=
+else
+  homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
+  report_homeops_deployment RUNNING "" || true
+fi
 new_api_image="${API_IMAGE_REPOSITORY}:${normalized_sha}"
 new_web_image="${WEB_IMAGE_REPOSITORY}:${normalized_sha}"
 current_api_image="$(read_env_value API_IMAGE)"

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -206,6 +206,10 @@ logged_in=false
 homeops_deployment_started_at=
 homeops_deployment_event_key=
 homeops_rollback_succeeded=false
+homeops_success_status=SUCCESS
+pending_has_homeops_context=false
+normalized_sha=
+previous_sha=
 
 report_homeops_deployment() {
   local status="$1"
@@ -321,7 +325,7 @@ cleanup() {
     if ! finished_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
       printf 'HomeOps deployment completion time could not be generated\n' >&2
     elif [[ "${exit_status}" -eq 0 ]]; then
-      report_homeops_deployment SUCCESS "${finished_at}" || true
+      report_homeops_deployment "${homeops_success_status}" "${finished_at}" || true
     elif [[ "${homeops_rollback_succeeded}" == true ]]; then
       report_homeops_deployment ROLLED_BACK "${finished_at}" || true
     else
@@ -955,12 +959,16 @@ write_pending_state() {
   local previous_config_digest="$2"
   local target_sha="$3"
   local target_config_digest="$4"
+  local homeops_event_key="${5:-}"
+  local homeops_started_at="${6:-}"
 
   /bin/mkdir -p "${RUNTIME_CONFIG_ROOT}"
   pending_temp="$(
     /usr/bin/mktemp "${RUNTIME_CONFIG_ROOT}/.pending.tmp.XXXXXX"
   )"
   {
+    printf 'HOMEOPS_DEPLOYMENT_EVENT_KEY=%s\n' "${homeops_event_key}"
+    printf 'HOMEOPS_DEPLOYMENT_STARTED_AT=%s\n' "${homeops_started_at}"
     printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${previous_sha}"
     printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_config_digest}"
     printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_sha}"
@@ -1060,9 +1068,80 @@ validate_pending_state() {
     /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_PENDING}" \
       | LC_ALL=C /usr/bin/sort
   )"
-  if [[ "${keys}" != $'PREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nTARGET_APPLICATION_REVISION\nTARGET_RUNTIME_CONFIG_DIGEST' ]]; then
+  pending_has_homeops_context=false
+  if [[ "${keys}" == $'HOMEOPS_DEPLOYMENT_EVENT_KEY\nHOMEOPS_DEPLOYMENT_STARTED_AT\nPREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nTARGET_APPLICATION_REVISION\nTARGET_RUNTIME_CONFIG_DIGEST' ]]; then
+    pending_has_homeops_context=true
+  elif [[ "${keys}" != $'PREVIOUS_APPLICATION_REVISION\nPREVIOUS_RUNTIME_CONFIG_DIGEST\nTARGET_APPLICATION_REVISION\nTARGET_RUNTIME_CONFIG_DIGEST' ]]; then
     fail "runtime config pending state keys are invalid"
   fi
+}
+
+initialize_homeops_recovery_event() {
+  local persisted_event_key=
+  local persisted_started_at=
+  local recovery_event_key
+  local recovery_started_at
+  local recovery_previous_digest
+  local recovery_previous_sha
+  local recovery_target_digest
+  local recovery_target_sha
+
+  validate_pending_state
+  recovery_previous_sha="$(read_pending_value PREVIOUS_APPLICATION_REVISION)"
+  recovery_previous_digest="$(read_pending_value PREVIOUS_RUNTIME_CONFIG_DIGEST)"
+  recovery_target_sha="$(read_pending_value TARGET_APPLICATION_REVISION)"
+  recovery_target_digest="$(read_pending_value TARGET_RUNTIME_CONFIG_DIGEST)"
+  if [[ ! "${recovery_previous_sha}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "${recovery_target_sha}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "${recovery_previous_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ ! "${recovery_target_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ "${recovery_target_digest}" == "${ZERO_DIGEST}" ]]
+  then
+    fail "runtime config pending state values are invalid"
+  fi
+
+  if [[ "${pending_has_homeops_context}" == true ]]; then
+    persisted_event_key="$(read_pending_value HOMEOPS_DEPLOYMENT_EVENT_KEY)"
+    persisted_started_at="$(read_pending_value HOMEOPS_DEPLOYMENT_STARTED_AT)"
+    if [[ -n "${persisted_event_key}" || -n "${persisted_started_at}" ]]; then
+      if [[ ! "${persisted_started_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+        || {
+          [[ "${persisted_event_key}" != "cubing-hub:deploy:${recovery_target_sha}:${persisted_started_at}" ]] \
+            && [[ ! "${persisted_event_key}" =~ ^cubing-hub:deploy-recovery:${recovery_target_sha}:${persisted_started_at}:[0-9]+$ ]];
+        }
+      then
+        fail "runtime config pending HomeOps context is invalid"
+      fi
+    fi
+  fi
+
+  if ! recovery_started_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
+    printf 'HomeOps recovery start time could not be generated\n' >&2
+    return
+  fi
+
+  normalized_sha="${recovery_target_sha}"
+  previous_sha=
+  if [[ "${recovery_previous_sha}" != "${ZERO_SHA}" ]]; then
+    previous_sha="${recovery_previous_sha}"
+  fi
+  if [[ -n "${persisted_event_key}" ]]; then
+    homeops_deployment_event_key="${persisted_event_key}"
+    homeops_deployment_started_at="${persisted_started_at}"
+    report_homeops_deployment FAILED "${recovery_started_at}" || true
+  fi
+
+  recovery_event_key="cubing-hub:deploy-recovery:${recovery_target_sha}:${recovery_started_at}:$$"
+  write_pending_state \
+    "${recovery_previous_sha}" \
+    "${recovery_previous_digest}" \
+    "${recovery_target_sha}" \
+    "${recovery_target_digest}" \
+    "${recovery_event_key}" \
+    "${recovery_started_at}"
+  homeops_deployment_event_key="${recovery_event_key}"
+  homeops_deployment_started_at="${recovery_started_at}"
+  report_homeops_deployment RUNNING "" || true
 }
 
 validate_state_file() {
@@ -1324,6 +1403,7 @@ recover_pending_transaction() {
       fail "bootstrap recovery could not stop interrupted app services"
     fi
     /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+    homeops_success_status=ROLLED_BACK
     printf 'Interrupted Cubing Hub bootstrap cleared with app services stopped\n'
     return 0
   fi
@@ -1376,10 +1456,12 @@ recover_pending_transaction() {
     write_initialization_marker
   fi
   /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+  homeops_success_status=ROLLED_BACK
   printf 'Cubing Hub runtime config transaction recovered to: %s\n' "${previous_sha}"
 }
 
 if [[ "${recovery_mode}" == true ]]; then
+  initialize_homeops_recovery_event
   recover_pending_transaction
   exit 0
 fi
@@ -1585,7 +1667,9 @@ if [[ "${legacy_mode}" == false ]]; then
     "${previous_sha:-${ZERO_SHA}}" \
     "${previous_config_digest}" \
     "${normalized_sha}" \
-    "${candidate_config_digest}"
+    "${candidate_config_digest}" \
+    "${homeops_deployment_event_key}" \
+    "${homeops_deployment_started_at}"
 fi
 
 active_compose_file="${candidate_compose_file}"

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -17,6 +17,7 @@ readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
 readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
 readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
 readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
+readonly RUNTIME_CONFIG_HOMEOPS_CONTEXT="${RUNTIME_CONFIG_ROOT}/homeops-deployment"
 readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
 readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
 readonly API_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-api
@@ -24,6 +25,7 @@ readonly WEB_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-web
 readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
 readonly ZERO_SHA=0000000000000000000000000000000000000000
 readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+readonly HOMEOPS_CONTEXT_MV_BIN=/bin/mv
 readonly HEALTH_TIMEOUT_SECONDS=240
 readonly MIGRATION_MAIN_CLASS=com.cubinghub.ops.MigrationMain
 readonly MIGRATION_JAR=/app/app.jar
@@ -197,6 +199,7 @@ docker_config_dir="$(
 env_temp=
 state_temp=
 pending_temp=
+homeops_context_temp=
 release_temp=
 current_link_temp=
 initialization_temp=
@@ -282,6 +285,7 @@ cleanup() {
   for cleanup_path in \
     "${state_temp}" \
     "${pending_temp}" \
+    "${homeops_context_temp}" \
     "${current_link_temp}" \
     "${initialization_temp}"
   do
@@ -326,10 +330,13 @@ cleanup() {
       printf 'HomeOps deployment completion time could not be generated\n' >&2
     elif [[ "${exit_status}" -eq 0 ]]; then
       report_homeops_deployment "${homeops_success_status}" "${finished_at}" || true
+      remove_homeops_context_if_owned
     elif [[ "${homeops_rollback_succeeded}" == true ]]; then
       report_homeops_deployment ROLLED_BACK "${finished_at}" || true
+      remove_homeops_context_if_owned
     else
       report_homeops_deployment FAILED "${finished_at}" || true
+      remove_homeops_context_if_owned
     fi
   fi
   return "${exit_status}"
@@ -962,10 +969,10 @@ write_pending_state() {
   local homeops_event_key="${5:-}"
   local homeops_started_at="${6:-}"
 
-  /bin/mkdir -p "${RUNTIME_CONFIG_ROOT}"
+  /bin/mkdir -p "${RUNTIME_CONFIG_ROOT}" || return
   pending_temp="$(
     /usr/bin/mktemp "${RUNTIME_CONFIG_ROOT}/.pending.tmp.XXXXXX"
-  )"
+  )" || return
   {
     printf 'HOMEOPS_DEPLOYMENT_EVENT_KEY=%s\n' "${homeops_event_key}"
     printf 'HOMEOPS_DEPLOYMENT_STARTED_AT=%s\n' "${homeops_started_at}"
@@ -973,10 +980,142 @@ write_pending_state() {
     printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_config_digest}"
     printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_sha}"
     printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${target_config_digest}"
-  } >"${pending_temp}"
-  /bin/chmod 600 "${pending_temp}"
-  /bin/mv -f -- "${pending_temp}" "${RUNTIME_CONFIG_PENDING}"
+  } >"${pending_temp}" || return
+  /bin/chmod 600 "${pending_temp}" || return
+  /bin/mv -f -- "${pending_temp}" "${RUNTIME_CONFIG_PENDING}" || return
   pending_temp=
+}
+
+read_homeops_context_value() {
+  local key="$1"
+  local value
+
+  value="$(
+    /usr/bin/awk -F= -v key="${key}" '
+      $1 == key {
+        value = substr($0, index($0, "=") + 1)
+        count += 1
+      }
+      END {
+        if (count != 1) {
+          exit 1
+        }
+        print value
+      }
+    ' "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}"
+  )" || return
+  printf '%s' "${value}"
+}
+
+validate_homeops_context() {
+  local event_key
+  local keys
+  local started_at
+  local target_sha
+
+  if [[ ! -f "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]
+  then
+    return 1
+  fi
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" \
+      | LC_ALL=C /usr/bin/sort
+  )" || return
+  if [[ "${keys}" != $'HOMEOPS_DEPLOYMENT_EVENT_KEY\nHOMEOPS_DEPLOYMENT_STARTED_AT\nTARGET_APPLICATION_REVISION' ]]; then
+    return 1
+  fi
+  event_key="$(read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY)" || return
+  started_at="$(read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT)" || return
+  target_sha="$(read_homeops_context_value TARGET_APPLICATION_REVISION)" || return
+  if [[ ! "${target_sha}" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "${started_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || {
+      [[ "${event_key}" != "cubing-hub:deploy:${target_sha}:${started_at}" ]] \
+        && [[ ! "${event_key}" =~ ^cubing-hub:deploy-recovery:${target_sha}:${started_at}:[0-9]+$ ]];
+    }
+  then
+    return 1
+  fi
+}
+
+write_homeops_context() {
+  local event_key="$1"
+  local started_at="$2"
+  local target_sha="$3"
+
+  /bin/mkdir -p "${RUNTIME_CONFIG_ROOT}" || return
+  homeops_context_temp="$(
+    /usr/bin/mktemp "${RUNTIME_CONFIG_ROOT}/.homeops-deployment.tmp.XXXXXX"
+  )" || return
+  {
+    printf 'HOMEOPS_DEPLOYMENT_EVENT_KEY=%s\n' "${event_key}"
+    printf 'HOMEOPS_DEPLOYMENT_STARTED_AT=%s\n' "${started_at}"
+    printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_sha}"
+  } >"${homeops_context_temp}" || return
+  /bin/chmod 600 "${homeops_context_temp}" || return
+  "${HOMEOPS_CONTEXT_MV_BIN}" -f -- \
+    "${homeops_context_temp}" \
+    "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" \
+    || return
+  homeops_context_temp=
+}
+
+remove_homeops_context_if_owned() {
+  local persisted_event_key
+
+  if [[ ! -f "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]
+  then
+    return
+  fi
+  persisted_event_key="$(
+    read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
+  )" || return
+  if [[ "${persisted_event_key}" != "${homeops_deployment_event_key}" ]]; then
+    return
+  fi
+  if ! "${RM_BIN}" -f -- "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}"; then
+    printf 'HomeOps deployment context could not be removed\n' >&2
+  fi
+}
+
+finalize_stale_homeops_context() {
+  local boundary_time="$1"
+  local next_target_sha="$2"
+
+  if [[ ! -e "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]] \
+    && [[ ! -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]
+  then
+    return 0
+  fi
+  if ! validate_homeops_context; then
+    printf 'Stale HomeOps deployment context is invalid; continuing without new telemetry\n' >&2
+    return 1
+  fi
+
+  normalized_sha="$(
+    read_homeops_context_value TARGET_APPLICATION_REVISION
+  )"
+  homeops_deployment_event_key="$(
+    read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
+  )"
+  homeops_deployment_started_at="$(
+    read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT
+  )"
+  previous_sha=
+  report_homeops_deployment FAILED "${boundary_time}" || true
+  remove_homeops_context_if_owned
+
+  normalized_sha="${next_target_sha}"
+  homeops_deployment_event_key=
+  homeops_deployment_started_at=
+  if [[ -e "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]] \
+    || [[ -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]
+  then
+    printf 'Stale HomeOps deployment context could not be cleared; continuing without new telemetry\n' >&2
+    return 1
+  fi
 }
 
 replace_current_link() {
@@ -1085,6 +1224,9 @@ initialize_homeops_recovery_event() {
   local recovery_previous_sha
   local recovery_target_digest
   local recovery_target_sha
+  local context_event_key=
+  local context_started_at=
+  local context_target_sha=
 
   validate_pending_state
   recovery_previous_sha="$(read_pending_value PREVIOUS_APPLICATION_REVISION)"
@@ -1115,6 +1257,26 @@ initialize_homeops_recovery_event() {
     fi
   fi
 
+  if [[ -e "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" || -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]; then
+    if ! validate_homeops_context; then
+      fail "HomeOps deployment context is invalid"
+    fi
+    context_event_key="$(
+      read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
+    )"
+    context_started_at="$(
+      read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT
+    )"
+    context_target_sha="$(
+      read_homeops_context_value TARGET_APPLICATION_REVISION
+    )"
+    if [[ "${context_target_sha}" != "${recovery_target_sha}" ]]; then
+      fail "HomeOps deployment context does not match the pending target"
+    fi
+    persisted_event_key="${context_event_key}"
+    persisted_started_at="${context_started_at}"
+  fi
+
   if ! recovery_started_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
     printf 'HomeOps recovery start time could not be generated\n' >&2
     return
@@ -1129,19 +1291,48 @@ initialize_homeops_recovery_event() {
     homeops_deployment_event_key="${persisted_event_key}"
     homeops_deployment_started_at="${persisted_started_at}"
     report_homeops_deployment FAILED "${recovery_started_at}" || true
+    remove_homeops_context_if_owned
   fi
 
   recovery_event_key="cubing-hub:deploy-recovery:${recovery_target_sha}:${recovery_started_at}:$$"
-  write_pending_state \
-    "${recovery_previous_sha}" \
-    "${recovery_previous_digest}" \
-    "${recovery_target_sha}" \
-    "${recovery_target_digest}" \
+  if write_homeops_context \
     "${recovery_event_key}" \
-    "${recovery_started_at}"
-  homeops_deployment_event_key="${recovery_event_key}"
-  homeops_deployment_started_at="${recovery_started_at}"
-  report_homeops_deployment RUNNING "" || true
+    "${recovery_started_at}" \
+    "${recovery_target_sha}"
+  then
+    homeops_deployment_event_key="${recovery_event_key}"
+    homeops_deployment_started_at="${recovery_started_at}"
+    report_homeops_deployment RUNNING "" || true
+  else
+    printf 'HomeOps recovery context could not be retained; continuing operational recovery\n' >&2
+    homeops_deployment_event_key=
+    homeops_deployment_started_at=
+  fi
+}
+
+recover_homeops_context_only() {
+  local finished_at
+
+  if ! validate_homeops_context; then
+    fail "HomeOps deployment context is invalid"
+  fi
+  normalized_sha="$(
+    read_homeops_context_value TARGET_APPLICATION_REVISION
+  )"
+  homeops_deployment_event_key="$(
+    read_homeops_context_value HOMEOPS_DEPLOYMENT_EVENT_KEY
+  )"
+  homeops_deployment_started_at="$(
+    read_homeops_context_value HOMEOPS_DEPLOYMENT_STARTED_AT
+  )"
+  if ! finished_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; then
+    fail "HomeOps interrupted deployment completion time could not be generated"
+  fi
+  report_homeops_deployment FAILED "${finished_at}" || true
+  remove_homeops_context_if_owned
+  homeops_deployment_event_key=
+  homeops_deployment_started_at=
+  printf 'Interrupted Cubing Hub deployment event finalized before runtime mutation\n'
 }
 
 validate_state_file() {
@@ -1461,6 +1652,12 @@ recover_pending_transaction() {
 }
 
 if [[ "${recovery_mode}" == true ]]; then
+  if [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]] \
+    && [[ -e "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" || -L "${RUNTIME_CONFIG_HOMEOPS_CONTEXT}" ]]
+  then
+    recover_homeops_context_only
+    exit 0
+  fi
   initialize_homeops_recovery_event
   recover_pending_transaction
   exit 0
@@ -1474,8 +1671,27 @@ if ! homeops_deployment_started_at="$("${DATE_BIN}" -u '+%Y-%m-%dT%H:%M:%SZ')"; 
   printf 'HomeOps deployment start time could not be generated\n' >&2
   homeops_deployment_started_at=
 else
-  homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
-  report_homeops_deployment RUNNING "" || true
+  next_homeops_started_at="${homeops_deployment_started_at}"
+  if [[ "${legacy_mode}" == true ]]; then
+    homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
+    report_homeops_deployment RUNNING "" || true
+  else
+    if finalize_stale_homeops_context "${next_homeops_started_at}" "${normalized_sha}"; then
+      homeops_deployment_started_at="${next_homeops_started_at}"
+      homeops_deployment_event_key="cubing-hub:deploy:${normalized_sha}:${homeops_deployment_started_at}"
+      if write_homeops_context \
+        "${homeops_deployment_event_key}" \
+        "${homeops_deployment_started_at}" \
+        "${normalized_sha}"
+      then
+        report_homeops_deployment RUNNING "" || true
+      else
+        printf 'HomeOps deployment context could not be retained; continuing without telemetry\n' >&2
+        homeops_deployment_event_key=
+        homeops_deployment_started_at=
+      fi
+    fi
+  fi
 fi
 new_api_image="${API_IMAGE_REPOSITORY}:${normalized_sha}"
 new_web_image="${WEB_IMAGE_REPOSITORY}:${normalized_sha}"
@@ -1620,6 +1836,17 @@ validation_baseline_compose_file=
 validation_baseline_api_image=
 validation_baseline_web_image=
 
+if [[ "${legacy_mode}" == false ]]; then
+  previous_config_digest="${current_config_digest:-${ZERO_DIGEST}}"
+  write_pending_state \
+    "${previous_sha:-${ZERO_SHA}}" \
+    "${previous_config_digest}" \
+    "${normalized_sha}" \
+    "${candidate_config_digest}" \
+    "${homeops_deployment_event_key}" \
+    "${homeops_deployment_started_at}"
+fi
+
 active_compose_file="${current_compose_file}"
 running_services="$(compose ps --status running --services)"
 if ! /usr/bin/grep -qx db <<<"${running_services}"; then
@@ -1659,17 +1886,6 @@ if [[ -n "${previous_sha}" ]]; then
   else
     "${active_backup_script}" --trigger predeploy
   fi
-fi
-
-if [[ "${legacy_mode}" == false ]]; then
-  previous_config_digest="${current_config_digest:-${ZERO_DIGEST}}"
-  write_pending_state \
-    "${previous_sha:-${ZERO_SHA}}" \
-    "${previous_config_digest}" \
-    "${normalized_sha}" \
-    "${candidate_config_digest}" \
-    "${homeops_deployment_event_key}" \
-    "${homeops_deployment_started_at}"
 fi
 
 active_compose_file="${candidate_compose_file}"

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -288,7 +288,10 @@ case "${command_name}" in
         "${edge_json}" \
         "${mysql_volume_extra}"
     elif [[ "${arguments}" == *" ps --status running --services "* ]]; then
-      printf 'db\nredis\napi\nweb\n'
+      printf '%s\n' "${FAKE_RUNNING_SERVICES:-db
+redis
+api
+web}"
     fi
     ;;
   *)

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -14,7 +14,16 @@ if [[ -n "${FAKE_DOCKER_LOG:-}" ]]; then
 fi
 
 case "${command_name}" in
-  login|logout|pull|rm)
+  pull)
+    if [[ -n "${FAKE_HOMEOPS_CONTEXT_CAPTURE:-}" ]] \
+      && [[ "$*" == *cubing-hub-api* ]]
+    then
+      /bin/cp "${FAKE_HOMEOPS_CONTEXT_FILE}" "${FAKE_HOMEOPS_CONTEXT_CAPTURE}"
+      exit 1
+    fi
+    exit 0
+    ;;
+  login|logout|rm)
     exit 0
     ;;
   create)
@@ -85,7 +94,11 @@ case "${command_name}" in
     ;;
   compose)
     arguments=" $* "
-    if [[ "${arguments}" == *" run "* ]] \
+    if [[ "${arguments}" == *" config --images db redis "* ]]; then
+      printf '%s\n' \
+        "${FAKE_RENDER_DB_IMAGE:-mysql:8.0.46}" \
+        "${FAKE_RENDER_REDIS_IMAGE:-redis:7.2.14-alpine}"
+    elif [[ "${arguments}" == *" run "* ]] \
       && [[ "${arguments}" == *"com.cubinghub.ops.MigrationMain"* ]] \
       && [[ -n "${FAKE_DOCKER_LOG:-}" ]]
     then
@@ -98,6 +111,12 @@ case "${command_name}" in
       && [[ "${arguments}" == *"com.cubinghub.ops.MigrationMain"* ]] \
       && [[ "${FAKE_MIGRATION_FAIL:-false}" == true ]]
     then
+      exit 1
+    elif [[ "${arguments}" == *" up "* ]] \
+      && [[ "${arguments}" == *" db redis "* ]] \
+      && [[ -n "${FAKE_PENDING_CAPTURE_ON_DATA_UP:-}" ]]
+    then
+      /bin/cp "${FAKE_PENDING_FILE}" "${FAKE_PENDING_CAPTURE_ON_DATA_UP}"
       exit 1
     elif [[ "${arguments}" == *" up "* ]] \
       && [[ -n "${FAKE_FAIL_APP_UP_ONCE_FILE:-}" ]] \

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -193,6 +193,22 @@ test("should_rollbackBothImagesWithoutDeletingPersistentData", () => {
     deployScript,
     /HomeOps recovery context could not be retained; continuing operational recovery/,
   );
+  assert.match(
+    deployScript,
+    /HomeOps deployment context is invalid; continuing operational recovery without new telemetry/,
+  );
+  assert.match(
+    deployScript,
+    /HomeOps recovery context is unusable; continuing operational recovery without new telemetry/,
+  );
+  const recoveryInitializer = deployScript.match(
+    /initialize_homeops_recovery_event\(\) \{[\s\S]*?\n\}/,
+  )?.[0];
+  assert.ok(recoveryInitializer);
+  assert.doesNotMatch(
+    recoveryInitializer,
+    /fail "HomeOps deployment context is invalid"/,
+  );
   const durableHomeOpsContext = deployScript.lastIndexOf(
     "if write_homeops_context \\",
   );
@@ -519,9 +535,17 @@ test("should_runOneShotFlywayBeforeCutoverAndGateSuccessOnPublicSmoke", () => {
   const migrationFunction = deployScript.match(
     /run_one_shot_migration\(\) \{[\s\S]*?\n\}/,
   )?.[0];
-  const pending = deployScript.lastIndexOf("write_pending_state \\");
+  const bootstrapPending = deployScript.indexOf(
+    'if [[ "${legacy_mode}" == false && -z "${previous_sha}" ]]; then',
+  );
+  const updatePending = deployScript.indexOf(
+    'if [[ "${legacy_mode}" == false && -n "${previous_sha}" ]]; then',
+  );
   const runningServicePreflight = deployScript.indexOf(
     'running_services="$(compose ps --status running --services)"',
+  );
+  const predeployBackup = deployScript.indexOf(
+    '"${active_backup_script}" --trigger predeploy',
   );
   const migration = deployScript.lastIndexOf(
     'if ! run_one_shot_migration "${new_api_image}" "${new_web_image}"; then',
@@ -546,9 +570,12 @@ test("should_runOneShotFlywayBeforeCutoverAndGateSuccessOnPublicSmoke", () => {
   assert.match(migrationFunction, /export API_IMAGE="\$\{candidate_api_image\}"/);
   assert.match(migrationFunction, /export WEB_IMAGE="\$\{candidate_web_image\}"/);
   assert.match(migrationFunction, /compose run \\\n[\s\S]*--pull never/);
-  assert.ok(pending >= 0);
-  assert.ok(runningServicePreflight > pending);
-  assert.ok(migration > pending);
+  assert.ok(bootstrapPending >= 0);
+  assert.ok(updatePending >= 0);
+  assert.ok(runningServicePreflight > bootstrapPending);
+  assert.ok(predeployBackup > runningServicePreflight);
+  assert.ok(updatePending > predeployBackup);
+  assert.ok(migration > updatePending);
   assert.ok(imageWrite > migration);
   assert.ok(publicSmoke > imageWrite);
   assert.ok(successState > publicSmoke);

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -189,6 +189,22 @@ test("should_rollbackBothImagesWithoutDeletingPersistentData", () => {
     deployScript,
     /cubing-hub:deploy-recovery:[\s\S]*report_homeops_deployment RUNNING/,
   );
+  assert.match(
+    deployScript,
+    /HomeOps recovery context could not be retained; continuing operational recovery/,
+  );
+  const durableHomeOpsContext = deployScript.lastIndexOf(
+    "if write_homeops_context \\",
+  );
+  const deploymentRunning = deployScript.lastIndexOf(
+    'report_homeops_deployment RUNNING "" || true',
+  );
+  const applicationImagePull = deployScript.indexOf(
+    'pull "${new_api_image}"',
+  );
+  assert.ok(durableHomeOpsContext >= 0);
+  assert.ok(durableHomeOpsContext < deploymentRunning);
+  assert.ok(deploymentRunning < applicationImagePull);
   assert.doesNotMatch(
     deployScript,
     /down[^\n]*(?:--volumes|-v)|volume rm|system prune/,
@@ -504,6 +520,9 @@ test("should_runOneShotFlywayBeforeCutoverAndGateSuccessOnPublicSmoke", () => {
     /run_one_shot_migration\(\) \{[\s\S]*?\n\}/,
   )?.[0];
   const pending = deployScript.lastIndexOf("write_pending_state \\");
+  const runningServicePreflight = deployScript.indexOf(
+    'running_services="$(compose ps --status running --services)"',
+  );
   const migration = deployScript.lastIndexOf(
     'if ! run_one_shot_migration "${new_api_image}" "${new_web_image}"; then',
   );
@@ -528,6 +547,7 @@ test("should_runOneShotFlywayBeforeCutoverAndGateSuccessOnPublicSmoke", () => {
   assert.match(migrationFunction, /export WEB_IMAGE="\$\{candidate_web_image\}"/);
   assert.match(migrationFunction, /compose run \\\n[\s\S]*--pull never/);
   assert.ok(pending >= 0);
+  assert.ok(runningServicePreflight > pending);
   assert.ok(migration > pending);
   assert.ok(imageWrite > migration);
   assert.ok(publicSmoke > imageWrite);

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -181,6 +181,14 @@ test("should_rollbackBothImagesWithoutDeletingPersistentData", () => {
     deployScript,
     /write_pending_state[\s\S]*"\$\{previous_sha:-\$\{ZERO_SHA\}\}"/,
   );
+  assert.match(
+    deployScript,
+    /HOMEOPS_DEPLOYMENT_EVENT_KEY[\s\S]*HOMEOPS_DEPLOYMENT_STARTED_AT/,
+  );
+  assert.match(
+    deployScript,
+    /cubing-hub:deploy-recovery:[\s\S]*report_homeops_deployment RUNNING/,
+  );
   assert.doesNotMatch(
     deployScript,
     /down[^\n]*(?:--volumes|-v)|volume rm|system prune/,

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -26,6 +26,8 @@ trap cleanup EXIT INT TERM
 
 mock_docker="${test_root}/docker"
 docker_log="${test_root}/docker.log"
+event_log="${test_root}/homeops-events.log"
+event_reporter="${test_root}/report-homeops-event.py"
 
 {
   printf '%s\n' \
@@ -53,6 +55,14 @@ docker_log="${test_root}/docker.log"
     'fi'
 } >"${mock_docker}"
 /bin/chmod 700 "${mock_docker}"
+: >"${event_log}"
+{
+  printf '#!/bin/bash\n'
+  printf 'printf "%%s " "$1" >>"%s"\n' "${event_log}"
+  printf '/bin/cat >>"%s"\n' "${event_log}"
+  printf 'printf "\\n" >>"%s"\n' "${event_log}"
+} >"${event_reporter}"
+/bin/chmod 700 "${event_reporter}"
 
 prepare_script() {
   local app_dir="$1"
@@ -74,6 +84,7 @@ prepare_script() {
     -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
     -e "s#readonly BACKUP_BOOTSTRAP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_BOOTSTRAP_SCRIPT=${target_script}#" \
     -e "s#readonly BACKUP_ROOT=${PRODUCTION_BACKUP_ROOT}#readonly BACKUP_ROOT=${backup_root}#" \
+    -e "s#readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py#readonly HOMEOPS_EVENT_REPORTER=${event_reporter}#" \
     "${SOURCE_SCRIPT}" >"${target_script}"
   if ! /usr/bin/grep -Fqx "readonly BACKUP_ROOT=${backup_root}" "${target_script}"; then
     printf 'Test backup path substitution failed: %s\n' "${backup_root}" >&2
@@ -293,9 +304,13 @@ prepare_script "${legacy_app}" "${legacy_backups}" "${legacy_script}"
 : >"${docker_log}"
 DOCKER_LOG="${docker_log}" \
 MOCK_POST_IMAGES_DIR="${legacy_post_images}" \
+HOMEOPS_EVENT_LOG="${event_log}" \
   "${legacy_script}" >/dev/null
 /usr/bin/grep -Fq -- "--project-name cubing-hub" "${docker_log}"
 /usr/bin/grep -Fq -- "--project-directory ${legacy_app}" "${docker_log}"
 /usr/bin/grep -Fq -- "--file ${legacy_app}/compose.yaml" "${docker_log}"
+/usr/bin/grep -Fq 'backups {"eventKey":"cubing-hub:backup:' "${event_log}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Fq '"status":"SUCCESS"' "${event_log}"
 
 printf 'Cubing Hub production backup selection tests passed\n'

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -90,7 +90,7 @@ export MOCK_DUMP_FILE="${default_dump_file}"
     '  fi' \
     '  printf '\''{"services":{"api":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]},"web":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]}}}\n'\'' "${MOCK_POST_IMAGES_DIR}" "${MOCK_POST_IMAGES_DIR}"' \
     'elif [[ " $* " == *" ps --status running --services "* ]]; then' \
-    '  printf "db\n"' \
+    '  printf "%s\n" "${FAKE_RUNNING_SERVICES:-db}"' \
     'elif [[ "$*" == *"BACKUP_QUERY=dump"* ]]; then' \
     '  /bin/cat "${MOCK_DUMP_FILE}"' \
     'elif [[ "$*" == *"BACKUP_QUERY=version"* ]]; then' \
@@ -609,6 +609,33 @@ printf 'image-one\n' >"${v2_post_images}/image-one.jpg"
 seed_retention_matrix "${v2_backups}" "${v2_retention_expected}"
 prepare_script "${v2_app}" "${v2_backups}" "${v2_script}"
 prepare_runtime_state "${v2_app}" "${v2_script}"
+
+preflight_failure_app="${test_root}/preflight-failure-app"
+preflight_failure_backups="${test_root}/preflight-failure-backups"
+preflight_failure_post_images="${test_root}/preflight-failure-post-images"
+preflight_failure_script="${test_root}/preflight-failure-backup.sh"
+/bin/mkdir -p "${preflight_failure_backups}"
+prepare_app "${preflight_failure_app}" "${preflight_failure_post_images}"
+prepare_script \
+  "${preflight_failure_app}" \
+  "${preflight_failure_backups}" \
+  "${preflight_failure_script}"
+: >"${event_log}"
+set +e
+DOCKER_LOG="${docker_log}" \
+HOMEOPS_EVENT_LOG="${event_log}" \
+FAKE_RUNNING_SERVICES=redis \
+MOCK_POST_IMAGES_DIR="${preflight_failure_post_images}" \
+  "${preflight_failure_script}" >/dev/null 2>&1
+preflight_failure_exit_code="$?"
+set -e
+if [[ "${preflight_failure_exit_code}" -ne 1 ]]; then
+  printf 'Backup DB preflight failure must fail\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fq 'backups {"eventKey":"cubing-hub:backup:' "${event_log}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
 
 COMPOSE_PROJECT_NAME=ambient-project \
 POST_IMAGES_HOST_DIR="${test_root}/ambient-post-images" \

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -33,6 +33,7 @@ backup_log="${test_root}/backup.log"
 event_log="${test_root}/homeops-events.log"
 event_reporter="${test_root}/report-homeops-event.py"
 mock_rm="${test_root}/rm"
+mock_date="${test_root}/date"
 backup_args_log="${test_root}/backup-args.log"
 curl_log="${test_root}/curl.log"
 runtime_compose="${test_root}/runtime-compose.yaml"
@@ -76,6 +77,14 @@ printf '%s\n' \
   'exec /bin/rm "$@"' \
   >"${mock_rm}"
 /bin/chmod 700 "${mock_rm}"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'if [[ "${FAIL_HOMEOPS_DEPLOYMENT_START_TIME:-false}" == true ]]; then' \
+  '  exit 75' \
+  'fi' \
+  'exec /bin/date "$@"' \
+  >"${mock_date}"
+/bin/chmod 700 "${mock_date}"
 : >"${backup_args_log}"
 : >"${curl_log}"
 
@@ -83,6 +92,7 @@ printf '%s\n' \
   -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
   -e "s#readonly CURL_BIN=/usr/bin/curl#readonly CURL_BIN=${MOCK_CURL}#" \
   -e "s#readonly RM_BIN=/bin/rm#readonly RM_BIN=${mock_rm}#" \
+  -e "s#readonly DATE_BIN=/bin/date#readonly DATE_BIN=${mock_date}#" \
   -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
   -e "s#readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_SCRIPT=${backup_script}#" \
   -e "s#readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py#readonly HOMEOPS_EVENT_REPORTER=${event_reporter}#" \
@@ -118,6 +128,7 @@ run_deploy() {
         FAKE_REVISION_THREE="${REVISION_THREE}" \
         FAKE_VALIDATION_TARGET_API_IMAGE="ghcr.io/xxh3898/cubing-hub-api:${target_revision}" \
         FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
+        FAIL_HOMEOPS_DEPLOYMENT_START_TIME="${FAIL_HOMEOPS_DEPLOYMENT_START_TIME:-false}" \
         TMPDIR="${FAKE_TMPDIR:-}" \
         FAKE_FAIL_CP="${FAKE_FAIL_CP:-false}" \
         FAKE_FAIL_APP_UP_ONCE_FILE="${FAKE_FAIL_APP_UP_ONCE_FILE:-}" \
@@ -258,6 +269,14 @@ test ! -e "${app_dir}/runtime-config/pending"
 /usr/bin/tail -n 1 "${backup_args_log}" \
   | /usr/bin/grep -Fxq -- '--trigger predeploy'
 /bin/chmod 700 "${backup_script}"
+
+: >"${event_log}"
+FAIL_HOMEOPS_DEPLOYMENT_START_TIME=true \
+  run_deploy "${REVISION_ONE}" keep test-user
+if [[ -s "${event_log}" ]]; then
+  printf 'HomeOps start-time failure must not emit incomplete deployment events\n' >&2
+  exit 1
+fi
 
 legacy_v2_scripts="${test_root}/legacy-v2-scripts"
 /bin/mv "${bootstrap_candidate}/scripts" "${legacy_v2_scripts}"

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -176,6 +176,8 @@ run_recovery() {
     FAKE_REVISION_THREE="${REVISION_THREE}" \
     FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
     FAKE_CURL_LOG="${curl_log}" \
+    HOMEOPS_EVENT_LOG="${event_log}" \
+    FAIL_HOMEOPS_DEPLOYMENT_START_TIME="${FAIL_HOMEOPS_DEPLOYMENT_START_TIME:-false}" \
     FAKE_PUBLIC_SMOKE_FAIL="${FAKE_PUBLIC_SMOKE_FAIL:-false}" \
     FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE="${FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE:-}" \
     /bin/bash "${test_script}" recover
@@ -400,13 +402,46 @@ if /usr/bin/find "${app_dir}/runtime-config/releases" -name '.current.*' | /usr/
 fi
 
 pending_file="${app_dir}/runtime-config/pending"
-{
-  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
-  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
-  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_THREE}"
-  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
-} >"${pending_file}"
-/bin/chmod 600 "${pending_file}"
+write_pending_fixture() {
+  local previous_revision="$1"
+  local previous_digest="$2"
+  local target_revision="$3"
+  local target_digest="$4"
+  local started_at=2026-08-06T00:00:00Z
+
+  {
+    printf 'HOMEOPS_DEPLOYMENT_EVENT_KEY=cubing-hub:deploy:%s:%s\n' \
+      "${target_revision}" "${started_at}"
+    printf 'HOMEOPS_DEPLOYMENT_STARTED_AT=%s\n' "${started_at}"
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${previous_revision}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_digest}"
+    printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_revision}"
+    printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${target_digest}"
+  } >"${pending_file}"
+  /bin/chmod 600 "${pending_file}"
+}
+
+write_legacy_pending_fixture() {
+  local previous_revision="$1"
+  local previous_digest="$2"
+  local target_revision="$3"
+  local target_digest="$4"
+
+  {
+    printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${previous_revision}"
+    printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${previous_digest}"
+    printf 'TARGET_APPLICATION_REVISION=%s\n' "${target_revision}"
+    printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${target_digest}"
+  } >"${pending_file}"
+  /bin/chmod 600 "${pending_file}"
+}
+
+write_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_THREE}" \
+  "${CONFIG_DIGEST}"
+: >"${event_log}"
 /usr/bin/sed \
   -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}#" \
   -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_THREE}#" \
@@ -448,16 +483,26 @@ test ! -e "${pending_file}"
   "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
   "${app_dir}/.env"
 /usr/bin/grep -Fxq "APPLICATION_REVISION=${REVISION_TWO}" "${state_file}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_THREE}:2026-08-06T00:00:00Z" \
+  "${event_log}"
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy-recovery:' "${event_log}"
+if ! /usr/bin/grep -Fq '"status":"ROLLED_BACK"' "${event_log}"; then
+  printf 'Successful recovery to the previous pair must report ROLLED_BACK\n' >&2
+  /bin/cat "${event_log}" >&2
+  exit 1
+fi
 
-{
-  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
-  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
-  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
-  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
-} >"${pending_file}"
-/bin/chmod 600 "${pending_file}"
+write_legacy_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}"
+: >"${event_log}"
 run_recovery
 test ! -e "${pending_file}"
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy-recovery:' "${event_log}"
+/usr/bin/grep -Fq '"status":"SUCCESS"' "${event_log}"
 
 release_one="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
 release_two="${app_dir}/runtime-config/releases/${CONFIG_DIGEST_TWO#sha256:}"
@@ -474,12 +519,11 @@ target_content_sha="$(
       "${release_two}/scripts/deploy-cubing-hub.sh"
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
 )"
-{
-  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
-  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST}"
-  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_THREE}"
-  printf 'TARGET_RUNTIME_CONFIG_DIGEST=%s\n' "${CONFIG_DIGEST_TWO}"
-} >"${pending_file}"
+write_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_THREE}" \
+  "${CONFIG_DIGEST_TWO}"
 /usr/bin/sed \
   -e "s#^APPLICATION_REVISION=.*#APPLICATION_REVISION=${REVISION_THREE}#" \
   -e "s#^RUNTIME_CONFIG_DIGEST=.*#RUNTIME_CONFIG_DIGEST=${CONFIG_DIGEST_TWO}#" \
@@ -533,12 +577,21 @@ then
   printf 'Completed target recovery must preserve pending while services are unhealthy\n' >&2
   exit 1
 fi
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy-recovery:' "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+: >"${event_log}"
 run_recovery
 
 test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" \
   = "releases/${CONFIG_DIGEST_TWO#sha256:}"
 test ! -e "${pending_file}"
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy-recovery:' "${event_log}"
+if ! /usr/bin/grep -Fq '"status":"SUCCESS"' "${event_log}"; then
+  printf 'Successful completed-target recovery must report SUCCESS\n' >&2
+  /bin/cat "${event_log}" >&2
+  exit 1
+fi
 
 /usr/bin/sed \
   -e "s#^APPLICATION_REVISION=.*#APPLICATION_REVISION=${REVISION_TWO}#" \

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -12,6 +12,7 @@ MOCK_CURL="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-curl.sh"
 REVISION_ONE=1111111111111111111111111111111111111111
 REVISION_TWO=2222222222222222222222222222222222222222
 REVISION_THREE=3333333333333333333333333333333333333333
+ZERO_SHA=0000000000000000000000000000000000000000
 CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 CONFIG_DIGEST_TWO=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 CONFIG_DIGEST_THREE=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -34,6 +35,7 @@ event_log="${test_root}/homeops-events.log"
 event_reporter="${test_root}/report-homeops-event.py"
 mock_rm="${test_root}/rm"
 mock_date="${test_root}/date"
+mock_homeops_context_mv="${test_root}/homeops-context-mv"
 backup_args_log="${test_root}/backup-args.log"
 curl_log="${test_root}/curl.log"
 runtime_compose="${test_root}/runtime-compose.yaml"
@@ -85,6 +87,16 @@ printf '%s\n' \
   'exec /bin/date "$@"' \
   >"${mock_date}"
 /bin/chmod 700 "${mock_date}"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'last_argument=' \
+  'for last_argument in "$@"; do :; done' \
+  'if [[ "${FAIL_HOMEOPS_CONTEXT_WRITE:-false}" == true && "${last_argument}" == */homeops-deployment ]]; then' \
+  '  exit 75' \
+  'fi' \
+  'exec /bin/mv "$@"' \
+  >"${mock_homeops_context_mv}"
+/bin/chmod 700 "${mock_homeops_context_mv}"
 : >"${backup_args_log}"
 : >"${curl_log}"
 
@@ -93,6 +105,7 @@ printf '%s\n' \
   -e "s#readonly CURL_BIN=/usr/bin/curl#readonly CURL_BIN=${MOCK_CURL}#" \
   -e "s#readonly RM_BIN=/bin/rm#readonly RM_BIN=${mock_rm}#" \
   -e "s#readonly DATE_BIN=/bin/date#readonly DATE_BIN=${mock_date}#" \
+  -e "s#readonly HOMEOPS_CONTEXT_MV_BIN=/bin/mv#readonly HOMEOPS_CONTEXT_MV_BIN=${mock_homeops_context_mv}#" \
   -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
   -e "s#readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_SCRIPT=${backup_script}#" \
   -e "s#readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py#readonly HOMEOPS_EVENT_REPORTER=${event_reporter}#" \
@@ -120,6 +133,9 @@ run_deploy() {
         FAKE_CURL_LOG="${curl_log}" \
         FAKE_PUBLIC_SMOKE_FAIL="${FAKE_PUBLIC_SMOKE_FAIL:-false}" \
         FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE="${FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE:-}" \
+        FAKE_RUNNING_SERVICES="${FAKE_RUNNING_SERVICES:-}" \
+        FAKE_PENDING_CAPTURE_ON_DATA_UP="${FAKE_PENDING_CAPTURE_ON_DATA_UP:-}" \
+        FAKE_PENDING_FILE="${app_dir}/runtime-config/pending" \
         FAKE_MIGRATION_FAIL="${FAKE_MIGRATION_FAIL:-false}" \
         FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
         FAKE_CONFIG_PROJECT="${FAKE_CONFIG_PROJECT:-cubing-hub}" \
@@ -128,6 +144,9 @@ run_deploy() {
         FAKE_REVISION_THREE="${REVISION_THREE}" \
         FAKE_VALIDATION_TARGET_API_IMAGE="ghcr.io/xxh3898/cubing-hub-api:${target_revision}" \
         FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
+        FAKE_HOMEOPS_CONTEXT_CAPTURE="${FAKE_HOMEOPS_CONTEXT_CAPTURE:-}" \
+        FAKE_HOMEOPS_CONTEXT_FILE="${app_dir}/runtime-config/homeops-deployment" \
+        FAIL_HOMEOPS_CONTEXT_WRITE="${FAIL_HOMEOPS_CONTEXT_WRITE:-false}" \
         FAIL_HOMEOPS_DEPLOYMENT_START_TIME="${FAIL_HOMEOPS_DEPLOYMENT_START_TIME:-false}" \
         TMPDIR="${FAKE_TMPDIR:-}" \
         FAKE_FAIL_CP="${FAKE_FAIL_CP:-false}" \
@@ -177,6 +196,7 @@ run_recovery() {
     FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
     FAKE_CURL_LOG="${curl_log}" \
     HOMEOPS_EVENT_LOG="${event_log}" \
+    FAIL_HOMEOPS_CONTEXT_WRITE="${FAIL_HOMEOPS_CONTEXT_WRITE:-false}" \
     FAIL_HOMEOPS_DEPLOYMENT_START_TIME="${FAIL_HOMEOPS_DEPLOYMENT_START_TIME:-false}" \
     FAKE_PUBLIC_SMOKE_FAIL="${FAKE_PUBLIC_SMOKE_FAIL:-false}" \
     FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE="${FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE:-}" \
@@ -189,7 +209,113 @@ current_link="${app_dir}/runtime-config/current"
 initialization_marker="${app_dir}/.runtime-config-v2-initialized"
 bootstrap_failure_marker="${test_root}/fail-bootstrap-app-up-once"
 bootstrap_docker_log="${test_root}/bootstrap-docker.log"
+homeops_context_file="${app_dir}/runtime-config/homeops-deployment"
+homeops_context_capture="${test_root}/homeops-context-before-pull"
 : >"${bootstrap_docker_log}"
+: >"${event_log}"
+
+set +e
+FAKE_HOMEOPS_CONTEXT_CAPTURE="${homeops_context_capture}" \
+  run_deploy \
+    "${REVISION_ONE}" \
+    update \
+    "${CONFIG_DIGEST}" \
+    test-user \
+    >/dev/null 2>&1
+pre_pull_failure_exit_code="$?"
+set -e
+if [[ "${pre_pull_failure_exit_code}" -ne 1 ]] \
+  || [[ ! -f "${homeops_context_capture}" ]] \
+  || [[ -e "${homeops_context_file}" ]]
+then
+  printf 'Application pull failure must observe durable HomeOps context and clean it on normal exit\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq \
+  "TARGET_APPLICATION_REVISION=${REVISION_ONE}" \
+  "${homeops_context_capture}"
+/usr/bin/grep -Fq 'HOMEOPS_DEPLOYMENT_EVENT_KEY=cubing-hub:deploy:' \
+  "${homeops_context_capture}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+: >"${event_log}"
+/bin/cp "${homeops_context_capture}" "${homeops_context_file}"
+/bin/chmod 600 "${homeops_context_file}"
+replacement_homeops_context_capture="${test_root}/homeops-context-after-stale-finalization"
+set +e
+FAKE_HOMEOPS_CONTEXT_CAPTURE="${replacement_homeops_context_capture}" \
+  run_deploy \
+    "${REVISION_THREE}" \
+    update \
+    "${CONFIG_DIGEST}" \
+    test-user \
+    >/dev/null 2>&1
+stale_context_replacement_exit_code="$?"
+set -e
+if [[ "${stale_context_replacement_exit_code}" -ne 1 ]] \
+  || [[ ! -f "${replacement_homeops_context_capture}" ]] \
+  || [[ -e "${homeops_context_file}" ]]
+then
+  printf 'A stale valid HomeOps context must be finalized without blocking the next deployment\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq \
+  "TARGET_APPLICATION_REVISION=${REVISION_THREE}" \
+  "${replacement_homeops_context_capture}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_ONE}:" \
+  "${event_log}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_THREE}:" \
+  "${event_log}"
+: >"${event_log}"
+/bin/cp "${homeops_context_capture}" "${homeops_context_file}"
+/bin/chmod 600 "${homeops_context_file}"
+run_recovery
+test ! -e "${homeops_context_file}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_ONE}:" \
+  "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+: >"${event_log}"
+
+data_bootstrap_pending_capture="${test_root}/pending-before-data-bootstrap"
+data_bootstrap_failure_log="${test_root}/data-bootstrap-failure.log"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${ZERO_SHA}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${ZERO_SHA}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.bootstrap-pending"
+/bin/mv "${app_dir}/.env.bootstrap-pending" "${app_dir}/.env"
+set +e
+FAKE_RUNNING_SERVICES=redis \
+FAKE_PENDING_CAPTURE_ON_DATA_UP="${data_bootstrap_pending_capture}" \
+  run_deploy \
+    "${REVISION_ONE}" \
+    update \
+    "${CONFIG_DIGEST}" \
+    test-user \
+    >"${data_bootstrap_failure_log}" 2>&1
+data_bootstrap_failure_exit_code="$?"
+set -e
+if [[ "${data_bootstrap_failure_exit_code}" -ne 1 ]] \
+  || [[ ! -f "${data_bootstrap_pending_capture}" ]] \
+  || [[ ! -f "${app_dir}/runtime-config/pending" ]]
+then
+  printf 'Data-service bootstrap failure must retain the operational pending transaction\n' >&2
+  /bin/cat "${data_bootstrap_failure_log}" >&2
+  exit 1
+fi
+/usr/bin/grep -Fxq "PREVIOUS_APPLICATION_REVISION=${ZERO_SHA}" \
+  "${data_bootstrap_pending_capture}"
+/usr/bin/grep -Fxq "TARGET_APPLICATION_REVISION=${REVISION_ONE}" \
+  "${data_bootstrap_pending_capture}"
+run_recovery
+test ! -e "${app_dir}/runtime-config/pending"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_TWO}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.after-bootstrap-recovery"
+/bin/mv "${app_dir}/.env.after-bootstrap-recovery" "${app_dir}/.env"
 : >"${event_log}"
 
 # The first v2 update must use the artifact worker without requiring the fixed
@@ -503,6 +629,32 @@ run_recovery
 test ! -e "${pending_file}"
 /usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy-recovery:' "${event_log}"
 /usr/bin/grep -Fq '"status":"SUCCESS"' "${event_log}"
+
+write_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_THREE}" \
+  "${CONFIG_DIGEST}"
+/usr/bin/sed \
+  -e "s#^API_IMAGE=.*#API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}#" \
+  -e "s#^WEB_IMAGE=.*#WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${REVISION_THREE}#" \
+  "${app_dir}/.env" >"${app_dir}/.env.recovery-context-failure"
+/bin/mv "${app_dir}/.env.recovery-context-failure" "${app_dir}/.env"
+: >"${event_log}"
+FAIL_HOMEOPS_CONTEXT_WRITE=true run_recovery
+test ! -e "${pending_file}"
+test ! -e "${homeops_context_file}"
+/usr/bin/grep -Fxq \
+  "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
+  "${app_dir}/.env"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_THREE}:2026-08-06T00:00:00Z" \
+  "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+if /usr/bin/grep -Fq 'cubing-hub:deploy-recovery:' "${event_log}"; then
+  printf 'Failed recovery context persistence must not start an untracked recovery event\n' >&2
+  exit 1
+fi
 
 release_one="${app_dir}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
 release_two="${app_dir}/runtime-config/releases/${CONFIG_DIGEST_TWO#sha256:}"

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -32,6 +32,7 @@ runtime_backup_script="${test_root}/runtime-backup.sh"
 backup_log="${test_root}/backup.log"
 event_log="${test_root}/homeops-events.log"
 event_reporter="${test_root}/report-homeops-event.py"
+mock_rm="${test_root}/rm"
 backup_args_log="${test_root}/backup-args.log"
 curl_log="${test_root}/curl.log"
 runtime_compose="${test_root}/runtime-compose.yaml"
@@ -66,12 +67,22 @@ printf '%s\n' \
   'printf "\n" >>"${HOMEOPS_EVENT_LOG}"' \
   >"${event_reporter}"
 /bin/chmod 700 "${event_reporter}"
+: >"${test_root}/cleanup-rm.log"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'if [[ "${FAIL_DEPLOY_CLEANUP:-false}" == true && "$*" == *cubing-hub-docker-config.* ]]; then' \
+  '  exit 75' \
+  'fi' \
+  'exec /bin/rm "$@"' \
+  >"${mock_rm}"
+/bin/chmod 700 "${mock_rm}"
 : >"${backup_args_log}"
 : >"${curl_log}"
 
 /usr/bin/sed \
   -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
   -e "s#readonly CURL_BIN=/usr/bin/curl#readonly CURL_BIN=${MOCK_CURL}#" \
+  -e "s#readonly RM_BIN=/bin/rm#readonly RM_BIN=${mock_rm}#" \
   -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
   -e "s#readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_SCRIPT=${backup_script}#" \
   -e "s#readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py#readonly HOMEOPS_EVENT_REPORTER=${event_reporter}#" \
@@ -107,6 +118,7 @@ run_deploy() {
         FAKE_REVISION_THREE="${REVISION_THREE}" \
         FAKE_VALIDATION_TARGET_API_IMAGE="ghcr.io/xxh3898/cubing-hub-api:${target_revision}" \
         FAKE_DOCKER_LOG="${FAKE_DOCKER_LOG:-}" \
+        TMPDIR="${FAKE_TMPDIR:-}" \
         FAKE_FAIL_CP="${FAKE_FAIL_CP:-false}" \
         FAKE_FAIL_APP_UP_ONCE_FILE="${FAKE_FAIL_APP_UP_ONCE_FILE:-}" \
         FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT="${FAKE_CANDIDATE_API_EXTRA_ENVIRONMENT:-}" \
@@ -165,6 +177,7 @@ initialization_marker="${app_dir}/.runtime-config-v2-initialized"
 bootstrap_failure_marker="${test_root}/fail-bootstrap-app-up-once"
 bootstrap_docker_log="${test_root}/bootstrap-docker.log"
 : >"${bootstrap_docker_log}"
+: >"${event_log}"
 
 # The first v2 update must use the artifact worker without requiring the fixed
 # pre-v2 backup fallback to be executable.
@@ -190,6 +203,9 @@ test ! -e "${state_file}"
 test ! -e "${current_link}"
 test ! -e "${initialization_marker}"
 test ! -e "${app_dir}/runtime-config/pending"
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy:' "${event_log}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Eq '"status":"(FAILED|ROLLED_BACK)"' "${event_log}"
 /usr/bin/grep -Fxq \
   "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_TWO}" \
   "${app_dir}/.env"
@@ -210,6 +226,25 @@ run_deploy \
   update \
   "${CONFIG_DIGEST}" \
   test-user
+
+: >"${event_log}"
+set +e
+FAKE_TMPDIR="${test_root}" \
+FAIL_DEPLOY_CLEANUP=true \
+  run_deploy "${REVISION_ONE}" keep test-user >/dev/null 2>&1
+cleanup_failure_exit_code="$?"
+set -e
+if [[ "${cleanup_failure_exit_code}" -ne 1 ]]; then
+  printf 'Successful deploy with credential cleanup failure must fail\n' >&2
+  exit 1
+fi
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy:' "${event_log}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+if /usr/bin/grep -Fq '"status":"SUCCESS"' "${event_log}"; then
+  printf 'Credential cleanup failure must not report deployment success\n' >&2
+  exit 1
+fi
 
 test -f "${state_file}"
 test "$(/bin/cat "${initialization_marker}")" = RUNTIME_CONFIG_V2=initialized

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -58,6 +58,7 @@ printf '%s\n' \
   '#!/bin/bash' \
   'printf "%s\n" "${BASH_SOURCE[0]}" >>"${FAKE_BACKUP_LOG}"' \
   'printf "%s\n" "$*" >>"${FAKE_BACKUP_ARGS_LOG}"' \
+  'if [[ "${FAKE_BACKUP_FAIL:-false}" == true ]]; then exit 1; fi' \
   >"${backup_script}"
 /bin/cp "${backup_script}" "${runtime_backup_script}"
 /bin/chmod 700 "${backup_script}" "${runtime_backup_script}"
@@ -130,6 +131,7 @@ run_deploy() {
         FAKE_BACKUP_LOG="${backup_log}" \
         HOMEOPS_EVENT_LOG="${event_log}" \
         FAKE_BACKUP_ARGS_LOG="${backup_args_log}" \
+        FAKE_BACKUP_FAIL="${FAKE_BACKUP_FAIL:-false}" \
         FAKE_CURL_LOG="${curl_log}" \
         FAKE_PUBLIC_SMOKE_FAIL="${FAKE_PUBLIC_SMOKE_FAIL:-false}" \
         FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE="${FAKE_PUBLIC_SMOKE_FAIL_ONCE_FILE:-}" \
@@ -759,6 +761,51 @@ fi
 /bin/rm -f -- "${app_dir}/runtime-config/current"
 /bin/ln -s "releases/${CONFIG_DIGEST#sha256:}" "${app_dir}/runtime-config/current"
 
+write_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_THREE}" \
+  "${CONFIG_DIGEST}"
+printf 'UNKNOWN=value\n' >"${homeops_context_file}"
+: >"${event_log}"
+run_recovery
+test ! -e "${pending_file}"
+test -f "${homeops_context_file}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_THREE}:2026-08-06T00:00:00Z" \
+  "${event_log}"
+/usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
+if /usr/bin/grep -Fq 'cubing-hub:deploy-recovery:' "${event_log}"; then
+  printf 'Invalid optional HomeOps context must not create an untracked recovery event\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${homeops_context_file}"
+
+write_pending_fixture \
+  "${REVISION_TWO}" \
+  "${CONFIG_DIGEST}" \
+  "${REVISION_THREE}" \
+  "${CONFIG_DIGEST}"
+{
+  printf 'HOMEOPS_DEPLOYMENT_EVENT_KEY=cubing-hub:deploy:%s:2026-08-06T00:00:00Z\n' \
+    "${REVISION_TWO}"
+  printf 'HOMEOPS_DEPLOYMENT_STARTED_AT=2026-08-06T00:00:00Z\n'
+  printf 'TARGET_APPLICATION_REVISION=%s\n' "${REVISION_TWO}"
+} >"${homeops_context_file}"
+/bin/chmod 600 "${homeops_context_file}"
+: >"${event_log}"
+run_recovery
+test ! -e "${pending_file}"
+test -f "${homeops_context_file}"
+/usr/bin/grep -Fq \
+  "cubing-hub:deploy:${REVISION_THREE}:2026-08-06T00:00:00Z" \
+  "${event_log}"
+if /usr/bin/grep -Fq 'cubing-hub:deploy-recovery:' "${event_log}"; then
+  printf 'Mismatched optional HomeOps context must not create an untracked recovery event\n' >&2
+  exit 1
+fi
+/bin/rm -f -- "${homeops_context_file}"
+
 printf 'UNKNOWN=value\n' >"${pending_file}"
 set +e
 run_recovery >/dev/null 2>&1
@@ -769,6 +816,57 @@ if [[ "${recovery_exit_code}" -ne 1 || ! -f "${pending_file}" ]]; then
   exit 1
 fi
 /bin/rm -f -- "${pending_file}"
+
+update_preflight_log="${test_root}/update-preflight-docker.log"
+: >"${update_preflight_log}"
+set +e
+FAKE_DOCKER_LOG="${update_preflight_log}" \
+FAKE_RUNNING_SERVICES=redis \
+FAKE_CONFIG_REVISION="${REVISION_ONE}" \
+  run_deploy \
+    "${REVISION_ONE}" \
+    update \
+    "${CONFIG_DIGEST_THREE}" \
+    test-user \
+    >/dev/null 2>&1
+missing_db_update_exit_code="$?"
+set -e
+if [[ "${missing_db_update_exit_code}" -ne 1 ]] \
+  || [[ -e "${pending_file}" ]] \
+  || [[ -e "${homeops_context_file}" ]]
+then
+  printf 'Existing update DB preflight failure must not leave a pending transaction\n' >&2
+  exit 1
+fi
+if /usr/bin/grep -Fq 'MigrationMain' "${update_preflight_log}"; then
+  printf 'Existing update DB preflight failure must not run migration\n' >&2
+  exit 1
+fi
+
+: >"${update_preflight_log}"
+set +e
+FAKE_DOCKER_LOG="${update_preflight_log}" \
+FAKE_BACKUP_FAIL=true \
+FAKE_CONFIG_REVISION="${REVISION_ONE}" \
+  run_deploy \
+    "${REVISION_ONE}" \
+    update \
+    "${CONFIG_DIGEST_THREE}" \
+    test-user \
+    >/dev/null 2>&1
+backup_failure_update_exit_code="$?"
+set -e
+if [[ "${backup_failure_update_exit_code}" -ne 1 ]] \
+  || [[ -e "${pending_file}" ]] \
+  || [[ -e "${homeops_context_file}" ]]
+then
+  printf 'Existing update backup failure must not leave a pending transaction\n' >&2
+  exit 1
+fi
+if /usr/bin/grep -Fq 'MigrationMain' "${update_preflight_log}"; then
+  printf 'Existing update backup failure must not run migration\n' >&2
+  exit 1
+fi
 
 set +e
 FAKE_SERVICE_HEALTH=unhealthy \

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -29,6 +29,8 @@ test_script="${test_root}/deploy-cubing-hub.sh"
 backup_script="${test_root}/backup.sh"
 runtime_backup_script="${test_root}/runtime-backup.sh"
 backup_log="${test_root}/backup.log"
+event_log="${test_root}/homeops-events.log"
+event_reporter="${test_root}/report-homeops-event.py"
 runtime_compose="${test_root}/runtime-compose.yaml"
 runtime_real_ip="${test_root}/cloudflare-edge-real-ip.conf"
 /bin/mkdir -p "${app_dir}"
@@ -52,11 +54,20 @@ printf '%s\n' \
 /bin/cp "${backup_script}" "${runtime_backup_script}"
 /bin/chmod 700 "${backup_script}" "${runtime_backup_script}"
 : >"${backup_log}"
+: >"${event_log}"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "%s " "$1" >>"${HOMEOPS_EVENT_LOG}"' \
+  '/bin/cat >>"${HOMEOPS_EVENT_LOG}"' \
+  'printf "\n" >>"${HOMEOPS_EVENT_LOG}"' \
+  >"${event_reporter}"
+/bin/chmod 700 "${event_reporter}"
 
 /usr/bin/sed \
   -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
   -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
   -e "s#readonly BACKUP_SCRIPT=/Users/homeserver/Server/scripts/backup/backup-cubing-hub.sh#readonly BACKUP_SCRIPT=${backup_script}#" \
+  -e "s#readonly HOMEOPS_EVENT_REPORTER=/Users/homeserver/Server/apps/homeops/runtime-config/current/scripts/report-homeops-event.py#readonly HOMEOPS_EVENT_REPORTER=${event_reporter}#" \
   "${SOURCE_SCRIPT}" \
   >"${test_script}"
 /bin/chmod 700 "${test_script}" "${MOCK_DOCKER}"
@@ -76,6 +87,7 @@ run_deploy() {
         FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX="${FAKE_RUNTIME_INVALID_DEPLOY_SYNTAX:-false}" \
         FAKE_RUNTIME_SYMLINK="${FAKE_RUNTIME_SYMLINK:-false}" \
         FAKE_BACKUP_LOG="${backup_log}" \
+        HOMEOPS_EVENT_LOG="${event_log}" \
         FAKE_CONFIG_REVISION="${FAKE_CONFIG_REVISION:-${REVISION_ONE}}" \
         FAKE_CONFIG_PROJECT="${FAKE_CONFIG_PROJECT:-cubing-hub}" \
         FAKE_REVISION_ONE="${REVISION_ONE}" \
@@ -690,5 +702,8 @@ fi
 /usr/bin/grep -Fxq \
   "API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:${REVISION_THREE}" \
   "${app_dir}/.env"
+/usr/bin/grep -Fq 'deployments {"eventKey":"cubing-hub:deploy:' "${event_log}"
+/usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
+/usr/bin/grep -Eq '"status":"(SUCCESS|ROLLED_BACK|FAILED)"' "${event_log}"
 
 printf 'Cubing Hub focused deploy v2 tests passed\n'


### PR DESCRIPTION
## 변경 내용

- 배포 lifecycle 이벤트를 HomeOps reporter로 전달
- 백업 결과 metadata와 실패 상태를 HomeOps로 전달
- reporter 실패가 기존 배포·백업 결과를 바꾸지 않도록 mock 회귀 테스트 보강

## 검증

- `/bin/bash -n` 대상 스크립트 검사
- deploy·backup focused mock 테스트

## 비범위

- 운영 runtime-config 반영
- HomeOps secret·ingestion 설정 변경
- 운영 배포 및 백업 실행