### PR TITLE
fix: Cloudflare edge proxy trust를 CIDR 기반으로 변경

### DIFF
--- a/homeserver/nginx/cloudflare-edge-real-ip.conf
+++ b/homeserver/nginx/cloudflare-edge-real-ip.conf
@@ -1,4 +1,4 @@
 # The shared Mac mini cloudflared connector is pinned to this edge address.
-set_real_ip_from 172.18.0.2;
+set_real_ip_from 172.18.0.0/16;
 real_ip_header CF-Connecting-IP;
 real_ip_recursive off;

--- a/homeserver/nginx/home-server.conf
+++ b/homeserver/nginx/home-server.conf
@@ -1,6 +1,6 @@
-map $realip_remote_addr $trusted_tunnel_request {
-    172.18.0.2 1;
+geo $trusted_tunnel_request {
     default 0;
+    172.18.0.0/16 1;
 }
 
 map "$trusted_tunnel_request:$http_x_forwarded_proto" $external_scheme {

--- a/homeserver/scripts/nginx-config.test.mjs
+++ b/homeserver/scripts/nginx-config.test.mjs
@@ -11,20 +11,29 @@ const realIpConfig = await readFile(
   "utf8",
 );
 
-test("should_trustOnlyPinnedSharedConnector_when_realIpIsEnabled", () => {
-  assert.match(realIpConfig, /set_real_ip_from 172\.18\.0\.2;/);
-  assert.match(realIpConfig, /real_ip_header CF-Connecting-IP;/);
-  assert.match(realIpConfig, /real_ip_recursive off;/);
+test("should_trustSharedEdgeNetwork_when_realIpIsEnabled", () => {
+  assert.match(
+    realIpConfig,
+    /set_real_ip_from 172\.18\.0\.0\/16;/,
+  );
+  assert.match(
+    realIpConfig,
+    /real_ip_header CF-Connecting-IP;/,
+  );
+  assert.match(
+    realIpConfig,
+    /real_ip_recursive off;/,
+  );
   assert.doesNotMatch(
     realIpConfig,
-    /set_real_ip_from (?:0\.0\.0\.0\/0|10\.0\.0\.0\/8|172\.18\.0\.0\/16|192\.168\.0\.0\/16);/,
+    /set_real_ip_from (?:0\.0\.0\.0\/0|10\.0\.0\.0\/8|172\.16\.0\.0\/12|192\.168\.0\.0\/16);/,
   );
 });
 
-test("should_honorForwardedSchemeOnlyFromPinnedConnector", () => {
+test("should_honorForwardedSchemeOnlyFromTrustedEdgeNetwork", () => {
   assert.match(
     nginxConfig,
-    /map \$realip_remote_addr \$trusted_tunnel_request \{[\s\S]*172\.18\.0\.2 1;[\s\S]*default 0;[\s\S]*\}/,
+    /geo \$trusted_tunnel_request \{[\s\S]*default 0;[\s\S]*172\.18\.0\.0\/16 1;[\s\S]*\}/,
   );
   assert.match(
     nginxConfig,


### PR DESCRIPTION
## 변경 내용
- shared cloudflared의 고정 IP `172.18.0.2` 의존성 제거
- production edge 네트워크 `172.18.0.0/16`을 trusted proxy 범위로 사용
- Nginx `real_ip` 신뢰 범위를 edge CIDR 기준으로 변경
- forwarded scheme 판정을 `map + 단일 IP`에서 `geo + CIDR` 기반으로 변경
- 기존 Nginx 회귀 테스트를 새로운 proxy trust 계약에 맞게 갱신

## 배경
shared cloudflared 컨테이너의 edge IP는 재생성 시 변경될 수 있는데, 기존 설정은 `172.18.0.2` 단일 주소만 trusted proxy로 인정하고 있었습니다.

현재 cloudflared가 다른 edge IP를 할당받으면서 forwarded protocol 및 real IP 처리 계약이 깨질 수 있는 상태였고, 이를 container IP가 아닌 전용 edge network CIDR 기준으로 변경했습니다.

## 검증
- Infrastructure checks 통과
- Nginx config tests 통과
- API forwarded metadata 검증 유지
- 과도한 private network trust 방지 테스트 유지