### PR TITLE
ci: validate pull requests targeting dev

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,7 @@ on:
       - dev
   pull_request:
     branches:
+      - dev
       - main
   workflow_call:
 

--- a/docs/06-quality/quality-gates.md
+++ b/docs/06-quality/quality-gates.md
@@ -15,12 +15,13 @@ related:
 ## CI trigger
 
 - dev push
+- dev 대상 pull request
 - main 대상 pull request
 - 다른 workflow의 workflow_call
 
 changed path classifier가 backend, frontend, infrastructure, API image, Web image 검증 범위를 결정한다.
 
-현재 `feat/* → dev` pull request 자체는 Validate를 시작하지 않는다. V2.1은 backend, Flyway, frontend가 연결된 변경이므로 merge 뒤 dev push에서 처음 검증하는 것보다, 별도 승인된 workflow 변경으로 `pull_request` target에 dev를 추가해 feature PR head를 merge 전에 검증하는 방향을 권장한다. 이 문서 작업에서는 workflow를 변경하지 않는다.
+이 trigger 계약으로 `feat/* → dev`와 `dev → main` pull request는 모두 merge 전에 Validate를 실행한다. Dev push validation도 integration branch의 merge 결과를 계속 검증한다.
 
 ## Backend gate
 

--- a/docs/07-operations/ci-cd.md
+++ b/docs/07-operations/ci-cd.md
@@ -9,12 +9,30 @@ tags: []
 related:
   - .github/workflows/validate.yml
   - .github/workflows/deploy.yml
+  - homeserver/scripts/workflow-config.test.mjs
 ---
 # CI/CD
 
 ## Validation
 
-validate workflow는 dev push와 main pull request에서 시작하고 workflow_call도 지원한다. changed path classifier가 필요한 backend, frontend, infrastructure, image job을 선택한다.
+Validate workflow는 다음 event에서 시작한다.
+
+- dev push
+- dev 대상 pull request
+- main 대상 pull request
+- 다른 workflow의 workflow_call
+
+changed path classifier가 필요한 backend, frontend, infrastructure, image job을 선택한다.
+
+Branch flow는 다음 pre-merge validation을 사용한다.
+
+```text
+feat/* → dev PR
+→ Validate before merge
+
+dev → main PR
+→ Validate before merge
+```
 
 - backend: Java 17 test, JaCoCo report, REST Docs, build
 - frontend: Node.js 20 install, lint, test, build
@@ -28,7 +46,8 @@ main push는 deploy workflow의 release validation을 시작한다. deployment f
 ## 승인 경계
 
 - dev push는 CI 실행
-- PR 생성은 remote collaboration
+- dev 또는 main 대상 PR은 pre-merge Validate 실행
+- PR 생성은 remote collaboration이며 merge 권한을 포함하지 않음
 - main merge는 release workflow 시작
 - production variable이 enable된 경우 merge가 실제 deploy로 이어질 수 있음
 

--- a/homeserver/scripts/workflow-config.test.mjs
+++ b/homeserver/scripts/workflow-config.test.mjs
@@ -16,14 +16,14 @@ const [
     read("../../scripts/classify-ci-paths.sh"),
   ]);
 
-test("should_validateDevPushAndMainPullRequestsBeforeRelease", () => {
+test("should_validateDevPushAndDevAndMainPullRequestsBeforeRelease", () => {
   assert.match(
     validateWorkflow,
     /push:\n    branches:\n      - dev/,
   );
   assert.match(
     validateWorkflow,
-    /pull_request:\n    branches:\n      - main/,
+    /pull_request:\n    branches:\n      - dev\n      - main/,
   );
   assert.match(validateWorkflow, /workflow_call:/);
   assert.match(


### PR DESCRIPTION
## Summary

- `dev` 대상 pull request에서도 Validate workflow 실행
- 기존 `main` 대상 PR validation 유지
- Workflow trigger regression test를 dev/main 계약으로 보강
- CI 운영·품질 문서를 실제 trigger와 동기화

## New validation flow

```text
feat/* → dev PR
→ Validate before merge

dev → main PR
→ Validate before merge
```

## Bootstrap note

이 PR의 base인 기존 `dev` workflow는 아직 `pull_request → dev` trigger를 포함하지 않으므로 이 PR 자체에는 pre-merge Validate가 실행되지 않을 수 있습니다.

Merge 이후 `dev` push Validate가 성공하면 이후 `feat/* → dev` PR부터 새 trigger가 적용됩니다.

## Verification

- `git diff --check` 통과
- Workflow YAML syntax와 exact dev/main trigger static validation 통과
- Docs frontmatter, H1, local link, related path validation 통과
- Secret pattern 검사 통과
- Host Node executable이 없어 `node --test homeserver/scripts/workflow-config.test.mjs`는 실행하지 않음
- PR #10 merge 뒤 dev Validate run 31384962527 success 확인

## Scope

CI trigger와 관련 문서/test만 변경.

Application code, DB/Flyway, deploy workflow, production runtime은 변경하지 않음.