### PR TITLE
feat: add V2.1 record foundation

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -232,6 +232,7 @@ include::{snippets}/record/create/request-fields.adoc[]
 
 ==== 응답
 include::{snippets}/record/create/http-response.adoc[]
+include::{snippets}/record/create/response-fields.adoc[]
 
 ==== 실패 응답
 ===== 유효하지 않은 기록 저장 요청

--- a/backend/src/main/java/com/cubinghub/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/cubinghub/common/exception/GlobalExceptionHandler.java
@@ -6,12 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MissingRequestCookieException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 @Slf4j
@@ -88,6 +89,17 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST.value(), requestSummary(request), ex.getName(), ex.getValue());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(HttpStatus.BAD_REQUEST, errorMessage));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex,
+            HttpServletRequest request
+    ) {
+        log.warn("요청 본문 해석 실패 - status: {}, request: {}, reason: {}",
+                HttpStatus.BAD_REQUEST.value(), requestSummary(request), ex.getClass().getSimpleName());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST, "잘못된 요청 형식입니다."));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/backend/src/main/java/com/cubinghub/domain/home/service/HomeService.java
+++ b/backend/src/main/java/com/cubinghub/domain/home/service/HomeService.java
@@ -56,7 +56,7 @@ public class HomeService {
             throw ex;
         }
 
-        List<HomeRecentRecordResponse> recentRecords = recordRepository.findByUserIdOrderByCreatedAtDesc(
+        List<HomeRecentRecordResponse> recentRecords = recordRepository.findByUserIdOrderByCreatedAtDescIdDesc(
                         profile.getUserId(),
                         PageRequest.of(0, RECENT_RECORD_LIMIT)
                 ).getContent().stream()

--- a/backend/src/main/java/com/cubinghub/domain/record/controller/RecordController.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/controller/RecordController.java
@@ -1,11 +1,12 @@
 package com.cubinghub.domain.record.controller;
 
 import com.cubinghub.common.response.ApiResponse;
-import com.cubinghub.common.response.IdResponse;
 import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
 import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
 import com.cubinghub.domain.record.dto.response.RecordPenaltyUpdateResponse;
 import com.cubinghub.domain.record.service.RecordService;
+import com.cubinghub.domain.record.service.RecordSubmissionService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -27,15 +28,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecordController {
 
     private final RecordService recordService;
+    private final RecordSubmissionService recordSubmissionService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<IdResponse>> saveRecord(
+    public ResponseEntity<ApiResponse<RecordCreateResponse>> saveRecord(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid RecordSaveRequest request
     ) {
-        Long recordId = recordService.saveRecord(userDetails.getUsername(), request);
-        return ResponseEntity.created(URI.create("/api/records/" + recordId))
-                .body(ApiResponse.success(HttpStatus.CREATED, "기록이 저장되었습니다.", new IdResponse(recordId)));
+        RecordCreateResponse response = recordSubmissionService.submit(userDetails.getUsername(), request);
+        return ResponseEntity.created(URI.create("/api/records/" + response.getId()))
+                .body(ApiResponse.success(HttpStatus.CREATED, "기록이 저장되었습니다.", response));
     }
 
     @PatchMapping("/{recordId}")

--- a/backend/src/main/java/com/cubinghub/domain/record/dto/internal/RecordSubmissionLookup.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/dto/internal/RecordSubmissionLookup.java
@@ -1,0 +1,23 @@
+package com.cubinghub.domain.record.dto.internal;
+
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
+import com.cubinghub.domain.record.entity.Record;
+
+public record RecordSubmissionLookup(RecordCreateResponse record, byte[] payloadHash) {
+
+    public RecordSubmissionLookup {
+        payloadHash = payloadHash == null ? null : payloadHash.clone();
+    }
+
+    @Override
+    public byte[] payloadHash() {
+        return payloadHash == null ? null : payloadHash.clone();
+    }
+
+    public static RecordSubmissionLookup from(Record record) {
+        return new RecordSubmissionLookup(
+                RecordCreateResponse.from(record),
+                record.getClientSubmissionPayloadHash()
+        );
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/dto/request/RecordSaveRequest.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/dto/request/RecordSaveRequest.java
@@ -1,10 +1,12 @@
 package com.cubinghub.domain.record.dto.request;
 
 import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
 import com.cubinghub.domain.record.entity.Penalty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,4 +31,12 @@ public class RecordSaveRequest {
 
     @NotBlank(message = "Scramble is required")
     private String scramble;
+
+    private InputMethod inputMethod;
+
+    private UUID clientSubmissionId;
+
+    public InputMethod normalizedInputMethod() {
+        return inputMethod == null ? InputMethod.UNKNOWN : inputMethod;
+    }
 }

--- a/backend/src/main/java/com/cubinghub/domain/record/dto/response/RecordCreateResponse.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/dto/response/RecordCreateResponse.java
@@ -1,4 +1,4 @@
-package com.cubinghub.domain.user.dto.response;
+package com.cubinghub.domain.record.dto.response;
 
 import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.record.entity.InputMethod;
@@ -8,41 +8,45 @@ import java.time.Instant;
 import lombok.Getter;
 
 @Getter
-public class MyProfileRecordResponse {
+public class RecordCreateResponse {
 
     private final Long id;
     private final EventType eventType;
     private final Integer timeMs;
-    private final Integer effectiveTimeMs;
     private final Penalty penalty;
+    private final Integer effectiveTimeMs;
+    private final String scramble;
     private final InputMethod inputMethod;
     private final Instant createdAt;
 
-    public MyProfileRecordResponse(
+    public RecordCreateResponse(
             Long id,
             EventType eventType,
             Integer timeMs,
-            Integer effectiveTimeMs,
             Penalty penalty,
+            Integer effectiveTimeMs,
+            String scramble,
             InputMethod inputMethod,
             Instant createdAt
     ) {
         this.id = id;
         this.eventType = eventType;
         this.timeMs = timeMs;
-        this.effectiveTimeMs = effectiveTimeMs;
         this.penalty = penalty;
+        this.effectiveTimeMs = effectiveTimeMs;
+        this.scramble = scramble;
         this.inputMethod = inputMethod;
         this.createdAt = createdAt;
     }
 
-    public static MyProfileRecordResponse from(Record record) {
-        return new MyProfileRecordResponse(
+    public static RecordCreateResponse from(Record record) {
+        return new RecordCreateResponse(
                 record.getId(),
                 record.getEventType(),
                 record.getTimeMs(),
-                record.getEffectiveTimeMs(),
                 record.getPenalty(),
+                record.getEffectiveTimeMs(),
+                record.getScramble(),
                 record.getInputMethod(),
                 record.getCreatedAt()
         );

--- a/backend/src/main/java/com/cubinghub/domain/record/entity/InputMethod.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/entity/InputMethod.java
@@ -1,0 +1,7 @@
+package com.cubinghub.domain.record.entity;
+
+public enum InputMethod {
+    UNKNOWN,
+    KEYBOARD,
+    TOUCH
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/entity/InputMethodConverter.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/entity/InputMethodConverter.java
@@ -1,0 +1,18 @@
+package com.cubinghub.domain.record.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class InputMethodConverter implements AttributeConverter<InputMethod, String> {
+
+    @Override
+    public String convertToDatabaseColumn(InputMethod attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public InputMethod convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : InputMethod.valueOf(dbData);
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/entity/Record.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/entity/Record.java
@@ -16,7 +16,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "records", indexes = {
         @Index(name = "idx_record_event_time", columnList = "event_type, time_ms"),
-        @Index(name = "idx_record_user_created_at", columnList = "user_id, created_at")
+        @Index(name = "idx_record_user_created_at", columnList = "user_id, created_at"),
+        @Index(name = "idx_record_user_event_created_at_id", columnList = "user_id, event_type, created_at, id")
+}, uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_record_user_client_submission",
+                columnNames = {"user_id", "client_submission_id"}
+        )
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Record extends BaseTimeEntity {
@@ -49,13 +55,37 @@ public class Record extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String scramble;
 
+    @Convert(converter = InputMethodConverter.class)
+    @Column(name = "input_method", length = 32)
+    private InputMethod inputMethod;
+
+    @Column(name = "client_submission_id", columnDefinition = "CHAR(36)", length = 36)
+    private String clientSubmissionId;
+
+    @Column(name = "client_submission_payload_hash", columnDefinition = "BINARY(32)", length = 32)
+    private byte[] clientSubmissionPayloadHash;
+
     @Builder
-    public Record(User user, EventType eventType, Integer timeMs, Penalty penalty, String scramble) {
+    public Record(
+            User user,
+            EventType eventType,
+            Integer timeMs,
+            Penalty penalty,
+            String scramble,
+            InputMethod inputMethod,
+            String clientSubmissionId,
+            byte[] clientSubmissionPayloadHash
+    ) {
         this.user = user;
         this.eventType = eventType;
         this.timeMs = timeMs;
         this.penalty = penalty;
         this.scramble = scramble;
+        this.inputMethod = inputMethod;
+        this.clientSubmissionId = clientSubmissionId;
+        this.clientSubmissionPayloadHash = clientSubmissionPayloadHash == null
+                ? null
+                : clientSubmissionPayloadHash.clone();
     }
 
     public void updatePenalty(Penalty penalty) {
@@ -64,5 +94,13 @@ public class Record extends BaseTimeEntity {
 
     public Integer getEffectiveTimeMs() {
         return penalty.applyTo(timeMs);
+    }
+
+    public InputMethod getInputMethod() {
+        return inputMethod == null ? InputMethod.UNKNOWN : inputMethod;
+    }
+
+    public byte[] getClientSubmissionPayloadHash() {
+        return clientSubmissionPayloadHash == null ? null : clientSubmissionPayloadHash.clone();
     }
 }

--- a/backend/src/main/java/com/cubinghub/domain/record/policy/PracticeEventCapabilities.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/policy/PracticeEventCapabilities.java
@@ -1,0 +1,61 @@
+package com.cubinghub.domain.record.policy;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.record.entity.EventType;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PracticeEventCapabilities {
+
+    public static final String UNSUPPORTED_EVENT_MESSAGE = "지원하지 않는 Practice 종목입니다.";
+
+    private final Map<EventType, PracticeEventCapability> capabilities;
+
+    public PracticeEventCapabilities() {
+        EnumMap<EventType, PracticeEventCapability> configured = new EnumMap<>(EventType.class);
+        configured.put(
+                EventType.WCA_333,
+                new PracticeEventCapability(
+                        EventType.WCA_333,
+                        ResultKind.TIME,
+                        true,
+                        true,
+                        true,
+                        true
+                )
+        );
+        capabilities = Collections.unmodifiableMap(configured);
+    }
+
+    public Optional<PracticeEventCapability> get(EventType eventType) {
+        return Optional.ofNullable(capabilities.get(eventType));
+    }
+
+    public void requireScrambleSupported(EventType eventType) {
+        requireSupported(eventType, PracticeEventCapability::scrambleSupported);
+    }
+
+    public void requirePracticeRecordSupported(EventType eventType) {
+        requireSupported(eventType, PracticeEventCapability::practiceRecordSupported);
+    }
+
+    public void requirePracticeRankingSupported(EventType eventType) {
+        requireSupported(eventType, PracticeEventCapability::practiceRankingSupported);
+    }
+
+    private void requireSupported(
+            EventType eventType,
+            Predicate<PracticeEventCapability> supportPredicate
+    ) {
+        PracticeEventCapability capability = capabilities.get(eventType);
+        if (capability == null || !supportPredicate.test(capability)) {
+            throw new CustomApiException(UNSUPPORTED_EVENT_MESSAGE, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/policy/PracticeEventCapability.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/policy/PracticeEventCapability.java
@@ -1,0 +1,13 @@
+package com.cubinghub.domain.record.policy;
+
+import com.cubinghub.domain.record.entity.EventType;
+
+public record PracticeEventCapability(
+        EventType eventType,
+        ResultKind resultKind,
+        boolean practiceTimerSupported,
+        boolean scrambleSupported,
+        boolean practiceRecordSupported,
+        boolean practiceRankingSupported
+) {
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/policy/ResultKind.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/policy/ResultKind.java
@@ -1,0 +1,5 @@
+package com.cubinghub.domain.record.policy;
+
+public enum ResultKind {
+    TIME
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/repository/RecordRepository.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/repository/RecordRepository.java
@@ -1,16 +1,23 @@
 package com.cubinghub.domain.record.repository;
 
 import com.cubinghub.domain.record.entity.Record;
+import com.cubinghub.domain.record.entity.EventType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long>, RecordRepositoryCustom {
-    List<Record> findByUserIdOrderByCreatedAtDesc(Long userId);
+    Page<Record> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
 
-    Page<Record> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    Page<Record> findByUserIdAndEventTypeOrderByCreatedAtDescIdDesc(
+            Long userId,
+            EventType eventType,
+            Pageable pageable
+    );
+
+    Optional<Record> findByUserEmailAndClientSubmissionId(String email, String clientSubmissionId);
 }

--- a/backend/src/main/java/com/cubinghub/domain/record/service/RecordService.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/service/RecordService.java
@@ -1,16 +1,19 @@
 package com.cubinghub.domain.record.service;
 
-import com.cubinghub.common.validation.InputConstraints;
 import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.common.validation.InputConstraints;
+import com.cubinghub.domain.record.dto.internal.RecordSubmissionLookup;
 import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
 import com.cubinghub.domain.record.dto.response.RecordPenaltyUpdateResponse;
 import com.cubinghub.domain.record.dto.response.RankingPageResponse;
 import com.cubinghub.domain.record.dto.response.RankingResponse;
-import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
 import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.record.entity.Penalty;
 import com.cubinghub.domain.record.entity.Record;
 import com.cubinghub.domain.record.entity.UserPB;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import com.cubinghub.domain.record.repository.RankingQueryResult;
 import com.cubinghub.domain.record.repository.RecordRepository;
 import com.cubinghub.domain.record.repository.UserPBRepository;
@@ -36,12 +39,14 @@ public class RecordService {
     private final UserPBRepository userPBRepository;
     private final UserRepository userRepository;
     private final RankingRedisService rankingRedisService;
+    private final PracticeEventCapabilities eventCapabilities;
 
     public RankingPageResponse getRankings(EventType eventType, String nickname, Integer page, Integer size) {
         return getRankings(eventType, nickname, page, size, null);
     }
 
     public RankingPageResponse getRankings(EventType eventType, String nickname, Integer page, Integer size, String currentUserEmail) {
+        eventCapabilities.requirePracticeRankingSupported(eventType);
         validateRankingPageRequest(page, size);
         validateRankingSearchRequest(nickname);
 
@@ -110,8 +115,19 @@ public class RecordService {
         );
     }
 
+    public Optional<RecordSubmissionLookup> findSubmission(String email, String clientSubmissionId) {
+        return recordRepository.findByUserEmailAndClientSubmissionId(email, clientSubmissionId)
+                .map(RecordSubmissionLookup::from);
+    }
+
     @Transactional
-    public Long saveRecord(String email, RecordSaveRequest request) {
+    public RecordCreateResponse createRecord(
+            String email,
+            RecordSaveRequest request,
+            String clientSubmissionId,
+            byte[] clientSubmissionPayloadHash
+    ) {
+        eventCapabilities.requirePracticeRecordSupported(request.getEventType());
         User user = findUserByEmail(email);
 
         Record record = Record.builder()
@@ -120,16 +136,19 @@ public class RecordService {
                 .timeMs(request.getTimeMs())
                 .penalty(request.getPenalty())
                 .scramble(request.getScramble())
+                .inputMethod(request.normalizedInputMethod())
+                .clientSubmissionId(clientSubmissionId)
+                .clientSubmissionPayloadHash(clientSubmissionPayloadHash)
                 .build();
 
-        Record savedRecord = recordRepository.save(record);
+        Record savedRecord = recordRepository.saveAndFlush(record);
 
         if (request.getPenalty().isRankable()) {
             PbRecalculationResult recalculationResult = recalculateUserPb(user, request.getEventType());
             syncRankingIfChanged(request.getEventType(), user.getId(), recalculationResult);
         }
 
-        return savedRecord.getId();
+        return RecordCreateResponse.from(savedRecord);
     }
 
     @Transactional

--- a/backend/src/main/java/com/cubinghub/domain/record/service/RecordSubmissionFingerprint.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/service/RecordSubmissionFingerprint.java
@@ -1,0 +1,51 @@
+package com.cubinghub.domain.record.service;
+
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecordSubmissionFingerprint {
+
+    private static final String CONTRACT_VERSION = "v1";
+
+    public byte[] create(RecordSaveRequest request) {
+        return sha256(encodeV1(request));
+    }
+
+    byte[] encodeV1(RecordSaveRequest request) {
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            DataOutputStream fields = new DataOutputStream(output);
+            writeLengthPrefixed(fields, CONTRACT_VERSION);
+            writeLengthPrefixed(fields, request.getEventType().name());
+            writeLengthPrefixed(fields, request.getTimeMs().toString());
+            writeLengthPrefixed(fields, request.getPenalty().name());
+            writeLengthPrefixed(fields, request.getScramble());
+            writeLengthPrefixed(fields, request.normalizedInputMethod().name());
+            fields.flush();
+            return output.toByteArray();
+        } catch (IOException exception) {
+            throw new IllegalStateException("Record fingerprint canonicalization failed", exception);
+        }
+    }
+
+    private void writeLengthPrefixed(DataOutputStream output, String value) throws IOException {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        output.writeInt(bytes.length);
+        output.write(bytes);
+    }
+
+    private byte[] sha256(byte[] payload) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(payload);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/service/RecordSubmissionService.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/service/RecordSubmissionService.java
@@ -1,0 +1,68 @@
+package com.cubinghub.domain.record.service;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.record.dto.internal.RecordSubmissionLookup;
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
+import java.security.MessageDigest;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecordSubmissionService {
+
+    private static final String SUBMISSION_CONFLICT_MESSAGE =
+            "clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.";
+
+    private final PracticeEventCapabilities eventCapabilities;
+    private final RecordSubmissionFingerprint fingerprint;
+    private final RecordService recordService;
+
+    public RecordCreateResponse submit(String email, RecordSaveRequest request) {
+        eventCapabilities.requirePracticeRecordSupported(request.getEventType());
+
+        UUID submissionId = request.getClientSubmissionId();
+        if (submissionId == null) {
+            return recordService.createRecord(email, request, null, null);
+        }
+
+        validateUuidV4(submissionId);
+        String canonicalSubmissionId = submissionId.toString();
+        byte[] payloadHash = fingerprint.create(request);
+        Optional<RecordSubmissionLookup> existing = recordService.findSubmission(email, canonicalSubmissionId);
+
+        if (existing.isPresent()) {
+            return resolveExisting(existing.get(), payloadHash);
+        }
+
+        try {
+            return recordService.createRecord(email, request, canonicalSubmissionId, payloadHash);
+        } catch (DataIntegrityViolationException exception) {
+            Optional<RecordSubmissionLookup> winner = recordService.findSubmission(email, canonicalSubmissionId);
+            if (winner.isEmpty()) {
+                throw exception;
+            }
+            return resolveExisting(winner.get(), payloadHash);
+        }
+    }
+
+    private void validateUuidV4(UUID submissionId) {
+        if (submissionId.version() != 4 || submissionId.variant() != 2) {
+            throw new IllegalArgumentException("clientSubmissionId는 UUID v4 형식이어야 합니다.");
+        }
+    }
+
+    private RecordCreateResponse resolveExisting(RecordSubmissionLookup existing, byte[] payloadHash) {
+        byte[] existingHash = existing.payloadHash();
+        if (existingHash == null || !MessageDigest.isEqual(existingHash, payloadHash)) {
+            throw new CustomApiException(SUBMISSION_CONFLICT_MESSAGE, HttpStatus.CONFLICT);
+        }
+        return existing.record();
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/record/service/ScrambleService.java
+++ b/backend/src/main/java/com/cubinghub/domain/record/service/ScrambleService.java
@@ -1,34 +1,27 @@
 package com.cubinghub.domain.record.service;
 
-import com.cubinghub.common.exception.CustomApiException;
 import com.cubinghub.common.util.ScrambleGenerator;
 import com.cubinghub.domain.record.dto.response.ScrambleResponse;
 import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import java.time.LocalDate;
-import java.util.EnumSet;
-import java.util.Set;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ScrambleService {
 
-    private static final Set<EventType> SUPPORTED_EVENT_TYPES = EnumSet.of(
-            EventType.WCA_333
-    );
+    private final PracticeEventCapabilities eventCapabilities;
 
     public ScrambleResponse generate(EventType eventType) {
-        if (!SUPPORTED_EVENT_TYPES.contains(eventType)) {
-            throw new CustomApiException("아직 구현되지 않은 종목입니다.", HttpStatus.BAD_REQUEST);
-        }
+        eventCapabilities.requireScrambleSupported(eventType);
 
         return new ScrambleResponse(eventType.name(), ScrambleGenerator.generate(eventType));
     }
 
     public ScrambleResponse generateDaily(EventType eventType, LocalDate date) {
-        if (!SUPPORTED_EVENT_TYPES.contains(eventType)) {
-            throw new CustomApiException("아직 구현되지 않은 종목입니다.", HttpStatus.BAD_REQUEST);
-        }
+        eventCapabilities.requireScrambleSupported(eventType);
 
         return new ScrambleResponse(eventType.name(), ScrambleGenerator.generateDaily(eventType, date));
     }

--- a/backend/src/main/java/com/cubinghub/domain/user/controller/UserProfileController.java
+++ b/backend/src/main/java/com/cubinghub/domain/user/controller/UserProfileController.java
@@ -1,6 +1,7 @@
 package com.cubinghub.domain.user.controller;
 
 import com.cubinghub.common.response.ApiResponse;
+import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.user.dto.request.ChangePasswordRequest;
 import com.cubinghub.domain.user.dto.request.UpdateMyProfileRequest;
 import com.cubinghub.domain.user.dto.response.MyRecordPageResponse;
@@ -42,6 +43,7 @@ public class UserProfileController {
     @GetMapping("/records")
     public ResponseEntity<ApiResponse<MyRecordPageResponse>> getMyRecords(
             @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) EventType eventType,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
@@ -49,7 +51,7 @@ public class UserProfileController {
                 ApiResponse.success(
                         HttpStatus.OK,
                         "내 기록을 조회했습니다.",
-                        userProfileService.getMyRecords(userDetails.getUsername(), page, size)
+                        userProfileService.getMyRecords(userDetails.getUsername(), eventType, page, size)
                 )
         );
     }

--- a/backend/src/main/java/com/cubinghub/domain/user/service/UserProfileService.java
+++ b/backend/src/main/java/com/cubinghub/domain/user/service/UserProfileService.java
@@ -2,7 +2,9 @@ package com.cubinghub.domain.user.service;
 
 import com.cubinghub.common.exception.CustomApiException;
 import com.cubinghub.domain.auth.repository.RefreshTokenService;
+import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.record.entity.Record;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import com.cubinghub.domain.record.repository.RecordRepository;
 import com.cubinghub.domain.record.repository.RecordSummaryQueryResult;
 import com.cubinghub.domain.user.dto.request.ChangePasswordRequest;
@@ -32,6 +34,7 @@ public class UserProfileService {
     private final RecordRepository recordRepository;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
+    private final PracticeEventCapabilities eventCapabilities;
 
     public MyProfileResponse getMyProfile(String email) {
         User user = findUserByEmail(email);
@@ -45,14 +48,24 @@ public class UserProfileService {
         );
     }
 
-    public MyRecordPageResponse getMyRecords(String email, Integer page, Integer size) {
+    public MyRecordPageResponse getMyRecords(String email, EventType eventType, Integer page, Integer size) {
         validatePageRequest(page, size);
 
         User user = findUserByEmail(email);
-        Page<Record> records = recordRepository.findByUserIdOrderByCreatedAtDesc(
-                user.getId(),
-                PageRequest.of(page - 1, size)
-        );
+        Page<Record> records;
+        if (eventType == null) {
+            records = recordRepository.findByUserIdOrderByCreatedAtDescIdDesc(
+                    user.getId(),
+                    PageRequest.of(page - 1, size)
+            );
+        } else {
+            eventCapabilities.requirePracticeRecordSupported(eventType);
+            records = recordRepository.findByUserIdAndEventTypeOrderByCreatedAtDescIdDesc(
+                    user.getId(),
+                    eventType,
+                    PageRequest.of(page - 1, size)
+            );
+        }
         List<MyProfileRecordResponse> items = new ArrayList<>(records.getNumberOfElements());
 
         for (Record record : records.getContent()) {

--- a/backend/src/main/resources/db/migration/V3__add_record_foundation_fields.sql
+++ b/backend/src/main/resources/db/migration/V3__add_record_foundation_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE records
+    ADD COLUMN input_method VARCHAR(32) NULL,
+    ADD COLUMN client_submission_id CHAR(36) NULL,
+    ADD COLUMN client_submission_payload_hash BINARY(32) NULL,
+    ADD UNIQUE INDEX uk_record_user_client_submission (user_id, client_submission_id),
+    ADD INDEX idx_record_user_event_created_at_id (user_id, event_type, created_at, id);

--- a/backend/src/test/java/com/cubinghub/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/cubinghub/common/exception/GlobalExceptionHandlerTest.java
@@ -100,6 +100,18 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("해석할 수 없는 JSON enum 값은 generic 500이 아니라 400으로 응답한다")
+    void should_return_bad_request_when_request_body_cannot_be_read() throws Exception {
+        mockMvc.perform(post("/test/not-readable")
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"value\":\"UNKNOWN\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("잘못된 요청 형식입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
     @DisplayName("AuthenticationException은 401로 응답한다")
     void should_return_unauthorized_when_authentication_exception_is_thrown() throws Exception {
         mockMvc.perform(get("/test/authentication"))
@@ -147,6 +159,11 @@ class GlobalExceptionHandlerTest {
             return request.name();
         }
 
+        @PostMapping("/test/not-readable")
+        String notReadable(@RequestBody EnumRequest request) {
+            return request.value().name();
+        }
+
         @GetMapping("/test/missing-cookie")
         String missingCookie(@CookieValue("refresh_token") String refreshToken) {
             return refreshToken;
@@ -164,5 +181,12 @@ class GlobalExceptionHandlerTest {
     }
 
     private record ValidationRequest(@NotBlank(message = "name is required") String name) {
+    }
+
+    private record EnumRequest(KnownValue value) {
+    }
+
+    private enum KnownValue {
+        KNOWN
     }
 }

--- a/backend/src/test/java/com/cubinghub/domain/home/service/HomeServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/home/service/HomeServiceTest.java
@@ -98,7 +98,7 @@ class HomeServiceTest {
                 user.getMainEvent(),
                 new MyProfileSummaryResponse(2, 9344, 10183)
         ));
-        when(recordRepository.findByUserIdOrderByCreatedAtDesc(user.getId(), PageRequest.of(0, 5)))
+        when(recordRepository.findByUserIdOrderByCreatedAtDescIdDesc(user.getId(), PageRequest.of(0, 5)))
                 .thenReturn(new PageImpl<>(List.of(firstRecord, secondRecord), PageRequest.of(0, 5), 2));
 
         HomeResponse response = homeService.getHome(user.getEmail());
@@ -109,7 +109,7 @@ class HomeServiceTest {
         assertThat(response.getRecentRecords()).hasSize(2);
         assertThat(response.getRecentRecords().get(0).getScramble()).isEqualTo("first scramble");
         assertThat(response.getRecentPosts()).hasSize(1);
-        verify(recordRepository).findByUserIdOrderByCreatedAtDesc(user.getId(), PageRequest.of(0, 5));
+        verify(recordRepository).findByUserIdOrderByCreatedAtDescIdDesc(user.getId(), PageRequest.of(0, 5));
     }
 
     @Test

--- a/backend/src/test/java/com/cubinghub/domain/record/RankingControllerIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RankingControllerIntegrationTest.java
@@ -168,6 +168,26 @@ class RankingControllerIntegrationTest extends JpaIntegrationTest {
     }
 
     @Test
+    @DisplayName("미지원 Practice event 랭킹 요청은 400을 반환한다")
+    void should_return_bad_request_when_practice_ranking_event_is_not_supported() throws Exception {
+        mockMvc.perform(get("/api/rankings")
+                        .param("eventType", EventType.WCA_222.name())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Practice 종목입니다."));
+    }
+
+    @Test
+    @DisplayName("알 수 없는 랭킹 EventType 문자열은 500이 아니라 400을 반환한다")
+    void should_return_bad_request_when_ranking_event_type_is_invalid() throws Exception {
+        mockMvc.perform(get("/api/rankings")
+                        .param("eventType", "UNKNOWN_EVENT")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("eventType 파라미터 형식이 올바르지 않습니다."));
+    }
+
+    @Test
     @DisplayName("Redis 랭킹이 준비되면 기본 랭킹 조회는 Redis 경로로 같은 계약을 반환한다")
     void should_return_rankings_from_redis_when_ready_marker_exists() throws Exception {
         for (int i = 0; i < 30; i++) {

--- a/backend/src/test/java/com/cubinghub/domain/record/RecordControllerIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RecordControllerIntegrationTest.java
@@ -7,11 +7,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
 import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
 import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
 import com.cubinghub.domain.record.entity.Penalty;
 import com.cubinghub.domain.record.entity.Record;
 import com.cubinghub.domain.record.entity.UserPB;
@@ -26,6 +28,7 @@ import com.cubinghub.security.JwtTokenProvider;
 import com.cubinghub.support.TestFixtures;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -92,6 +95,8 @@ class RecordControllerIntegrationTest extends JpaIntegrationTest {
                 .timeMs(12500)
                 .penalty(Penalty.NONE)
                 .scramble("R U R' U' R F R2 U' R' U' R U R' F'")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad"))
                 .build();
 
         mockMvc.perform(post("/api/records")
@@ -100,7 +105,15 @@ class RecordControllerIntegrationTest extends JpaIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("기록이 저장되었습니다."))
-                .andExpect(jsonPath("$.data.id").exists());
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.eventType").value("WCA_333"))
+                .andExpect(jsonPath("$.data.timeMs").value(12500))
+                .andExpect(jsonPath("$.data.penalty").value("NONE"))
+                .andExpect(jsonPath("$.data.effectiveTimeMs").value(12500))
+                .andExpect(jsonPath("$.data.scramble").value("R U R' U' R F R2 U' R' U' R U R' F'"))
+                .andExpect(jsonPath("$.data.inputMethod").value("KEYBOARD"))
+                .andExpect(jsonPath("$.data.createdAt").exists())
+                .andExpect(jsonPath("$.data.clientSubmissionId").doesNotExist());
 
         entityManager.flush();
         entityManager.clear();
@@ -109,11 +122,218 @@ class RecordControllerIntegrationTest extends JpaIntegrationTest {
         assertThat(recordRepository.findAll()).hasSize(1);
         Record savedRecord = recordRepository.findAll().get(0);
         assertThat(savedRecord.getTimeMs()).isEqualTo(12500);
+        assertThat(savedRecord.getInputMethod()).isEqualTo(InputMethod.KEYBOARD);
+        assertThat(savedRecord.getClientSubmissionId()).isEqualTo(request.getClientSubmissionId().toString());
+        assertThat(savedRecord.getClientSubmissionPayloadHash()).hasSize(32);
         assertThat(savedRecord.getUser().getId()).isEqualTo(testUser.getId());
 
         UserPB pb = userPBRepository.findByUserAndEventType(foundUser, EventType.WCA_333).orElseThrow();
         assertThat(pb.getBestTimeMs()).isEqualTo(12500);
         assertThat(pb.getRecord().getId()).isEqualTo(savedRecord.getId());
+    }
+
+    @Test
+    @DisplayName("legacy 기록 저장 요청은 optional provenance와 submission ID 없이 저장된다")
+    void should_create_legacy_record_when_optional_foundation_fields_are_missing() throws Exception {
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(13000)
+                .penalty(Penalty.NONE)
+                .scramble("legacy scramble")
+                .build();
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.inputMethod").value("UNKNOWN"));
+
+        Record savedRecord = recordRepository.findAll().get(0);
+        assertThat(savedRecord.getInputMethod()).isEqualTo(InputMethod.UNKNOWN);
+        assertThat(savedRecord.getClientSubmissionId()).isNull();
+        assertThat(savedRecord.getClientSubmissionPayloadHash()).isNull();
+    }
+
+    @Test
+    @DisplayName("동일 submission ID와 동일 payload replay는 기존 Record를 반환한다")
+    void should_replay_existing_record_when_submission_payload_matches() throws Exception {
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12500)
+                .penalty(Penalty.NONE)
+                .scramble("idempotent scramble")
+                .inputMethod(InputMethod.TOUCH)
+                .clientSubmissionId(UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad"))
+                .build();
+
+        var firstResult = mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String firstBody = firstResult.getResponse().getContentAsString();
+        String firstLocation = firstResult.getResponse().getHeader("Location");
+        long firstRecordId = objectMapper.readTree(firstBody).path("data").path("id").asLong();
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", firstLocation))
+                .andExpect(jsonPath("$.data.id").value(firstRecordId));
+
+        assertThat(recordRepository.count()).isEqualTo(1);
+        assertThat(userPBRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("최초 submission fingerprint는 이후 penalty PATCH와 무관하게 replay를 판정한다")
+    void should_replay_original_submission_after_penalty_is_updated() throws Exception {
+        UUID submissionId = UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad");
+        RecordSaveRequest createRequest = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12500)
+                .penalty(Penalty.NONE)
+                .scramble("immutable fingerprint")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(submissionId)
+                .build();
+        String createBody = mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        long recordId = objectMapper.readTree(createBody).path("data").path("id").asLong();
+        RecordPenaltyUpdateRequest penaltyRequest = RecordPenaltyUpdateRequest.builder()
+                .penalty(Penalty.PLUS_TWO)
+                .build();
+
+        mockMvc.perform(patch("/api/records/{recordId}", recordId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(penaltyRequest)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").value(recordId))
+                .andExpect(jsonPath("$.data.penalty").value("PLUS_TWO"))
+                .andExpect(jsonPath("$.data.effectiveTimeMs").value(14500));
+
+        assertThat(recordRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("동일 submission ID와 다른 payload는 409를 반환하고 mutation을 만들지 않는다")
+    void should_return_conflict_when_submission_id_is_reused_for_different_payload() throws Exception {
+        UUID submissionId = UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad");
+        RecordSaveRequest first = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12500)
+                .penalty(Penalty.NONE)
+                .scramble("conflict scramble")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(submissionId)
+                .build();
+        RecordSaveRequest conflict = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12501)
+                .penalty(Penalty.NONE)
+                .scramble("conflict scramble")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(submissionId)
+                .build();
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(first)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(conflict)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message")
+                        .value("clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다."));
+
+        assertThat(recordRepository.count()).isEqualTo(1);
+        assertThat(userPBRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("미지원 Practice event 기록 저장 요청은 400을 반환한다")
+    void should_return_bad_request_when_practice_event_is_not_supported() throws Exception {
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_222)
+                .timeMs(12500)
+                .penalty(Penalty.NONE)
+                .scramble("R U")
+                .build();
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Practice 종목입니다."));
+
+        assertThat(recordRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 EventType 문자열은 500이 아니라 400을 반환한다")
+    void should_return_bad_request_when_event_type_cannot_be_deserialized() throws Exception {
+        assertMalformedRequestIsBadRequest("""
+                {"eventType":"UNKNOWN_EVENT","timeMs":12500,"penalty":"NONE","scramble":"R U"}
+                """);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 InputMethod 문자열은 500이 아니라 400을 반환한다")
+    void should_return_bad_request_when_input_method_cannot_be_deserialized() throws Exception {
+        assertMalformedRequestIsBadRequest("""
+                {"eventType":"WCA_333","timeMs":12500,"penalty":"NONE","scramble":"R U",\
+                "inputMethod":"STACKMAT"}
+                """);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 clientSubmissionId 문자열은 500이 아니라 400을 반환한다")
+    void should_return_bad_request_when_submission_id_cannot_be_deserialized() throws Exception {
+        assertMalformedRequestIsBadRequest("""
+                {"eventType":"WCA_333","timeMs":12500,"penalty":"NONE","scramble":"R U",\
+                "clientSubmissionId":"not-a-uuid"}
+                """);
+    }
+
+    @Test
+    @DisplayName("UUID v4가 아닌 clientSubmissionId는 400을 반환한다")
+    void should_return_bad_request_when_submission_id_is_not_uuid_v4() throws Exception {
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12500)
+                .penalty(Penalty.NONE)
+                .scramble("R U")
+                .clientSubmissionId(UUID.fromString("f47ac10b-58cc-11cf-a447-001122334455"))
+                .build();
+
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("clientSubmissionId는 UUID v4 형식이어야 합니다."));
     }
 
     @Test
@@ -216,7 +436,9 @@ class RecordControllerIntegrationTest extends JpaIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.message").value("기록이 저장되었습니다."));
+                .andExpect(jsonPath("$.message").value("기록이 저장되었습니다."))
+                .andExpect(jsonPath("$.data.effectiveTimeMs").value(nullValue()))
+                .andExpect(jsonPath("$.data.inputMethod").value("UNKNOWN"));
 
         entityManager.flush();
         entityManager.clear();
@@ -514,5 +736,15 @@ class RecordControllerIntegrationTest extends JpaIntegrationTest {
                         .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("기록을 찾을 수 없습니다."));
+    }
+
+    private void assertMalformedRequestIsBadRequest(String body) throws Exception {
+        mockMvc.perform(post("/api/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("잘못된 요청 형식입니다."));
     }
 }

--- a/backend/src/test/java/com/cubinghub/domain/record/RecordDocsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RecordDocsTest.java
@@ -3,6 +3,7 @@ package com.cubinghub.domain.record;
 import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
 import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
 import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
 import com.cubinghub.domain.record.entity.Penalty;
 import com.cubinghub.domain.record.entity.Record;
 import com.cubinghub.domain.record.entity.UserPB;
@@ -14,6 +15,7 @@ import com.cubinghub.integration.RestDocsIntegrationTest;
 import com.cubinghub.security.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,6 +85,8 @@ class RecordDocsTest extends RestDocsIntegrationTest {
                 .timeMs(12500)
                 .penalty(Penalty.NONE)
                 .scramble("R U R' U' R F R2 U' R' U' R U R' F'")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad"))
                 .build();
 
         ResultActions result = mockMvc.perform(post("/api/records")
@@ -94,18 +98,33 @@ class RecordDocsTest extends RestDocsIntegrationTest {
                 .andExpect(jsonPath("$.status").value(201))
                 .andExpect(jsonPath("$.message").value("기록이 저장되었습니다."))
                 .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.eventType").value("WCA_333"))
+                .andExpect(jsonPath("$.data.timeMs").value(12500))
+                .andExpect(jsonPath("$.data.penalty").value("NONE"))
+                .andExpect(jsonPath("$.data.effectiveTimeMs").value(12500))
+                .andExpect(jsonPath("$.data.inputMethod").value("KEYBOARD"))
+                .andExpect(jsonPath("$.data.createdAt").exists())
                 .andDo(document("record/create",
                         requestFields(
                                 fieldWithPath("eventType").description("WCA 종목 코드 (e.g. WCA_333)"),
                                 fieldWithPath("timeMs").description("측정 시간 (밀리초)"),
                                 fieldWithPath("penalty").description("페널티 정보 (NONE, PLUS_TWO, DNF)"),
-                                fieldWithPath("scramble").description("해당 측정에 사용된 스크램블 문자열")
+                                fieldWithPath("scramble").description("해당 측정에 사용된 스크램블 문자열"),
+                                fieldWithPath("inputMethod").optional().description("입력 방식 (UNKNOWN, KEYBOARD, TOUCH; 누락 시 UNKNOWN)"),
+                                fieldWithPath("clientSubmissionId").optional().description("재시도 중복 방지용 UUID v4")
                         ),
                         responseFields(
                                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                                 fieldWithPath("data").type(JsonFieldType.OBJECT).description("생성된 리소스 정보"),
-                                fieldWithPath("data.id").description("생성된 기록 ID")
+                                fieldWithPath("data.id").description("생성된 기록 ID"),
+                                fieldWithPath("data.eventType").description("Practice 종목 코드"),
+                                fieldWithPath("data.timeMs").description("원본 측정 시간 (밀리초)"),
+                                fieldWithPath("data.penalty").description("적용 페널티"),
+                                fieldWithPath("data.effectiveTimeMs").optional().description("페널티 반영 시간 (DNF면 null)"),
+                                fieldWithPath("data.scramble").description("저장된 스크램블 snapshot"),
+                                fieldWithPath("data.inputMethod").description("정규화된 입력 방식"),
+                                fieldWithPath("data.createdAt").description("서버가 생성한 기록 저장 시각")
                         )
                 ));
     }
@@ -134,7 +153,9 @@ class RecordDocsTest extends RestDocsIntegrationTest {
                                 fieldWithPath("eventType").description("WCA 종목 코드 (e.g. WCA_333)"),
                                 fieldWithPath("timeMs").description("측정 시간 (밀리초)"),
                                 fieldWithPath("penalty").description("페널티 정보 (NONE, PLUS_TWO, DNF)"),
-                                fieldWithPath("scramble").description("해당 측정에 사용된 스크램블 문자열")
+                                fieldWithPath("scramble").description("해당 측정에 사용된 스크램블 문자열"),
+                                fieldWithPath("inputMethod").optional().description("입력 방식 (누락 시 UNKNOWN)"),
+                                fieldWithPath("clientSubmissionId").optional().description("재시도 중복 방지용 UUID v4")
                         ),
                         responseFields(
                                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),

--- a/backend/src/test/java/com/cubinghub/domain/record/RecordFoundationMigrationIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RecordFoundationMigrationIntegrationTest.java
@@ -1,0 +1,232 @@
+package com.cubinghub.domain.record;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
+import com.cubinghub.domain.record.repository.RecordRepository;
+import com.cubinghub.domain.record.repository.UserPBRepository;
+import com.cubinghub.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = RecordFoundationMigrationIntegrationTest.MigrationInitializer.class)
+@DisplayName("Record Foundation Flyway upgrade 통합 테스트")
+class RecordFoundationMigrationIntegrationTest {
+
+    private static final String SUBMISSION_ID = "d9428888-122b-4d3e-a58e-790c4e5f97ad";
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RecordRepository recordRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserPBRepository userPBRepository;
+
+    @Test
+    @DisplayName("V2 legacy Record와 PB를 보존하며 V3 schema를 application mapping으로 읽는다")
+    void should_preserve_legacy_record_and_pb_when_v3_migration_is_applied() {
+        var legacyRecord = recordRepository.findById(100L).orElseThrow();
+        var legacyUser = userRepository.findById(1L).orElseThrow();
+        var legacyPb = userPBRepository.findByUserAndEventType(legacyUser, EventType.WCA_333).orElseThrow();
+
+        assertThat(legacyRecord.getScramble()).isEqualTo("legacy scramble");
+        assertThat(legacyRecord.getInputMethod()).isEqualTo(InputMethod.UNKNOWN);
+        assertThat(legacyRecord.getClientSubmissionId()).isNull();
+        assertThat(legacyRecord.getClientSubmissionPayloadHash()).isNull();
+        assertThat(legacyPb.getRecord().getId()).isEqualTo(legacyRecord.getId());
+        assertThat(legacyPb.getBestTimeMs()).isEqualTo(12345);
+    }
+
+    @Test
+    @DisplayName("V3 columns와 Record 조회 index는 합의한 type과 nullability를 가진다")
+    void should_create_record_foundation_columns_and_indexes() {
+        assertColumn("input_method", "varchar", 32L, "YES");
+        assertColumn("client_submission_id", "char", 36L, "YES");
+        assertColumn("client_submission_payload_hash", "binary", 32L, "YES");
+
+        assertIndexColumns(
+                "idx_record_user_event_created_at_id",
+                "user_id",
+                "event_type",
+                "created_at",
+                "id"
+        );
+        assertIndexColumns("uk_record_user_client_submission", "user_id", "client_submission_id");
+        Integer nonUnique = jdbcTemplate.queryForObject("""
+                SELECT non_unique
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'records'
+                  AND index_name = 'uk_record_user_client_submission'
+                LIMIT 1
+                """, Integer.class);
+        assertThat(nonUnique).isZero();
+    }
+
+    private void assertIndexColumns(String indexName, String... expectedColumns) {
+        List<String> actualColumns = jdbcTemplate.queryForList("""
+                SELECT column_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'records'
+                  AND index_name = ?
+                ORDER BY seq_in_index
+                """, String.class, indexName);
+
+        assertThat(actualColumns).containsExactly(expectedColumns);
+    }
+
+    @Test
+    @DisplayName("submission ID unique 제약은 사용자 범위이고 legacy NULL은 여러 건 허용한다")
+    void should_enforce_submission_id_uniqueness_per_user_and_allow_legacy_nulls() {
+        insertRecord(101L, 1L, SUBMISSION_ID);
+
+        assertThatThrownBy(() -> insertRecord(102L, 1L, SUBMISSION_ID))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        insertRecord(103L, 2L, SUBMISSION_ID);
+        insertRecord(104L, 1L, null);
+        insertRecord(105L, 1L, null);
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM records WHERE id IN (101, 103, 104, 105)",
+                Integer.class
+        );
+        assertThat(count).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("V3 non-null provenance와 submission fields를 new application mapping으로 읽는다")
+    void should_read_record_foundation_values_with_new_application_mapping() {
+        String submissionId = "4a7c1dc1-715a-4ab0-bf0a-1f8c6cf63a91";
+        insertRecord(110L, 2L, submissionId);
+
+        var record = recordRepository.findById(110L).orElseThrow();
+
+        assertThat(record.getInputMethod()).isEqualTo(InputMethod.KEYBOARD);
+        assertThat(record.getClientSubmissionId()).isEqualTo(submissionId);
+        assertThat(record.getClientSubmissionPayloadHash()).hasSize(32);
+    }
+
+    private void assertColumn(String columnName, String dataType, Long maximumLength, String nullable) {
+        var column = jdbcTemplate.queryForMap("""
+                SELECT data_type, character_maximum_length, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'records'
+                  AND column_name = ?
+                """, columnName);
+
+        assertThat(column.get("data_type")).isEqualTo(dataType);
+        assertThat(((Number) column.get("character_maximum_length")).longValue()).isEqualTo(maximumLength);
+        assertThat(column.get("is_nullable")).isEqualTo(nullable);
+    }
+
+    private void insertRecord(Long id, Long userId, String submissionId) {
+        jdbcTemplate.update("""
+                INSERT INTO records (
+                    id, user_id, event_type, time_ms, penalty, scramble,
+                    input_method, client_submission_id, client_submission_payload_hash,
+                    created_at, updated_at
+                ) VALUES (?, ?, 'WCA_333', 15000, 'NONE', 'migration test scramble',
+                    'KEYBOARD', ?, UNHEX(REPEAT('01', 32)), NOW(6), NOW(6))
+                """, id, userId, submissionId);
+    }
+
+    static final class MigrationInitializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
+                DockerImageName.parse("mysql:8.0")
+        );
+        private static final AtomicBoolean MIGRATED = new AtomicBoolean();
+
+        @Override
+        public void initialize(ConfigurableApplicationContext context) {
+            migrateOnce();
+            TestPropertyValues.of(
+                    "spring.datasource.url=" + MYSQL.getJdbcUrl(),
+                    "spring.datasource.username=" + MYSQL.getUsername(),
+                    "spring.datasource.password=" + MYSQL.getPassword(),
+                    "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver",
+                    "spring.jpa.hibernate.ddl-auto=validate",
+                    "spring.flyway.enabled=false",
+                    "ranking.redis.rebuild-mode=disabled"
+            ).applyTo(context);
+        }
+
+        private static synchronized void migrateOnce() {
+            if (MIGRATED.get()) {
+                return;
+            }
+
+            MYSQL.start();
+            Flyway.configure()
+                    .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                    .target("2")
+                    .load()
+                    .migrate();
+
+            JdbcTemplate legacyDatabase = new JdbcTemplate(new DriverManagerDataSource(
+                    MYSQL.getJdbcUrl(),
+                    MYSQL.getUsername(),
+                    MYSQL.getPassword()
+            ));
+            insertLegacyFixture(legacyDatabase);
+
+            Flyway.configure()
+                    .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                    .load()
+                    .migrate();
+            MIGRATED.set(true);
+        }
+
+        private static void insertLegacyFixture(JdbcTemplate database) {
+            database.update("""
+                    INSERT INTO users (
+                        id, email, password, nickname, role, status, main_event, created_at, updated_at
+                    ) VALUES
+                        (1, 'legacy@cubinghub.com', 'password', 'Legacy', 'ROLE_USER', 'ACTIVE',
+                         'WCA_333', NOW(6), NOW(6)),
+                        (2, 'other@cubinghub.com', 'password', 'Other', 'ROLE_USER', 'ACTIVE',
+                         'WCA_333', NOW(6), NOW(6))
+                    """);
+            database.update("""
+                    INSERT INTO records (
+                        id, user_id, event_type, time_ms, penalty, scramble, created_at, updated_at
+                    ) VALUES
+                        (100, 1, 'WCA_333', 12345, 'NONE', 'legacy scramble', NOW(6), NOW(6))
+                    """);
+            database.update("""
+                    INSERT INTO user_pbs (
+                        id, user_id, event_type, best_time_ms, record_id, created_at, updated_at
+                    ) VALUES
+                        (200, 1, 'WCA_333', 12345, 100, NOW(6), NOW(6))
+                    """);
+        }
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/RecordSubmissionConcurrencyIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RecordSubmissionConcurrencyIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.cubinghub.domain.record;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.cubinghub.TestcontainersConfiguration;
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
+import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.repository.RecordRepository;
+import com.cubinghub.domain.record.repository.UserPBRepository;
+import com.cubinghub.domain.record.service.RankingRedisService;
+import com.cubinghub.domain.record.service.RecordSubmissionService;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.entity.UserRole;
+import com.cubinghub.domain.user.entity.UserStatus;
+import com.cubinghub.domain.user.repository.UserRepository;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@Import(TestcontainersConfiguration.class)
+@DisplayName("Record submission 동시성 통합 테스트")
+class RecordSubmissionConcurrencyIntegrationTest {
+
+    @Autowired
+    private RecordSubmissionService submissionService;
+
+    @Autowired
+    private RecordRepository recordRepository;
+
+    @Autowired
+    private UserPBRepository userPBRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private RankingRedisService rankingRedisService;
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        userPBRepository.deleteAll();
+        recordRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동일 사용자의 동시 duplicate submission은 Record와 PB side effect를 한 번만 만든다")
+    void should_create_one_record_and_one_pb_when_same_submission_is_concurrent() throws Exception {
+        User user = userRepository.saveAndFlush(User.builder()
+                .email("concurrent@cubinghub.com")
+                .password("password")
+                .nickname("Concurrent")
+                .role(UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build());
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(12345)
+                .penalty(Penalty.NONE)
+                .scramble("R U R' U'")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad"))
+                .build();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Future<RecordCreateResponse> first = submitConcurrently(user.getEmail(), request, ready, start);
+        Future<RecordCreateResponse> second = submitConcurrently(user.getEmail(), request, ready, start);
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+
+        RecordCreateResponse firstResponse = first.get(10, TimeUnit.SECONDS);
+        RecordCreateResponse secondResponse = second.get(10, TimeUnit.SECONDS);
+
+        assertThat(firstResponse.getId()).isEqualTo(secondResponse.getId());
+        assertThat(recordRepository.count()).isEqualTo(1);
+        assertThat(userPBRepository.count()).isEqualTo(1);
+        verify(rankingRedisService, times(1)).sync(any());
+    }
+
+    private Future<RecordCreateResponse> submitConcurrently(
+            String email,
+            RecordSaveRequest request,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) {
+        return executor.submit(() -> {
+            ready.countDown();
+            if (!start.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("concurrent submission start timed out");
+            }
+            return submissionService.submit(email, request);
+        });
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/ScrambleDocsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/ScrambleDocsTest.java
@@ -56,7 +56,7 @@ class ScrambleDocsTest extends RestDocsIntegrationTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.message").value("아직 구현되지 않은 종목입니다."))
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Practice 종목입니다."))
                 .andExpect(jsonPath("$.data").value(nullValue()))
                 .andDo(document("scramble/get/bad-request",
                         queryParameters(

--- a/backend/src/test/java/com/cubinghub/domain/record/entity/InputMethodConverterTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/entity/InputMethodConverterTest.java
@@ -1,0 +1,34 @@
+package com.cubinghub.domain.record.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("InputMethodConverter 단위 테스트")
+class InputMethodConverterTest {
+
+    private final InputMethodConverter converter = new InputMethodConverter();
+
+    @Test
+    @DisplayName("알려진 InputMethod는 VARCHAR 이름으로 왕복한다")
+    void should_round_trip_known_input_method() {
+        assertThat(converter.convertToDatabaseColumn(InputMethod.KEYBOARD)).isEqualTo("KEYBOARD");
+        assertThat(converter.convertToEntityAttribute("TOUCH")).isEqualTo(InputMethod.TOUCH);
+    }
+
+    @Test
+    @DisplayName("legacy DB NULL은 entity field NULL로 보존해 aggregate getter가 UNKNOWN으로 정규화하게 한다")
+    void should_preserve_database_null_for_legacy_normalization() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 DB InputMethod를 UNKNOWN으로 조용히 바꾸지 않는다")
+    void should_reject_unknown_database_input_method() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("STACKMAT"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/policy/PracticeEventCapabilitiesTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/policy/PracticeEventCapabilitiesTest.java
@@ -1,0 +1,50 @@
+package com.cubinghub.domain.record.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.record.entity.EventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("PracticeEventCapabilities 단위 테스트")
+class PracticeEventCapabilitiesTest {
+
+    private final PracticeEventCapabilities capabilities = new PracticeEventCapabilities();
+
+    @Test
+    @DisplayName("WCA_333은 TIME Practice 기능 전체를 지원한다")
+    void should_return_time_capability_when_event_type_is_wca_333() {
+        PracticeEventCapability capability = capabilities.get(EventType.WCA_333).orElseThrow();
+
+        assertThat(capability.eventType()).isEqualTo(EventType.WCA_333);
+        assertThat(capability.resultKind()).isEqualTo(ResultKind.TIME);
+        assertThat(capability.practiceTimerSupported()).isTrue();
+        assertThat(capability.scrambleSupported()).isTrue();
+        assertThat(capability.practiceRecordSupported()).isTrue();
+        assertThat(capability.practiceRankingSupported()).isTrue();
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 EventType은 Practice Record에서 거절한다")
+    void should_throw_bad_request_when_practice_record_event_is_not_supported() {
+        assertThatThrownBy(() -> capabilities.requirePracticeRecordSupported(EventType.WCA_222))
+                .isInstanceOfSatisfying(CustomApiException.class, exception -> {
+                    assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(exception.getMessage()).isEqualTo("지원하지 않는 Practice 종목입니다.");
+                });
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 EventType은 Scramble과 Practice Ranking에서도 같은 메시지로 거절한다")
+    void should_use_same_error_contract_when_scramble_or_ranking_event_is_not_supported() {
+        assertThatThrownBy(() -> capabilities.requireScrambleSupported(EventType.WCA_333FM))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("지원하지 않는 Practice 종목입니다.");
+        assertThatThrownBy(() -> capabilities.requirePracticeRankingSupported(EventType.WCA_333MBF))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("지원하지 않는 Practice 종목입니다.");
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/service/RecordServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/service/RecordServiceTest.java
@@ -12,12 +12,14 @@ import static org.mockito.Mockito.when;
 import com.cubinghub.common.exception.CustomApiException;
 import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
 import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
 import com.cubinghub.domain.record.dto.response.RecordPenaltyUpdateResponse;
 import com.cubinghub.domain.record.dto.response.RankingPageResponse;
 import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.record.entity.Penalty;
 import com.cubinghub.domain.record.entity.Record;
 import com.cubinghub.domain.record.entity.UserPB;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import com.cubinghub.domain.record.repository.RankingQueryResult;
 import com.cubinghub.domain.record.repository.RecordRepository;
 import com.cubinghub.domain.record.repository.UserPBRepository;
@@ -59,7 +61,13 @@ class RecordServiceTest {
 
     @BeforeEach
     void setUp() {
-        recordService = new RecordService(recordRepository, userPBRepository, userRepository, rankingRedisService);
+        recordService = new RecordService(
+                recordRepository,
+                userPBRepository,
+                userRepository,
+                rankingRedisService,
+                new PracticeEventCapabilities()
+        );
     }
 
     @Test
@@ -75,11 +83,11 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(savedRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(savedRecord);
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
-        assertThat(recordId).isEqualTo(savedRecord.getId());
+        assertThat(response.getId()).isEqualTo(savedRecord.getId());
         verify(userPBRepository, never()).findByUserAndEventType(any(), any());
         verify(userPBRepository, never()).save(any(UserPB.class));
     }
@@ -97,14 +105,14 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(savedRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(savedRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333)).thenReturn(Optional.of(savedRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.empty());
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
         ArgumentCaptor<UserPB> pbCaptor = ArgumentCaptor.forClass(UserPB.class);
-        assertThat(recordId).isEqualTo(savedRecord.getId());
+        assertThat(response.getId()).isEqualTo(savedRecord.getId());
         verify(userPBRepository).save(pbCaptor.capture());
         verify(rankingRedisService).sync(any(UserPB.class));
         assertThat(pbCaptor.getValue().getBestTimeMs()).isEqualTo(11800);
@@ -124,14 +132,14 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(savedRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(savedRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333)).thenReturn(Optional.of(savedRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.empty());
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
         ArgumentCaptor<UserPB> pbCaptor = ArgumentCaptor.forClass(UserPB.class);
-        assertThat(recordId).isEqualTo(savedRecord.getId());
+        assertThat(response.getId()).isEqualTo(savedRecord.getId());
         verify(userPBRepository).save(pbCaptor.capture());
         verify(rankingRedisService).sync(any(UserPB.class));
         assertThat(pbCaptor.getValue().getUser()).isEqualTo(user);
@@ -161,13 +169,13 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(fasterRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(fasterRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333)).thenReturn(Optional.of(fasterRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.of(existingPb));
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
-        assertThat(recordId).isEqualTo(fasterRecord.getId());
+        assertThat(response.getId()).isEqualTo(fasterRecord.getId());
         verify(existingPb).updateBestTime(9500, fasterRecord);
         verify(rankingRedisService).sync(existingPb);
         verify(userPBRepository, never()).save(any(UserPB.class));
@@ -194,13 +202,13 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(slowerRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(slowerRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333)).thenReturn(Optional.of(currentBestRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.of(existingPb));
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
-        assertThat(recordId).isEqualTo(slowerRecord.getId());
+        assertThat(response.getId()).isEqualTo(slowerRecord.getId());
         verify(existingPb, never()).updateBestTime(any(), any());
         verify(rankingRedisService, never()).sync(any());
         verify(userPBRepository, never()).save(any(UserPB.class));
@@ -227,11 +235,11 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(sameTimeRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(sameTimeRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333)).thenReturn(Optional.of(currentBestRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.of(existingPb));
 
-        recordService.saveRecord(user.getEmail(), request);
+        recordService.createRecord(user.getEmail(), request, null, null);
 
         verify(existingPb, never()).updateBestTime(any(), any());
         verify(rankingRedisService, never()).sync(any());
@@ -259,14 +267,14 @@ class RecordServiceTest {
                 .build();
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.save(any(Record.class))).thenReturn(sameTimeNewBestRecord);
+        when(recordRepository.saveAndFlush(any(Record.class))).thenReturn(sameTimeNewBestRecord);
         when(recordRepository.findBestRecordByUserIdAndEventType(user.getId(), EventType.WCA_333))
                 .thenReturn(Optional.of(sameTimeNewBestRecord));
         when(userPBRepository.findByUserAndEventType(user, EventType.WCA_333)).thenReturn(Optional.of(existingPb));
 
-        Long recordId = recordService.saveRecord(user.getEmail(), request);
+        RecordCreateResponse response = recordService.createRecord(user.getEmail(), request, null, null);
 
-        assertThat(recordId).isEqualTo(sameTimeNewBestRecord.getId());
+        assertThat(response.getId()).isEqualTo(sameTimeNewBestRecord.getId());
         verify(existingPb).updateBestTime(10000, sameTimeNewBestRecord);
         verify(rankingRedisService).sync(existingPb);
         verify(userPBRepository, never()).save(any(UserPB.class));
@@ -283,7 +291,7 @@ class RecordServiceTest {
                 .build();
         when(userRepository.findByEmail("missing@cubinghub.com")).thenReturn(Optional.empty());
 
-        Throwable thrown = catchThrowable(() -> recordService.saveRecord("missing@cubinghub.com", request));
+        Throwable thrown = catchThrowable(() -> recordService.createRecord("missing@cubinghub.com", request, null, null));
 
         assertThat(thrown).isInstanceOf(CustomApiException.class);
         CustomApiException exception = (CustomApiException) thrown;

--- a/backend/src/test/java/com/cubinghub/domain/record/service/RecordSubmissionFingerprintTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/service/RecordSubmissionFingerprintTest.java
@@ -1,0 +1,93 @@
+package com.cubinghub.domain.record.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
+import com.cubinghub.domain.record.entity.Penalty;
+import java.util.HexFormat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("RecordSubmissionFingerprint 단위 테스트")
+class RecordSubmissionFingerprintTest {
+
+    private final RecordSubmissionFingerprint fingerprint = new RecordSubmissionFingerprint();
+
+    @Test
+    @DisplayName("같은 logical payload는 같은 v1 SHA-256 fingerprint를 만든다")
+    void should_create_same_hash_when_logical_payload_is_same() {
+        RecordSaveRequest first = request(12345, "R U R' U'", InputMethod.KEYBOARD);
+        RecordSaveRequest second = request(12345, "R U R' U'", InputMethod.KEYBOARD);
+
+        assertThat(fingerprint.create(first)).isEqualTo(fingerprint.create(second));
+    }
+
+    @Test
+    @DisplayName("InputMethod 누락과 UNKNOWN은 같은 logical payload로 정규화한다")
+    void should_normalize_missing_input_method_to_unknown() {
+        RecordSaveRequest missing = request(12345, "R U R' U'", null);
+        RecordSaveRequest unknown = request(12345, "R U R' U'", InputMethod.UNKNOWN);
+
+        assertThat(fingerprint.create(missing)).isEqualTo(fingerprint.create(unknown));
+    }
+
+    @Test
+    @DisplayName("length prefix는 필드 경계가 다른 payload를 구분한다")
+    void should_create_different_hash_when_field_boundaries_differ() {
+        RecordSaveRequest first = request(1, "23", InputMethod.TOUCH);
+        RecordSaveRequest second = request(12, "3", InputMethod.TOUCH);
+
+        assertThat(fingerprint.create(first)).isNotEqualTo(fingerprint.create(second));
+    }
+
+    @Test
+    @DisplayName("Unicode scramble을 포함한 v1 fingerprint는 고정된 golden value를 유지한다")
+    void should_match_golden_hash_when_scramble_contains_unicode() {
+        RecordSaveRequest request = request(9876, "R U 큐브 Ω", InputMethod.KEYBOARD);
+
+        assertThat(HexFormat.of().formatHex(fingerprint.create(request)))
+                .isEqualTo("1e08b62236cdaf076ff1b41598e2288ab4cb011730f9eddace19b0679d5cc636");
+    }
+
+    @Test
+    @DisplayName("logical payload의 각 필드가 바뀌면 fingerprint가 바뀐다")
+    void should_create_different_hash_when_each_logical_field_changes() {
+        RecordSaveRequest baseline = request(12345, "R U R' U'", InputMethod.KEYBOARD);
+        RecordSaveRequest changedEvent = request(
+                EventType.WCA_222, 12345, Penalty.NONE, "R U R' U'", InputMethod.KEYBOARD
+        );
+        RecordSaveRequest changedPenalty = request(
+                EventType.WCA_333, 12345, Penalty.PLUS_TWO, "R U R' U'", InputMethod.KEYBOARD
+        );
+        RecordSaveRequest changedTime = request(12346, "R U R' U'", InputMethod.KEYBOARD);
+        RecordSaveRequest changedScramble = request(12345, "R U2 R' U'", InputMethod.KEYBOARD);
+        RecordSaveRequest changedInput = request(12345, "R U R' U'", InputMethod.TOUCH);
+        assertThat(fingerprint.create(changedEvent)).isNotEqualTo(fingerprint.create(baseline));
+        assertThat(fingerprint.create(changedPenalty)).isNotEqualTo(fingerprint.create(baseline));
+        assertThat(fingerprint.create(changedTime)).isNotEqualTo(fingerprint.create(baseline));
+        assertThat(fingerprint.create(changedScramble)).isNotEqualTo(fingerprint.create(baseline));
+        assertThat(fingerprint.create(changedInput)).isNotEqualTo(fingerprint.create(baseline));
+    }
+
+    private RecordSaveRequest request(int timeMs, String scramble, InputMethod inputMethod) {
+        return request(EventType.WCA_333, timeMs, Penalty.NONE, scramble, inputMethod);
+    }
+
+    private RecordSaveRequest request(
+            EventType eventType,
+            int timeMs,
+            Penalty penalty,
+            String scramble,
+            InputMethod inputMethod
+    ) {
+        return RecordSaveRequest.builder()
+                .eventType(eventType)
+                .timeMs(timeMs)
+                .penalty(penalty)
+                .scramble(scramble)
+                .inputMethod(inputMethod)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/service/RecordSubmissionServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/service/RecordSubmissionServiceTest.java
@@ -1,0 +1,233 @@
+package com.cubinghub.domain.record.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.record.dto.internal.RecordSubmissionLookup;
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.InputMethod;
+import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RecordSubmissionService 단위 테스트")
+class RecordSubmissionServiceTest {
+
+    private static final String EMAIL = "tester@cubinghub.com";
+    private static final UUID SUBMISSION_ID = UUID.fromString("d9428888-122b-4d3e-a58e-790c4e5f97ad");
+
+    @Mock
+    private RecordSubmissionFingerprint fingerprint;
+
+    @Mock
+    private RecordService recordService;
+
+    private RecordSubmissionService submissionService;
+
+    @BeforeEach
+    void setUp() {
+        submissionService = new RecordSubmissionService(
+                new PracticeEventCapabilities(),
+                fingerprint,
+                recordService
+        );
+    }
+
+    @Test
+    @DisplayName("최초 submission은 transactional create 결과를 반환한다")
+    void should_create_record_when_submission_id_is_new() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        byte[] payloadHash = {1, 2, 3};
+        RecordCreateResponse created = response(10L);
+        when(fingerprint.create(request)).thenReturn(payloadHash);
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString())).thenReturn(Optional.empty());
+        when(recordService.createRecord(EMAIL, request, SUBMISSION_ID.toString(), payloadHash)).thenReturn(created);
+
+        RecordCreateResponse result = submissionService.submit(EMAIL, request);
+
+        assertThat(result).isSameAs(created);
+    }
+
+    @Test
+    @DisplayName("같은 submission ID와 payload replay는 기존 Record를 반환한다")
+    void should_return_existing_record_when_submission_payload_matches() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        byte[] payloadHash = {1, 2, 3};
+        RecordCreateResponse existing = response(10L);
+        when(fingerprint.create(request)).thenReturn(payloadHash);
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString()))
+                .thenReturn(Optional.of(new RecordSubmissionLookup(existing, payloadHash)));
+
+        RecordCreateResponse result = submissionService.submit(EMAIL, request);
+
+        assertThat(result).isSameAs(existing);
+        verify(recordService, never()).createRecord(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("같은 submission ID와 다른 payload는 409를 반환한다")
+    void should_throw_conflict_when_submission_payload_differs() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        when(fingerprint.create(request)).thenReturn(new byte[]{1, 2, 3});
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString()))
+                .thenReturn(Optional.of(new RecordSubmissionLookup(response(10L), new byte[]{9, 9, 9})));
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request))
+                .isInstanceOfSatisfying(CustomApiException.class, exception -> {
+                    assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(exception.getMessage())
+                            .isEqualTo("clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.");
+                });
+        verify(recordService, never()).createRecord(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("concurrent unique loser는 실패 transaction 밖에서 winner를 읽어 replay한다")
+    void should_return_winner_when_unique_constraint_loses_concurrent_race() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        byte[] payloadHash = {1, 2, 3};
+        RecordCreateResponse winner = response(10L);
+        when(fingerprint.create(request)).thenReturn(payloadHash);
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString()))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(new RecordSubmissionLookup(winner, payloadHash)));
+        when(recordService.createRecord(EMAIL, request, SUBMISSION_ID.toString(), payloadHash))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        RecordCreateResponse result = submissionService.submit(EMAIL, request);
+
+        assertThat(result).isSameAs(winner);
+        verify(recordService).createRecord(EMAIL, request, SUBMISSION_ID.toString(), payloadHash);
+    }
+
+    @Test
+    @DisplayName("concurrent unique loser payload가 winner와 다르면 409를 반환한다")
+    void should_throw_conflict_when_concurrent_winner_payload_differs() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        byte[] payloadHash = {1, 2, 3};
+        when(fingerprint.create(request)).thenReturn(payloadHash);
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString()))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(new RecordSubmissionLookup(response(10L), new byte[]{9, 9, 9})));
+        when(recordService.createRecord(EMAIL, request, SUBMISSION_ID.toString(), payloadHash))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request))
+                .isInstanceOfSatisfying(CustomApiException.class, exception -> {
+                    assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(exception.getMessage())
+                            .isEqualTo("clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.");
+                });
+    }
+
+    @Test
+    @DisplayName("unique 위반 뒤 winner가 없으면 원래 persistence 예외를 다시 던진다")
+    void should_rethrow_data_integrity_exception_when_unique_winner_does_not_exist() {
+        RecordSaveRequest request = request(SUBMISSION_ID, 12345);
+        byte[] payloadHash = {1, 2, 3};
+        DataIntegrityViolationException failure = new DataIntegrityViolationException("not submission duplicate");
+        when(fingerprint.create(request)).thenReturn(payloadHash);
+        when(recordService.findSubmission(EMAIL, SUBMISSION_ID.toString())).thenReturn(Optional.empty());
+        when(recordService.createRecord(EMAIL, request, SUBMISSION_ID.toString(), payloadHash)).thenThrow(failure);
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request)).isSameAs(failure);
+    }
+
+    @Test
+    @DisplayName("legacy request는 fingerprint 없이 기존 non-idempotent create를 유지한다")
+    void should_create_without_idempotency_when_submission_id_is_missing() {
+        RecordSaveRequest request = request(null, 12345);
+        RecordCreateResponse created = response(10L);
+        when(recordService.createRecord(EMAIL, request, null, null)).thenReturn(created);
+
+        RecordCreateResponse result = submissionService.submit(EMAIL, request);
+
+        assertThat(result).isSameAs(created);
+        verify(fingerprint, never()).create(any());
+        verify(recordService, never()).findSubmission(any(), any());
+    }
+
+    @Test
+    @DisplayName("UUID v4가 아닌 submission ID는 400으로 거절한다")
+    void should_throw_bad_request_when_submission_id_is_not_uuid_v4() {
+        UUID versionOne = UUID.fromString("f47ac10b-58cc-11cf-a447-001122334455");
+        RecordSaveRequest request = request(versionOne, 12345);
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clientSubmissionId는 UUID v4 형식이어야 합니다.");
+        verify(recordService, never()).createRecord(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("RFC 4122 variant가 아닌 UUID v4 모양의 submission ID는 400으로 거절한다")
+    void should_throw_bad_request_when_submission_id_has_invalid_uuid_variant() {
+        UUID invalidVariant = UUID.fromString("d9428888-122b-4d3e-258e-790c4e5f97ad");
+        RecordSaveRequest request = request(invalidVariant, 12345);
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clientSubmissionId는 UUID v4 형식이어야 합니다.");
+        verify(recordService, never()).createRecord(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("미지원 Practice event는 persistence 전에 거절한다")
+    void should_throw_bad_request_before_persistence_when_event_is_not_supported() {
+        RecordSaveRequest request = RecordSaveRequest.builder()
+                .eventType(EventType.WCA_222)
+                .timeMs(12345)
+                .penalty(Penalty.NONE)
+                .scramble("R U")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(SUBMISSION_ID)
+                .build();
+
+        assertThatThrownBy(() -> submissionService.submit(EMAIL, request))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("지원하지 않는 Practice 종목입니다.");
+        verify(recordService, never()).createRecord(any(), any(), any(), any());
+    }
+
+    private RecordSaveRequest request(UUID submissionId, int timeMs) {
+        return RecordSaveRequest.builder()
+                .eventType(EventType.WCA_333)
+                .timeMs(timeMs)
+                .penalty(Penalty.NONE)
+                .scramble("R U R' U'")
+                .inputMethod(InputMethod.KEYBOARD)
+                .clientSubmissionId(submissionId)
+                .build();
+    }
+
+    private RecordCreateResponse response(Long id) {
+        return new RecordCreateResponse(
+                id,
+                EventType.WCA_333,
+                12345,
+                Penalty.NONE,
+                12345,
+                "R U R' U'",
+                InputMethod.KEYBOARD,
+                Instant.parse("2026-08-10T11:15:30.123Z")
+        );
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/record/service/ScrambleServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/service/ScrambleServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.cubinghub.common.exception.CustomApiException;
 import com.cubinghub.domain.record.dto.response.ScrambleResponse;
 import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ import org.springframework.http.HttpStatus;
 @DisplayName("ScrambleService 단위 테스트")
 class ScrambleServiceTest {
 
-    private final ScrambleService scrambleService = new ScrambleService();
+    private final ScrambleService scrambleService = new ScrambleService(new PracticeEventCapabilities());
 
     @Test
     @DisplayName("지원 종목이면 scramble을 생성한다")
@@ -44,6 +45,6 @@ class ScrambleServiceTest {
         assertThat(thrown).isInstanceOf(CustomApiException.class);
         CustomApiException exception = (CustomApiException) thrown;
         assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(exception.getMessage()).isEqualTo("아직 구현되지 않은 종목입니다.");
+        assertThat(exception.getMessage()).isEqualTo("지원하지 않는 Practice 종목입니다.");
     }
 }

--- a/backend/src/test/java/com/cubinghub/domain/user/UserProfileDocsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/user/UserProfileDocsTest.java
@@ -114,6 +114,7 @@ class UserProfileDocsTest extends RestDocsIntegrationTest {
 
         mockMvc.perform(get("/api/users/me/records")
                         .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_333.name())
                         .param("page", "1")
                         .param("size", "2"))
                 .andExpect(status().isOk())
@@ -126,6 +127,7 @@ class UserProfileDocsTest extends RestDocsIntegrationTest {
                                 headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
                         ),
                         queryParameters(
+                                parameterWithName("eventType").optional().description("Practice 종목 필터 (V2.1은 WCA_333 지원)"),
                                 parameterWithName("page").optional().description("1부터 시작하는 페이지 번호 (기본값 1)"),
                                 parameterWithName("size").optional().description("페이지 크기 (기본값 10, 최대 100)")
                         ),
@@ -139,6 +141,7 @@ class UserProfileDocsTest extends RestDocsIntegrationTest {
                                 fieldWithPath("data.items[].timeMs").type(JsonFieldType.NUMBER).description("원본 측정 시간 (밀리초)"),
                                 fieldWithPath("data.items[].effectiveTimeMs").type(JsonFieldType.NUMBER).optional().description("페널티 반영 시간 (DNF면 null)"),
                                 fieldWithPath("data.items[].penalty").type(JsonFieldType.STRING).description("페널티 정보"),
+                                fieldWithPath("data.items[].inputMethod").type(JsonFieldType.STRING).description("정규화된 입력 방식"),
                                 fieldWithPath("data.items[].createdAt").type(JsonFieldType.STRING).description("기록 생성 시각"),
                                 fieldWithPath("data.page").type(JsonFieldType.NUMBER).description("현재 페이지 번호 (1부터 시작)"),
                                 fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("페이지 크기"),

--- a/backend/src/test/java/com/cubinghub/domain/user/UserProfileIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/user/UserProfileIntegrationTest.java
@@ -22,6 +22,7 @@ import com.cubinghub.integration.JpaIntegrationTest;
 import com.cubinghub.security.JwtTokenProvider;
 import com.cubinghub.support.TestFixtures;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,9 @@ class UserProfileIntegrationTest extends JpaIntegrationTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private User testUser;
     private String accessToken;
@@ -107,6 +111,7 @@ class UserProfileIntegrationTest extends JpaIntegrationTest {
                 .andExpect(jsonPath("$.message").value("내 기록을 조회했습니다."))
                 .andExpect(jsonPath("$.data.items.length()").value(2))
                 .andExpect(jsonPath("$.data.items[0].id").exists())
+                .andExpect(jsonPath("$.data.items[0].inputMethod").value("UNKNOWN"))
                 .andExpect(jsonPath("$.data.items[0].createdAt").exists())
                 .andExpect(jsonPath("$.data.page").value(1))
                 .andExpect(jsonPath("$.data.size").value(2))
@@ -114,6 +119,59 @@ class UserProfileIntegrationTest extends JpaIntegrationTest {
                 .andExpect(jsonPath("$.data.totalPages").value(2))
                 .andExpect(jsonPath("$.data.hasNext").value(true))
                 .andExpect(jsonPath("$.data.hasPrevious").value(false));
+    }
+
+    @Test
+    @DisplayName("eventType 필터는 해당 Practice event 기록만 안정된 순서로 반환한다")
+    void should_filter_my_records_by_event_type_with_stable_ordering() throws Exception {
+        Record olderId = saveRecord(testUser, EventType.WCA_333, 10000, Penalty.NONE, "first-333");
+        Record newerId = saveRecord(testUser, EventType.WCA_333, 11000, Penalty.NONE, "second-333");
+        saveRecord(testUser, EventType.WCA_222, 5000, Penalty.NONE, "legacy-222");
+        recordRepository.flush();
+        entityManager.createNativeQuery("""
+                        UPDATE records
+                        SET created_at = '2026-08-10 11:15:30.123000'
+                        WHERE id IN (:firstId, :secondId)
+                        """)
+                .setParameter("firstId", olderId.getId())
+                .setParameter("secondId", newerId.getId())
+                .executeUpdate();
+        entityManager.clear();
+
+        mockMvc.perform(get("/api/users/me/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", "WCA_333")
+                        .param("page", "1")
+                        .param("size", "12")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.items[0].id").value(newerId.getId()))
+                .andExpect(jsonPath("$.data.items[1].id").value(olderId.getId()))
+                .andExpect(jsonPath("$.data.items[0].eventType").value("WCA_333"))
+                .andExpect(jsonPath("$.data.items[1].eventType").value("WCA_333"));
+    }
+
+    @Test
+    @DisplayName("미지원 Practice event 기록 필터 요청은 400을 반환한다")
+    void should_return_bad_request_when_history_event_is_not_supported() throws Exception {
+        mockMvc.perform(get("/api/users/me/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", "WCA_222")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Practice 종목입니다."));
+    }
+
+    @Test
+    @DisplayName("알 수 없는 history EventType 문자열은 500이 아니라 400을 반환한다")
+    void should_return_bad_request_when_history_event_type_is_invalid() throws Exception {
+        mockMvc.perform(get("/api/users/me/records")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", "UNKNOWN_EVENT")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("eventType 파라미터 형식이 올바르지 않습니다."));
     }
 
     @Test

--- a/backend/src/test/java/com/cubinghub/domain/user/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/user/service/UserProfileServiceTest.java
@@ -10,6 +10,7 @@ import com.cubinghub.common.exception.CustomApiException;
 import com.cubinghub.domain.auth.repository.RefreshTokenService;
 import com.cubinghub.domain.record.entity.EventType;
 import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
 import com.cubinghub.domain.record.repository.RecordRepository;
 import com.cubinghub.domain.record.repository.RecordSummaryQueryResult;
 import com.cubinghub.domain.user.dto.request.ChangePasswordRequest;
@@ -53,7 +54,13 @@ class UserProfileServiceTest {
 
     @BeforeEach
     void setUp() {
-        userProfileService = new UserProfileService(userRepository, recordRepository, passwordEncoder, refreshTokenService);
+        userProfileService = new UserProfileService(
+                userRepository,
+                recordRepository,
+                passwordEncoder,
+                refreshTokenService,
+                new PracticeEventCapabilities()
+        );
     }
 
     @Test
@@ -83,10 +90,10 @@ class UserProfileServiceTest {
         var dnfRecord = TestFixtures.createRecord(12L, user, EventType.WCA_333, 9500, Penalty.DNF, "dnf");
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
-        when(recordRepository.findByUserIdOrderByCreatedAtDesc(user.getId(), PageRequest.of(1, 2)))
+        when(recordRepository.findByUserIdOrderByCreatedAtDescIdDesc(user.getId(), PageRequest.of(1, 2)))
                 .thenReturn(new PageImpl<>(List.of(dnfRecord, plusTwoRecord), PageRequest.of(1, 2), 5));
 
-        MyRecordPageResponse response = userProfileService.getMyRecords(user.getEmail(), 2, 2);
+        MyRecordPageResponse response = userProfileService.getMyRecords(user.getEmail(), null, 2, 2);
 
         assertThat(response.getItems()).hasSize(2);
         assertThat(response.getItems().get(0).getPenalty()).isEqualTo(Penalty.DNF);
@@ -98,6 +105,54 @@ class UserProfileServiceTest {
         assertThat(response.getTotalPages()).isEqualTo(3);
         assertThat(response.isHasNext()).isTrue();
         assertThat(response.isHasPrevious()).isTrue();
+    }
+
+    @Test
+    @DisplayName("내 기록 event filter는 지원 Practice event repository query를 사용한다")
+    void should_query_records_by_event_when_supported_filter_is_present() {
+        User user = TestFixtures.createUser(1L, "tester@cubinghub.com", "Tester", UserRole.ROLE_USER, UserStatus.ACTIVE);
+        var record = TestFixtures.createRecord(11L, user, EventType.WCA_333, 9000, Penalty.NONE, "filtered");
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(recordRepository.findByUserIdAndEventTypeOrderByCreatedAtDescIdDesc(
+                user.getId(),
+                EventType.WCA_333,
+                PageRequest.of(0, 12)
+        )).thenReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 12), 1));
+
+        MyRecordPageResponse response = userProfileService.getMyRecords(
+                user.getEmail(),
+                EventType.WCA_333,
+                1,
+                12
+        );
+
+        assertThat(response.getItems()).singleElement()
+                .extracting(item -> item.getEventType())
+                .isEqualTo(EventType.WCA_333);
+    }
+
+    @Test
+    @DisplayName("내 기록 event filter는 미지원 Practice event를 repository 조회 전에 거절한다")
+    void should_reject_unsupported_event_before_querying_filtered_records() {
+        User user = TestFixtures.createUser(1L, "tester@cubinghub.com", "Tester", UserRole.ROLE_USER, UserStatus.ACTIVE);
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+
+        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords(
+                user.getEmail(),
+                EventType.WCA_222,
+                1,
+                12
+        ));
+
+        assertThat(thrown)
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("지원하지 않는 Practice 종목입니다.");
+        verify(recordRepository, never()).findByUserIdAndEventTypeOrderByCreatedAtDescIdDesc(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 
     @Test
@@ -179,7 +234,7 @@ class UserProfileServiceTest {
     void should_throw_unauthorized_exception_when_my_records_user_does_not_exist() {
         when(userRepository.findByEmail("missing@cubinghub.com")).thenReturn(Optional.empty());
 
-        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("missing@cubinghub.com", 1, 10));
+        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("missing@cubinghub.com", null, 1, 10));
 
         assertThat(thrown)
                 .isInstanceOf(CustomApiException.class)
@@ -239,7 +294,7 @@ class UserProfileServiceTest {
     @Test
     @DisplayName("내 기록 조회 page가 1보다 작으면 예외를 던진다")
     void should_throw_illegal_argument_exception_when_page_is_less_than_one() {
-        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", 0, 10));
+        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", null, 0, 10));
 
         assertThat(thrown)
                 .isInstanceOf(IllegalArgumentException.class)
@@ -249,7 +304,7 @@ class UserProfileServiceTest {
     @Test
     @DisplayName("내 기록 조회 size가 1보다 작으면 예외를 던진다")
     void should_throw_illegal_argument_exception_when_size_is_less_than_one() {
-        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", 1, 0));
+        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", null, 1, 0));
 
         assertThat(thrown)
                 .isInstanceOf(IllegalArgumentException.class)
@@ -259,7 +314,7 @@ class UserProfileServiceTest {
     @Test
     @DisplayName("내 기록 조회 size가 범위를 벗어나면 예외를 던진다")
     void should_throw_illegal_argument_exception_when_size_is_out_of_range() {
-        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", 1, 101));
+        Throwable thrown = catchThrowable(() -> userProfileService.getMyRecords("tester@cubinghub.com", null, 1, 101));
 
         assertThat(thrown)
                 .isInstanceOf(IllegalArgumentException.class)

--- a/docs/03-architecture/backend-architecture.md
+++ b/docs/03-architecture/backend-architecture.md
@@ -40,7 +40,7 @@ related:
 
 ## V2.1 Timer / Record 목표 구조
 
-아래는 사용자 승인된 구현 목표이며 현재 code에는 아직 반영되지 않았다.
+아래 Record Foundation backend 경계는 V3 migration, application service와 executable test에 반영됐다. Timer Core, stopped time canonicalization, frontend provenance wiring과 pending solve recovery는 다음 Timer Foundation slice의 책임이다.
 
 ### Practice Record boundary
 
@@ -52,7 +52,7 @@ related:
 
 - `clientSubmissionId`는 JSON body의 canonical UUID v4 string이다. 갱신된 Timer는 필수로 보내지만 cached legacy client transition 동안 server request field는 optional이다.
 - user-scoped identity는 DB `UNIQUE(user_id, client_submission_id)`로 최종 보장한다. identity가 없는 legacy request는 기존 non-idempotent create로 처리한다.
-- server는 eventType, canonical timeMs, penalty, exact scramble, normalized Input Method를 length-prefixed UTF-8 `v1` sequence로 만들고 SHA-256 fingerprint를 계산해 최초 create payload와 함께 불변 보존한다.
+- server는 `v1`, eventType, canonical timeMs, penalty, exact scramble, normalized Input Method 순서로 각 UTF-8 byte length를 4-byte big-endian integer로 붙인 `v1` sequence를 만들고 SHA-256 fingerprint를 계산해 최초 create payload와 함께 불변 보존한다. JSON serialization 결과에는 의존하지 않는다.
 - 같은 user·identity·fingerprint는 기존 Record를 반환하고, fingerprint가 다르면 409 Conflict다. 현재 penalty가 이후 PATCH로 바뀌어도 최초 fingerprint 비교에는 영향을 주지 않는다.
 - 일반 replay는 Record create와 같은 201 Created, 같은 Location과 canonical body를 반환한다. 이렇게 해야 기존 client의 status contract를 바꾸지 않는다.
 - pre-check replay는 repository mutation 전에 반환한다. Concurrent race에서는 Record insert를 flush해 unique 위반을 PB·Redis 계산보다 먼저 확정한다.

--- a/docs/04-data/data-dictionary.md
+++ b/docs/04-data/data-dictionary.md
@@ -12,6 +12,7 @@ related:
   - docs/01-domain/solve-model.md
   - backend/src/main/resources/db/migration/V1__init_schema.sql
   - backend/src/main/resources/db/migration/V2__add_query_support_indexes.sql
+  - backend/src/main/resources/db/migration/V3__add_record_foundation_fields.sql
 ---
 # Data Dictionary
 
@@ -39,21 +40,14 @@ related:
 | time_ms | penalty 전 positive raw time |
 | penalty | NONE, PLUS_TWO, DNF |
 | scramble | solve에 사용한 문자열 |
-| created_at, updated_at | PB tie-break와 변경 시각 |
+| input_method | varchar(32), nullable, DB default 없음. application `InputMethod` enum provenance이며 legacy null은 response에서 UNKNOWN으로 정규화 |
+| client_submission_id | char(36), nullable, DB default 없음. canonical lowercase UUID v4의 user 범위 retry identity |
+| client_submission_payload_hash | binary(32), nullable, DB default 없음. 최초 normalized logical payload의 SHA-256 internal value |
+| created_at, updated_at | history ordering과 변경 시각 |
 
-V2 index는 user_id, created_at 조합을 사용한다.
+V2 index는 user_id, created_at 조합을 사용한다. V3는 user-scoped submission unique index와 event-filtered stable history index를 추가한다.
 
-### 승인된 V2.1 target contract
-
-아래 column은 아직 current Flyway schema에 없으며 새 forward-only migration에서만 추가한다.
-
-| Column | Target type·nullability | 의미·제약 |
-| --- | --- | --- |
-| input_method | varchar(32), nullable, DB default 없음 | application `InputMethod` enum provenance. New Timer는 UNKNOWN, KEYBOARD, TOUCH 중 하나를 기록하고 legacy null은 response에서 UNKNOWN으로 정규화 |
-| client_submission_id | char(36), nullable, DB default 없음 | canonical lowercase UUID v4 string. user 범위 create retry identity이며 ordering에 사용하지 않음 |
-| client_submission_payload_hash | binary(32), nullable, DB default 없음 | 최초 server-normalized logical payload의 SHA-256. replay와 409 conflict 판정용 internal immutable value |
-
-Target index는 다음과 같다.
+V3 index는 다음과 같다.
 
 - `uk_record_user_client_submission` on `(user_id, client_submission_id)`
 - `idx_record_user_event_created_at_id` on `(user_id, event_type, created_at, id)`

--- a/docs/04-data/erd.md
+++ b/docs/04-data/erd.md
@@ -9,10 +9,11 @@ tags: []
 related:
   - docs/04-data/data-dictionary.md
   - backend/src/main/resources/db/migration/V1__init_schema.sql
+  - backend/src/main/resources/db/migration/V3__add_record_foundation_fields.sql
 ---
 # ERD
 
-Flyway V1과 V2 기준으로 현재 MySQL schema에는 9개 table이 있다.
+Flyway V1부터 V3 기준으로 현재 MySQL schema에는 9개 table이 있다.
 
 ```mermaid
 erDiagram
@@ -44,6 +45,9 @@ erDiagram
       int time_ms
       enum penalty
       text scramble
+      varchar input_method
+      char client_submission_id
+      binary client_submission_payload_hash
     }
     USER_PBS {
       bigint id PK

--- a/docs/04-data/migration-policy.md
+++ b/docs/04-data/migration-policy.md
@@ -16,7 +16,7 @@ related:
 
 ## Source of Truth
 
-backend/src/main/resources/db/migration의 Flyway SQL이 production schema의 Source of Truth다. 현재 적용 순서는 V1 init schema, V2 query support indexes다.
+backend/src/main/resources/db/migration의 Flyway SQL이 production schema의 Source of Truth다. 현재 적용 순서는 V1 init schema, V2 query support indexes, V3 Record Foundation fields다.
 
 ## 작성 원칙
 
@@ -49,11 +49,11 @@ production API는 SPRING_FLYWAY_ENABLED=false와 Hibernate validate로 실행한
 - index와 query plan 영향
 - backup과 restore 또는 forward recovery 절차
 
-## V2.1 Record Foundation migration plan
+## V2.1 Record Foundation migration
 
 현재 user 확인 기준 `records`와 `user_pbs`에는 data가 없다. 이 세션에서는 production query를 실행하지 않았으며, data가 없다는 조건이 migration discipline을 완화하지는 않는다.
 
-실제 구현에서는 applied V1·V2를 수정하지 않고 `V3__add_record_foundation_fields.sql` 같은 새 migration 한 개를 추가한다. 정확한 version은 구현 시작 시 migration directory를 다시 확인한 뒤 충돌 없이 정한다.
+Applied V1·V2를 수정하지 않고 `V3__add_record_foundation_fields.sql` forward-only migration 한 개를 추가했다.
 
 Migration 순서는 다음과 같다.
 
@@ -90,4 +90,4 @@ Test는 column type·nullability, index 존재, legacy row와 PB FK 보존, null
 
 기존 global test profile의 Flyway disabled·Hibernate create-drop 설정은 그대로 두고, dedicated test에서만 실제 migration path를 구성한다. CI workflow나 별도 DB infrastructure는 추가하지 않는다.
 
-이번 Documentation / Decision Gate에서는 migration 파일, schema, Testcontainers 설정과 test code를 변경하지 않는다.
+`RecordFoundationMigrationIntegrationTest`가 실제 V2→V3 upgrade와 새 application mapping을 executable contract로 유지한다.

--- a/docs/06-quality/test-strategy.md
+++ b/docs/06-quality/test-strategy.md
@@ -51,7 +51,7 @@ related:
 
 현재 `application-test.yaml`은 Flyway를 비활성화하고 Hibernate `create-drop`으로 schema를 만든다. 이 test profile만으로는 이미 적용된 schema에서 새 forward-only migration을 실행하는 upgrade path를 증명할 수 없다.
 
-V2.1 schema 변경은 별도 `RecordFoundationMigrationIntegrationTest` 성격의 MySQL Testcontainers test로 검증한다. 현재 dependency에 Flyway API와 MySQL Testcontainers가 이미 있으므로 새 runtime이나 CI service를 추가하지 않는다.
+V2.1 schema 변경은 별도 `RecordFoundationMigrationIntegrationTest` MySQL Testcontainers test로 검증한다. 현재 dependency의 Flyway API와 MySQL Testcontainers를 사용하므로 새 runtime이나 CI service를 추가하지 않는다.
 
 ```text
 programmatic Flyway target=V2
@@ -75,7 +75,7 @@ Dedicated context initializer가 application bean 생성 전에 위 migration과
 
 Current production data가 없더라도 representative legacy fixture를 넣는다. 이는 현재 row count에 의존하지 않고 old image rollback과 future non-empty upgrade path를 계속 검증하기 위한 golden fixture다. Clean schema 생성 성공을 upgrade 성공으로 대신하지 않는다.
 
-이번 Documentation / Decision Gate에서는 Testcontainers, Flyway test 설정, application test와 CI를 변경하지 않는다.
+이 전용 test는 V2→V3 upgrade 뒤 application context를 `ddl-auto=validate`로 시작한다. 일반 test profile의 Flyway disabled·Hibernate create-drop 계약은 변경하지 않는다.
 
 ## Infrastructure
 


### PR DESCRIPTION
## Summary

- V2.1 completed Practice Record backend foundation 구현
- WCA_333 Practice capability와 Input Method provenance 추가
- clientSubmissionId 기반 idempotent create와 canonical Record response 구현
- event-filtered history와 stable ordering 추가

## Domain contracts

- Record = completed Practice solve 경계 유지
- EventType identity와 Practice support capability 분리
- Input Method = UNKNOWN / KEYBOARD / TOUCH, Verification과 독립
- WCA_333만 V2.1 Practice Record / Scramble / Ranking 지원

## Database migration

- 신규 `V3__add_record_foundation_fields.sql` 추가
- nullable `input_method`, `client_submission_id`, `client_submission_payload_hash` 추가
- `UNIQUE(user_id, client_submission_id)`와 event history index 추가
- applied V1/V2 migration 미변경과 additive old-image compatibility 유지

## Idempotency

- UUID v4 body field와 normalized logical payload SHA-256 v1 fingerprint 구현
- same user + same ID + same payload의 201 replay 구현
- same user + same ID + different payload의 409 Conflict 구현
- DB unique loser를 failed transaction 밖에서 다시 읽는 concurrency 경계 구현
- replay의 Record/PB/Redis 중복 mutation 방지

## API changes

- `POST /api/records`의 기존 `data.id`를 유지한 additive canonical response 구현
- raw/effective time, penalty, scramble, normalized inputMethod, server createdAt 반환
- malformed EventType/InputMethod/UUID의 400 error contract 추가
- clientSubmissionId와 fingerprint 비노출 유지

## History / ordering

- `GET /api/users/me/records?eventType=WCA_333` optional filter 추가
- eventType 생략 시 기존 all-event history 의미 유지
- `created_at DESC, id DESC` stable ordering 적용

## Compatibility

- legacy request의 inputMethod/clientSubmissionId 누락 허용
- DB NULL Input Method의 UNKNOWN response 정규화
- MySQL records/user_pbs Source of Truth와 Redis rebuildable Read Model 책임 유지
- frontend consumer의 기존 `data.id` 계약 유지

## Tests

- capability, InputMethod converter, fingerprint golden value와 replay/conflict unit test 추가
- canonical create/error/history/PB regression MockMvc test 추가
- 실제 MySQL concurrent duplicate integration test 추가
- programmatic Flyway V2 → V3 legacy fixture upgrade와 Hibernate validate test 추가
- REST Docs request/response contract 갱신
- `git diff --check`, applied migration 불변, docs link/frontmatter, secret와 scope static validation 통과
- Mac mini host Java/Gradle 미실행: PR Validate가 full backend test/build와 REST Docs의 최종 근거

## Out of scope

- Timer Core frontend refactor와 canonical stopped time
- Keyboard/Touch frontend provenance wiring과 pending solve recovery
- Daily Challenge, Verified Record, Competition, Session과 hardware integration
- production DB/runtime, deploy와 CI workflow 변경

## Known risks

- 기존 synchronous Redis projection과 DB commit의 atomicity는 outbox 범위 밖
- PR #11에서 동일 SHA 재실행 후 성공한 unrelated TimerPage fallback test의 flaky 가능성
- V3 CHAR/BINARY mapping과 actual concurrency exception path는 이 PR의 MySQL CI 결과로 최종 확인 필요