### PR TITLE
feat: add V2.1 timer foundation

### DIFF
--- a/docs/02-requirements/features/timer.md
+++ b/docs/02-requirements/features/timer.md
@@ -104,7 +104,7 @@ solve stop
 - access token, refresh token과 credential은 저장하지 않는다.
 - storage key와 snapshot userId가 현재 authenticated user와 일치할 때만 복구한다.
 - logout이나 명시적 session clear는 현재 user의 pending을 제거한다. 다른 account pending을 읽거나 제출하지 않는다.
-- malformed JSON, schema mismatch, invalid field는 server에 제출하지 않고 일반 안내와 명시적 discard를 제공한다.
+- malformed JSON, schema mismatch, invalid field는 server에 제출하지 않고 일반 안내와 명시적 discard를 제공한다. corrupt pending이 남아 있는 동안 Timer input도 비활성화해 새 solve가 해당 entry를 덮어쓰지 못하게 한다.
 - sessionStorage page session과 명시적 discard를 사용하며 V2.1에서 임의의 시간 만료 정책을 추가하지 않는다. `savedAt`은 recovery metadata이지 `occurred_at`이 아니다.
 - 여러 solve를 쌓는 offline queue와 background sync는 만들지 않는다.
 - 저장 성공 전에는 결과를 저장 완료로 표시하지 않는다.

--- a/docs/02-requirements/features/timer.md
+++ b/docs/02-requirements/features/timer.md
@@ -104,7 +104,7 @@ solve stop
 - access token, refresh token과 credential은 저장하지 않는다.
 - storage key와 snapshot userId가 현재 authenticated user와 일치할 때만 복구한다.
 - logout이나 명시적 session clear는 현재 user의 pending을 제거한다. 다른 account pending을 읽거나 제출하지 않는다.
-- malformed JSON, schema mismatch, invalid field는 해당 pending을 안전하게 폐기하고 일반 안내를 표시한다.
+- malformed JSON, schema mismatch, invalid field는 server에 제출하지 않고 일반 안내와 명시적 discard를 제공한다.
 - sessionStorage page session과 명시적 discard를 사용하며 V2.1에서 임의의 시간 만료 정책을 추가하지 않는다. `savedAt`은 recovery metadata이지 `occurred_at`이 아니다.
 - 여러 solve를 쌓는 offline queue와 background sync는 만들지 않는다.
 - 저장 성공 전에는 결과를 저장 완료로 표시하지 않는다.

--- a/docs/03-architecture/frontend-architecture.md
+++ b/docs/03-architecture/frontend-architecture.md
@@ -38,13 +38,11 @@ ProtectedRoute와 AdminRoute가 화면 접근을 제어하지만 server authoriz
 - multipart request는 browser가 boundary를 설정하도록 기본 Content-Type을 제거한다.
 - page는 api module을 통해 backend endpoint를 호출한다.
 
-## 현재 Timer와 local state
+## Timer와 local state
 
-guest Timer history는 browser localStorage를 사용한다. keyboard와 pointer 입력은 한 hook의 Timer 상태 전이를 공유한다. 현재 상태, clock, keyboard, touch 처리와 animation 책임은 완전히 분리되어 있지 않다.
+guest Timer history는 browser localStorage를 사용한다. authenticated Timer의 단일 pending solve는 user-scoped sessionStorage에만 보존한다. V2.1 Timer는 browser event를 직접 알지 않는 reducer/state machine과 browser orchestration을 분리한다.
 
-## V2.1 Timer 목표 구조
-
-아래는 사용자 승인된 구현 목표이며 현재 frontend에는 아직 반영되지 않았다.
+## V2.1 Timer Core / Input Adapter
 
 ```text
 Keyboard Adapter ─┐
@@ -54,7 +52,7 @@ Touch Adapter ────┘
 
 - Pure `timerMachine` reducer는 idle, holding, ready, running, stopped 상태와 transition만 소유한다.
 - `useCubeTimer` core hook은 reducer, hold timeout, injected clock provider와 requestAnimationFrame lifecycle을 조합한다. Default clock은 `performance.now()`다.
-- Keyboard/Touch adapter는 browser event를 `PRESS`, `RELEASE`, `CANCEL` command와 UNKNOWN·KEYBOARD·TOUCH provenance로 변환한다. Internal `HOLD_READY`, `TICK`, `RESET`은 core가 처리한다.
+- Keyboard/Touch adapter는 browser event를 `PRESS`, `RELEASE`, `CANCEL` command와 KEYBOARD·TOUCH provenance로 변환한다. UNKNOWN은 legacy 또는 provenance 없는 Record의 normalized 의미이며 adapter가 hardware value처럼 발행하지 않는다. Internal `HOLD_READY`, `TICK`, `RESET`은 core가 처리한다.
 - Reducer는 browser global을 직접 읽지 않고 hook이 읽은 monotonic `now`를 event payload로 받는다.
 - solve를 시작한 initial press provenance를 stopped snapshot까지 유지하고, stop adapter는 provenance를 바꾸지 않는다.
 - RAF는 running 표시만 갱신한다. Stop에서는 elapsed를 `Math.round()`한 integer millisecond로 한 번 확정하고 stopped rendering, guest save, pending snapshot과 request가 같은 값을 사용한다.
@@ -78,7 +76,7 @@ Frontend label 목록은 EventType 표현을 유지하되 각 option에 `support
 - retry는 같은 client submission identity를 유지해 같은 server operation을 가리킨다. Response가 유실된 이미 저장된 solve도 server replay 뒤 정리된다.
 - access token, refresh token, credential은 browser storage에 저장하지 않는다.
 - 현재 userId가 key와 snapshot에 모두 일치할 때만 복구한다. Logout·session clear는 현재 user key를 제거하고 다른 account key를 읽지 않는다.
-- malformed JSON, unknown schema version, invalid event·time·UUID는 해당 snapshot을 제거하고 recoverable notice로 처리한다.
+- malformed JSON, unknown schema version, invalid event·time·UUID는 server에 제출하지 않고 recoverable notice와 explicit discard로 처리한다.
 - arbitrary time expiry는 두지 않는다. sessionStorage lifecycle과 explicit discard가 stale pending 경계이며 savedAt은 occurrence timestamp가 아니다.
 - 여러 solve를 쌓는 offline queue와 background sync는 V2.1 범위가 아니다.
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -432,7 +432,7 @@ export async function saveRecord(payload) {
     const response = await apiClient.post('/api/records', payload)
     return unwrapResponse(response)
   } catch (error) {
-    throw new Error(toErrorMessage(error))
+    throw toRequestError(error)
   }
 }
 

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -299,15 +299,6 @@ const genericCases = [
     expectedErrorMessage: '스크램블 조회 실패',
   },
   {
-    name: 'saveRecord',
-    fn: saveRecord,
-    method: 'post',
-    args: [{ eventType: 'WCA_333', timeMs: 8123 }],
-    expectedCallArgs: ['/api/records', { eventType: 'WCA_333', timeMs: 8123 }],
-    errorFactory: () => createResponseError('기록 저장 실패'),
-    expectedErrorMessage: '기록 저장 실패',
-  },
-  {
     name: 'updateRecordPenalty',
     fn: updateRecordPenalty,
     method: 'patch',
@@ -328,6 +319,17 @@ const genericCases = [
 ]
 
 const requestErrorCases = [
+  {
+    name: 'saveRecord',
+    fn: saveRecord,
+    method: 'post',
+    args: [{ eventType: 'WCA_333', timeMs: 8123 }],
+    expectedCallArgs: ['/api/records', { eventType: 'WCA_333', timeMs: 8123 }],
+    errorFactory: () => createResponseError('clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.', 409),
+    expectedErrorMessage: 'clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.',
+    expectedStatus: 409,
+    expectedIsNetworkError: false,
+  },
   {
     name: 'login',
     fn: login,

--- a/frontend/src/constants/eventOptions.js
+++ b/frontend/src/constants/eventOptions.js
@@ -1,23 +1,29 @@
+export const SUPPORTED_PRACTICE_EVENT_TYPES = new Set(['WCA_333'])
+
 export const eventOptions = [
-  { value: 'WCA_333', label: '3x3x3', supported: true },
-  { value: 'WCA_222', label: '2x2x2', supported: false },
-  { value: 'WCA_444', label: '4x4x4', supported: false },
-  { value: 'WCA_555', label: '5x5x5', supported: false },
-  { value: 'WCA_666', label: '6x6x6', supported: false },
-  { value: 'WCA_777', label: '7x7x7', supported: false },
-  { value: 'WCA_333BF', label: '3x3x3 블라인드', supported: false },
-  { value: 'WCA_444BF', label: '4x4x4 블라인드', supported: false },
-  { value: 'WCA_555BF', label: '5x5x5 블라인드', supported: false },
-  { value: 'WCA_333MBF', label: '3x3x3 멀티 블라인드', supported: false },
-  { value: 'WCA_333OH', label: '3x3x3 원핸드', supported: false },
-  { value: 'WCA_333FM', label: '3x3x3 최소회전', supported: false },
-  { value: 'WCA_CLOCK', label: '루빅스 클락', supported: false },
-  { value: 'WCA_MINX', label: '메가밍크스', supported: false },
-  { value: 'WCA_PYRAM', label: '피라밍크스', supported: false },
-  { value: 'WCA_SKEWB', label: '스큐브', supported: false },
-  { value: 'WCA_SQ1', label: '스퀘어-1', supported: false },
+  { value: 'WCA_333', label: '3x3x3' },
+  { value: 'WCA_222', label: '2x2x2' },
+  { value: 'WCA_444', label: '4x4x4' },
+  { value: 'WCA_555', label: '5x5x5' },
+  { value: 'WCA_666', label: '6x6x6' },
+  { value: 'WCA_777', label: '7x7x7' },
+  { value: 'WCA_333BF', label: '3x3x3 블라인드' },
+  { value: 'WCA_444BF', label: '4x4x4 블라인드' },
+  { value: 'WCA_555BF', label: '5x5x5 블라인드' },
+  { value: 'WCA_333MBF', label: '3x3x3 멀티 블라인드' },
+  { value: 'WCA_333OH', label: '3x3x3 원핸드' },
+  { value: 'WCA_333FM', label: '3x3x3 최소회전' },
+  { value: 'WCA_CLOCK', label: '루빅스 클락' },
+  { value: 'WCA_MINX', label: '메가밍크스' },
+  { value: 'WCA_PYRAM', label: '피라밍크스' },
+  { value: 'WCA_SKEWB', label: '스큐브' },
+  { value: 'WCA_SQ1', label: '스퀘어-1' },
 ]
 
 export function findEventOption(value) {
   return eventOptions.find((option) => option.value === value)
+}
+
+export function isPracticeEventSupported(eventType) {
+  return SUPPORTED_PRACTICE_EVENT_TYPES.has(eventType)
 }

--- a/frontend/src/constants/eventOptions.test.js
+++ b/frontend/src/constants/eventOptions.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { eventOptions, isPracticeEventSupported, SUPPORTED_PRACTICE_EVENT_TYPES } from './eventOptions.js'
+
+describe('eventOptions', () => {
+  it('should_expose_only_wca_333_as_the_v2_1_practice_capability', () => {
+    expect([...SUPPORTED_PRACTICE_EVENT_TYPES]).toEqual(['WCA_333'])
+    expect(isPracticeEventSupported('WCA_333')).toBe(true)
+    expect(isPracticeEventSupported('WCA_333FM')).toBe(false)
+    expect(isPracticeEventSupported('WCA_333MBF')).toBe(false)
+  })
+
+  it('should_keep_event_labels_separate_from_practice_capability', () => {
+    expect(eventOptions.find((option) => option.value === 'WCA_222')).toEqual({
+      value: 'WCA_222',
+      label: '2x2x2',
+    })
+  })
+})

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,6 @@
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useRef, useState } from 'react'
 import { clearRefreshCookie, getMe, refreshSession } from '../api.js'
+import { clearPendingTimerSolve } from '../lib/pendingTimerSolveStorage.js'
 import {
   clearStoredAccessToken,
   getStoredAccessToken,
@@ -26,12 +27,18 @@ export function AuthProvider({ children }) {
   const [currentUser, setCurrentUser] = useState(null)
   const [isBootstrapping, setIsBootstrapping] = useState(true)
   const [isSessionSyncing, setIsSessionSyncing] = useState(false)
+  const currentUserRef = useRef(currentUser)
+
+  useEffect(() => {
+    currentUserRef.current = currentUser
+  }, [currentUser])
 
   useEffect(() => {
     return subscribeToAccessToken((nextToken) => {
       setAccessTokenState(nextToken)
 
       if (!nextToken) {
+        clearPendingTimerSolve(currentUserRef.current?.userId)
         setCurrentUser(null)
         setIsSessionSyncing(false)
       }
@@ -126,6 +133,7 @@ export function AuthProvider({ children }) {
   }
 
   const clearAccessToken = () => {
+    clearPendingTimerSolve(currentUserRef.current?.userId)
     setCurrentUser(null)
     setIsSessionSyncing(false)
     clearStoredAccessToken()

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearStoredAccessToken, getStoredAccessToken, setStoredAccessToken } from '../authStorage.js'
 import { clearRefreshCookie, getMe, refreshSession } from '../api.js'
+import { clearPendingTimerSolve, loadPendingTimerSolve, PENDING_TIMER_SOLVE_SCHEMA_VERSION, savePendingTimerSolve } from '../lib/pendingTimerSolveStorage.js'
 import { AuthProvider } from './AuthContext.jsx'
 import { useAuth } from './useAuth.js'
 
@@ -55,6 +56,7 @@ function AuthStateProbe() {
 describe('AuthProvider', () => {
   beforeEach(() => {
     clearStoredAccessToken()
+    window.sessionStorage.clear()
     vi.clearAllMocks()
   })
 
@@ -464,6 +466,73 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('has-auth-token')).toHaveTextContent('false')
       expect(screen.getByTestId('nickname')).toHaveTextContent('none')
     })
+  })
+
+  it('should_clear_the_current_users_pending_timer_solve_before_another_account_can_sign_in', async () => {
+    vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
+      status: 400,
+      isNetworkError: false,
+    }))
+    vi.mocked(getMe)
+      .mockResolvedValueOnce({
+        data: {
+          userId: 41,
+          nickname: 'AccountA',
+          role: 'ROLE_USER',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          userId: 42,
+          nickname: 'AccountB',
+          role: 'ROLE_USER',
+        },
+      })
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountA')
+    })
+
+    savePendingTimerSolve({
+      schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+      userId: 41,
+      eventType: 'WCA_333',
+      timeMs: 1235,
+      penalty: 'NONE',
+      scramble: "R U R' U'",
+      inputMethod: 'KEYBOARD',
+      clientSubmissionId: 'd9428888-122b-4d3e-a58e-790c4e5f97ad',
+      savedAt: '2026-08-10T13:00:00.000Z',
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '빈 토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated')).toHaveTextContent('false')
+    })
+
+    expect(loadPendingTimerSolve(41).snapshot).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountB')
+    })
+
+    expect(loadPendingTimerSolve(42).snapshot).toBeNull()
+    clearPendingTimerSolve(41)
   })
 
   it('should_ignore_null_updates_when_update_current_user_is_called_without_payload_or_user', async () => {

--- a/frontend/src/hooks/timerMachine.js
+++ b/frontend/src/hooks/timerMachine.js
@@ -1,0 +1,118 @@
+export const TIMER_STATUS = {
+  IDLE: 'idle',
+  HOLDING: 'holding',
+  READY: 'ready',
+  RUNNING: 'running',
+  STOPPED: 'stopped',
+}
+
+export const TIMER_COMMAND = {
+  PRESS: 'PRESS',
+  RELEASE: 'RELEASE',
+  HOLD_READY: 'HOLD_READY',
+  TICK: 'TICK',
+  CANCEL: 'CANCEL',
+  RESET: 'RESET',
+  RESTORE_STOPPED: 'RESTORE_STOPPED',
+}
+
+export function createInitialTimerState() {
+  return {
+    status: TIMER_STATUS.IDLE,
+    displayTime: 0,
+    finalTime: null,
+    startTime: null,
+    inputMethod: null,
+  }
+}
+
+export function canonicalizeElapsedTime(elapsedTime) {
+  if (!Number.isFinite(elapsedTime)) {
+    return 1
+  }
+
+  return Math.max(1, Math.round(Math.max(0, elapsedTime)))
+}
+
+export function timerReducer(state, command) {
+  switch (command.type) {
+    case TIMER_COMMAND.PRESS:
+      if (state.status === TIMER_STATUS.IDLE) {
+        return {
+          ...state,
+          status: TIMER_STATUS.HOLDING,
+          inputMethod: command.inputMethod,
+        }
+      }
+
+      if (state.status === TIMER_STATUS.RUNNING && state.startTime != null) {
+        const finalTime = canonicalizeElapsedTime(command.now - state.startTime)
+
+        return {
+          ...state,
+          status: TIMER_STATUS.STOPPED,
+          displayTime: finalTime,
+          finalTime,
+          startTime: null,
+        }
+      }
+
+      return state
+
+    case TIMER_COMMAND.HOLD_READY:
+      return state.status === TIMER_STATUS.HOLDING
+        ? { ...state, status: TIMER_STATUS.READY }
+        : state
+
+    case TIMER_COMMAND.RELEASE:
+      if (state.status === TIMER_STATUS.HOLDING) {
+        return createInitialTimerState()
+      }
+
+      if (state.status === TIMER_STATUS.READY) {
+        return {
+          ...state,
+          status: TIMER_STATUS.RUNNING,
+          displayTime: 0,
+          finalTime: null,
+          startTime: command.now,
+        }
+      }
+
+      return state
+
+    case TIMER_COMMAND.TICK:
+      if (state.status !== TIMER_STATUS.RUNNING || state.startTime == null || !Number.isFinite(command.now)) {
+        return state
+      }
+
+      return {
+        ...state,
+        displayTime: Math.max(0, command.now - state.startTime),
+      }
+
+    case TIMER_COMMAND.CANCEL:
+      return state.status === TIMER_STATUS.HOLDING || state.status === TIMER_STATUS.READY
+        ? createInitialTimerState()
+        : state
+
+    case TIMER_COMMAND.RESET:
+      return createInitialTimerState()
+
+    case TIMER_COMMAND.RESTORE_STOPPED:
+      if (!Number.isSafeInteger(command.timeMs) || command.timeMs < 1) {
+        return state
+      }
+
+      return {
+        status: TIMER_STATUS.STOPPED,
+        displayTime: command.timeMs,
+        finalTime: command.timeMs,
+        startTime: null,
+        inputMethod: command.inputMethod,
+      }
+
+    default:
+      return state
+  }
+}

--- a/frontend/src/hooks/timerMachine.test.js
+++ b/frontend/src/hooks/timerMachine.test.js
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeElapsedTime,
+  createInitialTimerState,
+  TIMER_COMMAND,
+  TIMER_STATUS,
+  timerReducer,
+} from './timerMachine.js'
+
+function reduce(state, command) {
+  return timerReducer(state, command)
+}
+
+describe('timerMachine', () => {
+  it('should_transition_from_idle_to_running_after_hold_ready_and_release', () => {
+    const holding = reduce(createInitialTimerState(), {
+      type: TIMER_COMMAND.PRESS,
+      inputMethod: 'KEYBOARD',
+      now: 100,
+    })
+    const ready = reduce(holding, { type: TIMER_COMMAND.HOLD_READY })
+    const running = reduce(ready, { type: TIMER_COMMAND.RELEASE, now: 1000 })
+
+    expect(holding).toMatchObject({ status: TIMER_STATUS.HOLDING, inputMethod: 'KEYBOARD' })
+    expect(ready.status).toBe(TIMER_STATUS.READY)
+    expect(running).toMatchObject({
+      status: TIMER_STATUS.RUNNING,
+      startTime: 1000,
+      displayTime: 0,
+      finalTime: null,
+      inputMethod: 'KEYBOARD',
+    })
+  })
+
+  it.each([
+    [1234.1, 1234],
+    [1234.4, 1234],
+    [1234.5, 1235],
+    [1234.7, 1235],
+  ])('should_canonicalize_elapsed_time_at_stop_for_%s', (elapsed, expected) => {
+    expect(canonicalizeElapsedTime(elapsed)).toBe(expected)
+  })
+
+  it('should_keep_start_input_provenance_when_a_different_input_stops_the_solve', () => {
+    const running = {
+      ...createInitialTimerState(),
+      status: TIMER_STATUS.RUNNING,
+      startTime: 1000,
+      inputMethod: 'KEYBOARD',
+    }
+
+    const stopped = reduce(running, {
+      type: TIMER_COMMAND.PRESS,
+      inputMethod: 'TOUCH',
+      now: 2234.7,
+    })
+
+    expect(stopped).toMatchObject({
+      status: TIMER_STATUS.STOPPED,
+      displayTime: 1235,
+      finalTime: 1235,
+      inputMethod: 'KEYBOARD',
+    })
+  })
+
+  it('should_keep_fractional_running_display_until_stop_canonicalizes_it', () => {
+    const running = {
+      ...createInitialTimerState(),
+      status: TIMER_STATUS.RUNNING,
+      startTime: 1000,
+      inputMethod: 'TOUCH',
+    }
+
+    const ticking = reduce(running, { type: TIMER_COMMAND.TICK, now: 2234.7 })
+    const stopped = reduce(ticking, { type: TIMER_COMMAND.PRESS, inputMethod: 'KEYBOARD', now: 2234.7 })
+
+    expect(ticking.displayTime).toBeCloseTo(1234.7)
+    expect(stopped.displayTime).toBe(1235)
+  })
+
+  it('should_cancel_holding_or_ready_but_preserve_a_running_solve', () => {
+    const holding = {
+      ...createInitialTimerState(),
+      status: TIMER_STATUS.HOLDING,
+      inputMethod: 'KEYBOARD',
+    }
+    const running = {
+      ...createInitialTimerState(),
+      status: TIMER_STATUS.RUNNING,
+      startTime: 1000,
+      inputMethod: 'KEYBOARD',
+    }
+
+    expect(reduce(holding, { type: TIMER_COMMAND.CANCEL })).toEqual(createInitialTimerState())
+    expect(reduce(running, { type: TIMER_COMMAND.CANCEL })).toEqual(running)
+  })
+
+  it('should_restore_a_pending_stopped_solve_without_remeasuring_elapsed_time', () => {
+    const restored = reduce(createInitialTimerState(), {
+      type: TIMER_COMMAND.RESTORE_STOPPED,
+      timeMs: 1235,
+      inputMethod: 'TOUCH',
+    })
+
+    expect(restored).toMatchObject({
+      status: TIMER_STATUS.STOPPED,
+      displayTime: 1235,
+      finalTime: 1235,
+      inputMethod: 'TOUCH',
+    })
+  })
+})

--- a/frontend/src/hooks/useCubeTimer.js
+++ b/frontend/src/hooks/useCubeTimer.js
@@ -1,18 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useReducer, useRef } from 'react'
+import {
+  createInitialTimerState,
+  TIMER_COMMAND,
+  TIMER_STATUS,
+  timerReducer,
+} from './timerMachine.js'
+import { useKeyboardTimerInput } from './useKeyboardTimerInput.js'
+import { useTouchTimerInput } from './useTouchTimerInput.js'
 
 const HOLD_DELAY_MS = 300
-
-function isTouchLikePointer(pointerType) {
-  return pointerType === 'touch' || pointerType === 'pen'
-}
-
-function isInteractiveTarget(target) {
-  if (!(target instanceof HTMLElement)) {
-    return false
-  }
-
-  return Boolean(target.closest('input, textarea, button, select'))
-}
 
 function formatTime(milliseconds) {
   const totalMilliseconds = Math.max(0, Math.floor(milliseconds))
@@ -27,228 +23,155 @@ function formatTime(milliseconds) {
   return `${String(seconds).padStart(2, '0')}.${String(remainingMilliseconds).padStart(3, '0')}`
 }
 
-export function useCubeTimer({ enabled }) {
-  const [status, setStatus] = useState('idle')
-  const [displayTime, setDisplayTime] = useState(0)
-  const [finalTime, setFinalTime] = useState(null)
+function defaultClock() {
+  return performance.now()
+}
 
+export function useCubeTimer({ enabled, clock = defaultClock }) {
+  const [state, dispatch] = useReducer(timerReducer, undefined, createInitialTimerState)
+  const stateRef = useRef(state)
   const holdTimeoutRef = useRef(null)
   const frameRef = useRef(null)
-  const startTimeRef = useRef(null)
-  const activePointerIdRef = useRef(null)
+
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
+
+  const dispatchCommand = useCallback((command) => {
+    const previousState = stateRef.current
+    const nextState = timerReducer(previousState, command)
+
+    stateRef.current = nextState
+    dispatch(command)
+
+    return { previousState, nextState }
+  }, [])
 
   const clearHoldTimeout = useCallback(() => {
-    if (holdTimeoutRef.current) {
+    if (holdTimeoutRef.current != null) {
       window.clearTimeout(holdTimeoutRef.current)
       holdTimeoutRef.current = null
     }
   }, [])
 
   const stopAnimation = useCallback(() => {
-    if (frameRef.current) {
+    if (frameRef.current != null) {
       window.cancelAnimationFrame(frameRef.current)
       frameRef.current = null
     }
   }, [])
 
-  const clearActivePointer = useCallback(() => {
-    activePointerIdRef.current = null
-  }, [])
+  const startAnimation = useCallback(() => {
+    const tick = () => {
+      if (stateRef.current.status !== TIMER_STATUS.RUNNING) {
+        return
+      }
+
+      dispatchCommand({ type: TIMER_COMMAND.TICK, now: clock() })
+      frameRef.current = window.requestAnimationFrame(tick)
+    }
+
+    frameRef.current = window.requestAnimationFrame(tick)
+  }, [clock, dispatchCommand])
+
+  const pressInput = useCallback((inputMethod) => {
+    if (!enabled) {
+      return
+    }
+
+    const { previousState, nextState } = dispatchCommand({
+      type: TIMER_COMMAND.PRESS,
+      inputMethod,
+      now: clock(),
+    })
+
+    if (previousState.status === TIMER_STATUS.IDLE && nextState.status === TIMER_STATUS.HOLDING) {
+      clearHoldTimeout()
+      holdTimeoutRef.current = window.setTimeout(() => {
+        holdTimeoutRef.current = null
+        dispatchCommand({ type: TIMER_COMMAND.HOLD_READY })
+      }, HOLD_DELAY_MS)
+    }
+
+    if (previousState.status === TIMER_STATUS.RUNNING && nextState.status === TIMER_STATUS.STOPPED) {
+      stopAnimation()
+    }
+  }, [clearHoldTimeout, clock, dispatchCommand, enabled, stopAnimation])
+
+  const releaseInput = useCallback(() => {
+    if (!enabled) {
+      return
+    }
+
+    const previousState = stateRef.current
+
+    if (previousState.status === TIMER_STATUS.HOLDING || previousState.status === TIMER_STATUS.READY) {
+      clearHoldTimeout()
+    }
+
+    const { nextState } = dispatchCommand({
+      type: TIMER_COMMAND.RELEASE,
+      now: clock(),
+    })
+
+    if (previousState.status === TIMER_STATUS.READY && nextState.status === TIMER_STATUS.RUNNING) {
+      startAnimation()
+    }
+  }, [clearHoldTimeout, clock, dispatchCommand, enabled, startAnimation])
+
+  const cancelInput = useCallback(() => {
+    clearHoldTimeout()
+    dispatchCommand({ type: TIMER_COMMAND.CANCEL })
+  }, [clearHoldTimeout, dispatchCommand])
+
+  const {
+    handlePointerDown,
+    handlePointerUp,
+    handlePointerCancel,
+    clearActivePointer,
+  } = useTouchTimerInput({
+    enabled,
+    onPress: pressInput,
+    onRelease: releaseInput,
+    onCancel: cancelInput,
+  })
 
   const resetTimer = useCallback(() => {
     clearHoldTimeout()
     stopAnimation()
     clearActivePointer()
-    startTimeRef.current = null
-    setStatus('idle')
-    setDisplayTime(0)
-    setFinalTime(null)
-  }, [clearActivePointer, clearHoldTimeout, stopAnimation])
+    dispatchCommand({ type: TIMER_COMMAND.RESET })
+  }, [clearActivePointer, clearHoldTimeout, dispatchCommand, stopAnimation])
 
-  const startAnimation = useCallback(() => {
-    const tick = () => {
-      if (startTimeRef.current == null) {
-        return
-      }
-
-      setDisplayTime(performance.now() - startTimeRef.current)
-      frameRef.current = window.requestAnimationFrame(tick)
-    }
-
-    frameRef.current = window.requestAnimationFrame(tick)
-  }, [])
-
-  const transitionToHolding = useCallback(() => {
-    setStatus('holding')
+  const restoreStoppedSolve = useCallback(({ timeMs, inputMethod }) => {
     clearHoldTimeout()
-    holdTimeoutRef.current = window.setTimeout(() => {
-      setStatus('ready')
-    }, HOLD_DELAY_MS)
-  }, [clearHoldTimeout])
-
-  const transitionToIdle = useCallback(() => {
-    clearHoldTimeout()
-    setStatus('idle')
-  }, [clearHoldTimeout])
-
-  const transitionToRunning = useCallback(() => {
-    clearHoldTimeout()
-    startTimeRef.current = performance.now()
-    setDisplayTime(0)
-    setFinalTime(null)
-    setStatus('running')
-    startAnimation()
-  }, [clearHoldTimeout, startAnimation])
-
-  const transitionToStopped = useCallback(() => {
-    /* v8 ignore next -- transitionToStopped is only reached after a running start timestamp exists */
-    if (startTimeRef.current == null) {
-      return
-    }
-
     stopAnimation()
-    const nextFinalTime = performance.now() - startTimeRef.current
-    setDisplayTime(nextFinalTime)
-    setFinalTime(nextFinalTime)
-    setStatus('stopped')
-  }, [stopAnimation])
-
-  const handleKeyDown = useCallback((event) => {
-    if (event.code !== 'Space' || event.repeat || isInteractiveTarget(event.target)) {
-      return
-    }
-
-    event.preventDefault()
-
-    if (!enabled) {
-      return
-    }
-
-    if (status === 'idle') {
-      transitionToHolding()
-      return
-    }
-
-    if (status === 'running') {
-      transitionToStopped()
-    }
-  }, [enabled, status, transitionToHolding, transitionToStopped])
-
-  const handleKeyUp = useCallback((event) => {
-    if (event.code !== 'Space' || isInteractiveTarget(event.target)) {
-      return
-    }
-
-    event.preventDefault()
-
-    if (!enabled) {
-      return
-    }
-
-    if (status === 'holding') {
-      transitionToIdle()
-      return
-    }
-
-    if (status === 'ready') {
-      transitionToRunning()
-    }
-  }, [enabled, status, transitionToIdle, transitionToRunning])
-
-  const handleKeyPress = useCallback((event) => {
-    if (event.code !== 'Space' || isInteractiveTarget(event.target)) {
-      return
-    }
-
-    event.preventDefault()
-  }, [])
-
-  const handleWindowBlur = useCallback(() => {
     clearActivePointer()
+    dispatchCommand({
+      type: TIMER_COMMAND.RESTORE_STOPPED,
+      timeMs,
+      inputMethod,
+    })
+  }, [clearActivePointer, clearHoldTimeout, dispatchCommand, stopAnimation])
 
-    if (status === 'holding' || status === 'ready') {
-      resetTimer()
-      return
-    }
-
-    clearHoldTimeout()
-  }, [clearActivePointer, clearHoldTimeout, resetTimer, status])
-
-  const handlePointerDown = useCallback((event) => {
-    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current != null || !enabled) {
-      return
-    }
-
-    event.preventDefault()
-    activePointerIdRef.current = event.pointerId
-    event.currentTarget?.setPointerCapture?.(event.pointerId)
-
-    if (status === 'idle') {
-      transitionToHolding()
-      return
-    }
-
-    if (status === 'running') {
-      transitionToStopped()
-    }
-  }, [enabled, status, transitionToHolding, transitionToStopped])
-
-  const handlePointerUp = useCallback((event) => {
-    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current !== event.pointerId) {
-      return
-    }
-
-    event.preventDefault()
-    clearActivePointer()
-
-    if (event.currentTarget?.hasPointerCapture?.(event.pointerId)) {
-      event.currentTarget.releasePointerCapture?.(event.pointerId)
-    }
-
-    if (!enabled) {
-      return
-    }
-
-    if (status === 'holding') {
-      transitionToIdle()
-      return
-    }
-
-    if (status === 'ready') {
-      transitionToRunning()
-    }
-  }, [clearActivePointer, enabled, status, transitionToIdle, transitionToRunning])
-
-  const handlePointerCancel = useCallback((event) => {
-    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current !== event.pointerId) {
-      return
-    }
-
-    clearActivePointer()
-    clearHoldTimeout()
-
-    if (event.currentTarget?.hasPointerCapture?.(event.pointerId)) {
-      event.currentTarget.releasePointerCapture?.(event.pointerId)
-    }
-
-    if (status === 'holding' || status === 'ready') {
-      setStatus('idle')
-    }
-  }, [clearActivePointer, clearHoldTimeout, status])
+  useKeyboardTimerInput({
+    enabled,
+    onPress: pressInput,
+    onRelease: releaseInput,
+  })
 
   useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown, { capture: true })
-    window.addEventListener('keyup', handleKeyUp, { capture: true })
-    window.addEventListener('keypress', handleKeyPress, { capture: true })
+    const handleWindowBlur = () => {
+      clearActivePointer()
+      cancelInput()
+    }
+
     window.addEventListener('blur', handleWindowBlur)
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown, { capture: true })
-      window.removeEventListener('keyup', handleKeyUp, { capture: true })
-      window.removeEventListener('keypress', handleKeyPress, { capture: true })
       window.removeEventListener('blur', handleWindowBlur)
     }
-  }, [handleKeyDown, handleKeyPress, handleKeyUp, handleWindowBlur])
+  }, [cancelInput, clearActivePointer])
 
   useEffect(() => () => {
     clearHoldTimeout()
@@ -256,13 +179,15 @@ export function useCubeTimer({ enabled }) {
   }, [clearHoldTimeout, stopAnimation])
 
   return {
-    status,
-    displayTime,
-    finalTime,
-    formattedTime: formatTime(displayTime),
+    status: state.status,
+    displayTime: state.displayTime,
+    finalTime: state.finalTime,
+    inputMethod: state.inputMethod,
+    formattedTime: formatTime(state.displayTime),
     handlePointerDown,
     handlePointerUp,
     handlePointerCancel,
     resetTimer,
+    restoreStoppedSolve,
   }
 }

--- a/frontend/src/hooks/useCubeTimer.test.jsx
+++ b/frontend/src/hooks/useCubeTimer.test.jsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCubeTimer } from './useCubeTimer.js'
 
 let animationFrameCallbacks = []
+let now = 0
 
 function dispatchSpaceKeyEvent(type, options = {}) {
   const target = options.target ?? window
@@ -48,10 +49,20 @@ function createPointerEvent({ pointerId = 1, pointerType = 'touch', currentTarge
   }
 }
 
+function renderTimer(initialEnabled = true) {
+  const clock = () => now
+
+  return renderHook(
+    ({ enabled }) => useCubeTimer({ enabled, clock }),
+    { initialProps: { enabled: initialEnabled } },
+  )
+}
+
 describe('useCubeTimer', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
+    now = 0
     animationFrameCallbacks = []
+    vi.useFakeTimers()
     vi.stubGlobal('requestAnimationFrame', vi.fn((callback) => {
       animationFrameCallbacks.push(callback)
       return animationFrameCallbacks.length
@@ -65,267 +76,219 @@ describe('useCubeTimer', () => {
     vi.restoreAllMocks()
   })
 
-  it('should_transition_to_running_when_spacebar_is_held_and_released', () => {
-    vi.spyOn(performance, 'now').mockReturnValue(1000)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+  it('should_transition_keyboard_input_and_share_the_canonical_stopped_value_with_display', () => {
+    now = 1000
+    const { result } = renderTimer()
 
     dispatchSpaceKeyEvent('keydown')
-    expect(result.current.status).toBe('holding')
+    expect(result.current).toMatchObject({ status: 'holding', inputMethod: 'KEYBOARD' })
 
     act(() => {
       vi.advanceTimersByTime(300)
     })
-
     expect(result.current.status).toBe('ready')
 
     dispatchSpaceKeyEvent('keyup')
     expect(result.current.status).toBe('running')
-  })
 
-  it('should_transition_to_running_when_touch_hold_completes_and_pointer_is_released', () => {
-    vi.spyOn(performance, 'now').mockReturnValue(1000)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-    const pointerTarget = createPointerTarget()
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget }))
-    })
-    expect(result.current.status).toBe('holding')
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    expect(result.current.status).toBe('ready')
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget }))
-    })
-    expect(result.current.status).toBe('running')
-  })
-
-  it('should_return_to_idle_when_touch_is_released_before_hold_delay', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-    const pointerTarget = createPointerTarget()
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget }))
-    })
-    expect(result.current.status).toBe('holding')
-
-    act(() => {
-      vi.advanceTimersByTime(150)
-    })
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget }))
-    })
-    expect(result.current.status).toBe('idle')
-  })
-
-  it('should_stop_timer_when_touch_starts_while_running', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(2450)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-    const firstPointerTarget = createPointerTarget()
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: firstPointerTarget, pointerId: 1 }))
-    })
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: firstPointerTarget, pointerId: 1 }))
-    })
-    expect(result.current.status).toBe('running')
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ pointerId: 2 }))
-    })
-    expect(result.current.status).toBe('stopped')
-    expect(result.current.finalTime).toBe(1450)
-  })
-
-  it('should_ignore_mouse_pointer_events_when_touch_handlers_receive_mouse_input', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ pointerId: 1, pointerType: 'mouse' }))
-      result.current.handlePointerUp(createPointerEvent({ pointerId: 1, pointerType: 'mouse' }))
-    })
-
-    expect(result.current.status).toBe('idle')
-  })
-
-  it('should_preserve_running_timer_when_window_blurs_during_active_solve', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(2450)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
+    now = 2234.7
     dispatchSpaceKeyEvent('keydown')
 
-    act(() => {
-      vi.advanceTimersByTime(300)
+    expect(result.current).toMatchObject({
+      status: 'stopped',
+      finalTime: 1235,
+      displayTime: 1235,
+      formattedTime: '01.235',
+      inputMethod: 'KEYBOARD',
     })
+  })
 
+  it('should_preserve_touch_provenance_when_keyboard_stops_a_touch_started_solve', () => {
+    now = 1000
+    const pointerTarget = createPointerTarget()
+    const { result } = renderTimer()
+
+    act(() => {
+      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget }))
+      vi.advanceTimersByTime(300)
+      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget }))
+    })
+    expect(result.current).toMatchObject({ status: 'running', inputMethod: 'TOUCH' })
+
+    now = 2234.5
+    dispatchSpaceKeyEvent('keydown')
+
+    expect(result.current).toMatchObject({
+      status: 'stopped',
+      finalTime: 1235,
+      inputMethod: 'TOUCH',
+    })
+  })
+
+  it('should_return_to_idle_when_hold_is_released_before_the_threshold', () => {
+    const { result } = renderTimer()
+
+    dispatchSpaceKeyEvent('keydown')
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
     dispatchSpaceKeyEvent('keyup')
-    expect(result.current.status).toBe('running')
 
-    dispatchWindowBlur()
-    expect(result.current.status).toBe('running')
-
-    dispatchSpaceKeyEvent('keydown')
-    expect(result.current.status).toBe('stopped')
-    expect(result.current.finalTime).toBe(1450)
+    expect(result.current).toMatchObject({
+      status: 'idle',
+      finalTime: null,
+      inputMethod: null,
+    })
   })
 
-  it('should_cancel_pending_start_when_window_blurs_in_ready_state', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    dispatchSpaceKeyEvent('keydown')
+  it('should_return_to_idle_when_touch_is_released_before_the_hold_threshold', () => {
+    const pointerTarget = createPointerTarget()
+    const { result } = renderTimer()
 
     act(() => {
-      vi.advanceTimersByTime(300)
+      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget }))
+      vi.advanceTimersByTime(299)
+      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget }))
     })
 
-    expect(result.current.status).toBe('ready')
-
-    dispatchWindowBlur()
-
-    expect(result.current.status).toBe('idle')
-    expect(result.current.displayTime).toBe(0)
-    expect(result.current.finalTime).toBeNull()
+    expect(result.current).toMatchObject({ status: 'idle', finalTime: null, inputMethod: null })
   })
 
-  it('should_ignore_keyboard_events_when_target_is_interactive_or_repeat_is_true', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+  it('should_ignore_mouse_and_interactive_target_input', () => {
+    const { result } = renderTimer()
     const button = document.createElement('button')
     document.body.append(button)
 
+    act(() => {
+      result.current.handlePointerDown(createPointerEvent({ pointerType: 'mouse' }))
+      result.current.handlePointerUp(createPointerEvent({ pointerType: 'mouse' }))
+    })
     dispatchSpaceKeyEvent('keydown', { target: button })
-    expect(result.current.status).toBe('idle')
+    dispatchSpaceKeyEvent('keyup', { target: button })
 
-    dispatchSpaceKeyEvent('keydown', { repeat: true })
     expect(result.current.status).toBe('idle')
-
-    dispatchSpaceKeyEvent('keypress', { target: button })
-    expect(result.current.status).toBe('idle')
+    button.remove()
   })
 
-  it('should_ignore_keyboard_and_pointer_events_when_timer_is_disabled', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: false }))
+  it('should_ignore_repeated_space_and_all_input_while_the_timer_is_disabled', () => {
+    const { result, rerender } = renderTimer(false)
 
     dispatchSpaceKeyEvent('keydown')
-    dispatchSpaceKeyEvent('keyup')
-
     act(() => {
       result.current.handlePointerDown(createPointerEvent({ pointerType: 'touch' }))
       result.current.handlePointerDown(createPointerEvent({ pointerType: 'pen' }))
     })
+    expect(result.current).toMatchObject({ status: 'idle', finalTime: null })
+
+    rerender({ enabled: true })
+    dispatchSpaceKeyEvent('keydown', { repeat: true })
 
     expect(result.current.status).toBe('idle')
-    expect(result.current.finalTime).toBeNull()
   })
 
-  it('should_ignore_keydown_when_timer_is_ready_but_not_running', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+  it('should_ignore_a_second_press_while_ready_and_subsequent_input_after_stop', () => {
+    now = 1000
+    const pointerTarget = createPointerTarget()
+    const { result } = renderTimer()
 
     dispatchSpaceKeyEvent('keydown')
-
     act(() => {
       vi.advanceTimersByTime(300)
     })
-
     expect(result.current.status).toBe('ready')
 
     dispatchSpaceKeyEvent('keydown')
-
     expect(result.current.status).toBe('ready')
-  })
-
-  it('should_ignore_keyup_when_target_is_interactive_or_timer_is_not_ready', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-    const button = document.createElement('button')
-    document.body.append(button)
-
-    dispatchSpaceKeyEvent('keyup', { target: button })
-    expect(result.current.status).toBe('idle')
 
     dispatchSpaceKeyEvent('keyup')
-    expect(result.current.status).toBe('idle')
+    now = 2234.7
+    act(() => {
+      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 7 }))
+    })
+    expect(result.current.status).toBe('stopped')
+
+    act(() => {
+      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget, pointerId: 7 }))
+      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 8 }))
+    })
+    expect(result.current).toMatchObject({ status: 'stopped', finalTime: 1235 })
   })
 
-  it('should_update_display_time_and_format_minutes_when_animation_frame_ticks', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(62001)
-      .mockReturnValueOnce(63001)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+  it('should_cancel_holding_or_ready_on_blur_but_preserve_a_running_solve', () => {
+    now = 1000
+    const { result } = renderTimer()
 
     dispatchSpaceKeyEvent('keydown')
+    dispatchWindowBlur()
+    expect(result.current.status).toBe('idle')
 
+    dispatchSpaceKeyEvent('keydown')
     act(() => {
       vi.advanceTimersByTime(300)
     })
+    expect(result.current.status).toBe('ready')
 
+    dispatchWindowBlur()
+    expect(result.current.status).toBe('idle')
+
+    dispatchSpaceKeyEvent('keydown')
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    dispatchSpaceKeyEvent('keyup')
+    expect(result.current.status).toBe('running')
+
+    dispatchWindowBlur()
+    expect(result.current.status).toBe('running')
+  })
+
+  it('should_update_only_running_display_on_animation_frame_and_clean_up_after_reset', () => {
+    now = 1000
+    const { result } = renderTimer()
+
+    dispatchSpaceKeyEvent('keydown')
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
     dispatchSpaceKeyEvent('keyup')
 
+    now = 62001
     act(() => {
       animationFrameCallbacks[0]()
     })
-
-    expect(result.current.displayTime).toBe(61001)
     expect(result.current.formattedTime).toBe('1:01.001')
-
-    dispatchSpaceKeyEvent('keydown')
-    expect(result.current.status).toBe('stopped')
-    expect(result.current.finalTime).toBe(62001)
-  })
-
-  it('should_ignore_animation_tick_when_timer_is_reset_after_start', () => {
-    vi.spyOn(performance, 'now').mockReturnValue(1000)
-
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    dispatchSpaceKeyEvent('keydown')
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    dispatchSpaceKeyEvent('keyup')
 
     act(() => {
       result.current.resetTimer()
       animationFrameCallbacks[0]()
     })
 
-    expect(result.current.status).toBe('idle')
-    expect(result.current.displayTime).toBe(0)
-    expect(result.current.finalTime).toBeNull()
+    expect(result.current).toMatchObject({ status: 'idle', displayTime: 0, finalTime: null })
+    expect(window.cancelAnimationFrame).toHaveBeenCalled()
   })
 
-  it('should_ignore_pointer_up_when_timer_becomes_disabled_after_pointer_capture', () => {
+  it('should_cancel_the_animation_frame_when_unmounted_while_running', () => {
+    now = 1000
+    const { unmount } = renderTimer()
+
+    dispatchSpaceKeyEvent('keydown')
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    dispatchSpaceKeyEvent('keyup')
+
+    unmount()
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalled()
+  })
+
+  it('should_release_pointer_capture_without_transition_when_timer_becomes_disabled', () => {
     const pointerTarget = createPointerTarget()
-    const { result, rerender } = renderHook(
-      ({ enabled }) => useCubeTimer({ enabled }),
-      { initialProps: { enabled: true } },
-    )
+    const { result, rerender } = renderTimer()
 
     act(() => {
       result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 7 }))
     })
-
     rerender({ enabled: false })
 
     act(() => {
@@ -336,176 +299,47 @@ describe('useCubeTimer', () => {
     expect(result.current.status).toBe('holding')
   })
 
-  it('should_reset_to_idle_when_pointer_cancel_occurs_with_matching_pointer', () => {
+  it('should_support_pen_input_and_cancel_an_incomplete_hold', () => {
     const pointerTarget = createPointerTarget()
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+    const { result } = renderTimer()
 
     act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 9, pointerType: 'pen' }))
+      result.current.handlePointerDown(createPointerEvent({
+        currentTarget: pointerTarget,
+        pointerId: 7,
+        pointerType: 'pen',
+      }))
     })
-    expect(result.current.status).toBe('holding')
+    expect(result.current).toMatchObject({ status: 'holding', inputMethod: 'TOUCH' })
 
     act(() => {
-      result.current.handlePointerCancel(createPointerEvent({ currentTarget: pointerTarget, pointerId: 9, pointerType: 'pen' }))
+      result.current.handlePointerCancel(createPointerEvent({
+        currentTarget: pointerTarget,
+        pointerId: 7,
+        pointerType: 'pen',
+      }))
     })
 
-    expect(pointerTarget.releasePointerCapture).toHaveBeenCalledWith(9)
-    expect(result.current.status).toBe('idle')
+    expect(pointerTarget.releasePointerCapture).toHaveBeenCalledWith(7)
+    expect(result.current).toMatchObject({ status: 'idle', finalTime: null, inputMethod: null })
   })
 
-  it('should_ignore_pointer_down_when_timer_is_stopped_but_not_running', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(2450)
-
-    const pointerTarget = createPointerTarget()
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
+  it('should_restore_a_pending_stopped_solve_without_starting_a_new_timer', () => {
+    const { result } = renderTimer()
 
     act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 1 }))
+      result.current.restoreStoppedSolve({ timeMs: 1235, inputMethod: 'TOUCH' })
     })
 
-    act(() => {
-      vi.advanceTimersByTime(300)
+    expect(result.current).toMatchObject({
+      status: 'stopped',
+      finalTime: 1235,
+      displayTime: 1235,
+      inputMethod: 'TOUCH',
     })
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget, pointerId: 1 }))
-    })
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 2 }))
-    })
-
-    expect(result.current.status).toBe('stopped')
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: pointerTarget, pointerId: 2 }))
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 3 }))
-    })
-
-    expect(result.current.status).toBe('stopped')
-    expect(result.current.finalTime).toBe(1450)
   })
 
-  it('should_skip_pointer_capture_release_when_target_does_not_report_capture', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(2450)
-
-    const uncapturedTarget = {
-      setPointerCapture: vi.fn(),
-      hasPointerCapture: vi.fn(() => false),
-      releasePointerCapture: vi.fn(),
-    }
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 1 }))
-    })
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 1 }))
-    })
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 2 }))
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 2 }))
-    })
-
-    expect(uncapturedTarget.releasePointerCapture).not.toHaveBeenCalled()
-    expect(result.current.status).toBe('stopped')
-  })
-
-  it('should_ignore_pointer_cancel_idle_reset_when_timer_is_stopped_and_target_has_no_capture', () => {
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(2450)
-
-    const uncapturedTarget = {
-      setPointerCapture: vi.fn(),
-      hasPointerCapture: vi.fn(() => false),
-      releasePointerCapture: vi.fn(),
-    }
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 1 }))
-    })
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    act(() => {
-      result.current.handlePointerUp(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 1 }))
-    })
-    expect(result.current.status).toBe('running')
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 2 }))
-    })
-
-    expect(result.current.status).toBe('stopped')
-
-    act(() => {
-      result.current.handlePointerCancel(createPointerEvent({ currentTarget: uncapturedTarget, pointerId: 2 }))
-    })
-
-    expect(uncapturedTarget.releasePointerCapture).not.toHaveBeenCalled()
-    expect(result.current.status).toBe('stopped')
-  })
-
-  it('should_ignore_pointer_cancel_when_pointer_does_not_match_active_pointer', () => {
-    const pointerTarget = createPointerTarget()
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 3 }))
-    })
-
-    act(() => {
-      result.current.handlePointerCancel(createPointerEvent({ currentTarget: pointerTarget, pointerId: 4 }))
-    })
-
-    expect(pointerTarget.releasePointerCapture).not.toHaveBeenCalled()
-    expect(result.current.status).toBe('holding')
-  })
-
-  it('should_cancel_animation_frame_when_hook_is_unmounted_while_running', () => {
-    vi.spyOn(performance, 'now').mockReturnValue(1000)
-
-    const { unmount } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    dispatchSpaceKeyEvent('keydown')
-
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    dispatchSpaceKeyEvent('keyup')
-
-    unmount()
-
-    expect(window.cancelAnimationFrame).toHaveBeenCalled()
-  })
-
-  it('should_return_to_idle_when_keyboard_hold_is_released_before_ready_state', () => {
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    dispatchSpaceKeyEvent('keydown')
-    expect(result.current.status).toBe('holding')
-
-    dispatchSpaceKeyEvent('keyup')
-
-    expect(result.current.status).toBe('idle')
-  })
-
-  it('should_prevent_default_on_keypress_for_spacebar_when_target_is_not_interactive', () => {
+  it('should_prevent_default_on_non_interactive_space_keypress', () => {
     const keypressEvent = new KeyboardEvent('keypress', {
       bubbles: true,
       cancelable: true,
@@ -513,32 +347,12 @@ describe('useCubeTimer', () => {
     })
     const preventDefaultSpy = vi.spyOn(keypressEvent, 'preventDefault')
 
-    renderHook(() => useCubeTimer({ enabled: true }))
+    renderTimer()
 
     act(() => {
       window.dispatchEvent(keypressEvent)
     })
 
     expect(preventDefaultSpy).toHaveBeenCalled()
-  })
-
-  it('should_reset_to_idle_when_pointer_cancel_occurs_in_ready_state', () => {
-    const pointerTarget = createPointerTarget()
-    const { result } = renderHook(() => useCubeTimer({ enabled: true }))
-
-    act(() => {
-      result.current.handlePointerDown(createPointerEvent({ currentTarget: pointerTarget, pointerId: 12 }))
-    })
-    act(() => {
-      vi.advanceTimersByTime(300)
-    })
-
-    expect(result.current.status).toBe('ready')
-
-    act(() => {
-      result.current.handlePointerCancel(createPointerEvent({ currentTarget: pointerTarget, pointerId: 12 }))
-    })
-
-    expect(result.current.status).toBe('idle')
   })
 })

--- a/frontend/src/hooks/useKeyboardTimerInput.js
+++ b/frontend/src/hooks/useKeyboardTimerInput.js
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+
+export function isInteractiveTimerTarget(target) {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return Boolean(target.closest('input, textarea, button, select'))
+}
+
+function isSpaceKeyEvent(event) {
+  return event.code === 'Space' && !isInteractiveTimerTarget(event.target)
+}
+
+export function useKeyboardTimerInput({ enabled, onPress, onRelease }) {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (!isSpaceKeyEvent(event) || event.repeat) {
+        return
+      }
+
+      event.preventDefault()
+
+      if (enabled) {
+        onPress('KEYBOARD')
+      }
+    }
+
+    const handleKeyUp = (event) => {
+      if (!isSpaceKeyEvent(event)) {
+        return
+      }
+
+      event.preventDefault()
+
+      if (enabled) {
+        onRelease()
+      }
+    }
+
+    const handleKeyPress = (event) => {
+      if (isSpaceKeyEvent(event)) {
+        event.preventDefault()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('keyup', handleKeyUp, true)
+    window.addEventListener('keypress', handleKeyPress, true)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('keyup', handleKeyUp, true)
+      window.removeEventListener('keypress', handleKeyPress, true)
+    }
+  }, [enabled, onPress, onRelease])
+}

--- a/frontend/src/hooks/useTouchTimerInput.js
+++ b/frontend/src/hooks/useTouchTimerInput.js
@@ -1,0 +1,61 @@
+import { useCallback, useRef } from 'react'
+
+export function isTouchLikePointer(pointerType) {
+  return pointerType === 'touch' || pointerType === 'pen'
+}
+
+function releasePointerCapture(event) {
+  if (event.currentTarget?.hasPointerCapture?.(event.pointerId)) {
+    event.currentTarget.releasePointerCapture?.(event.pointerId)
+  }
+}
+
+export function useTouchTimerInput({ enabled, onPress, onRelease, onCancel }) {
+  const activePointerIdRef = useRef(null)
+
+  const clearActivePointer = useCallback(() => {
+    activePointerIdRef.current = null
+  }, [])
+
+  const handlePointerDown = useCallback((event) => {
+    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current != null || !enabled) {
+      return
+    }
+
+    event.preventDefault()
+    activePointerIdRef.current = event.pointerId
+    event.currentTarget?.setPointerCapture?.(event.pointerId)
+    onPress('TOUCH')
+  }, [enabled, onPress])
+
+  const handlePointerUp = useCallback((event) => {
+    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current !== event.pointerId) {
+      return
+    }
+
+    event.preventDefault()
+    clearActivePointer()
+    releasePointerCapture(event)
+
+    if (enabled) {
+      onRelease()
+    }
+  }, [clearActivePointer, enabled, onRelease])
+
+  const handlePointerCancel = useCallback((event) => {
+    if (!isTouchLikePointer(event.pointerType) || activePointerIdRef.current !== event.pointerId) {
+      return
+    }
+
+    clearActivePointer()
+    releasePointerCapture(event)
+    onCancel()
+  }, [clearActivePointer, onCancel])
+
+  return {
+    handlePointerDown,
+    handlePointerUp,
+    handlePointerCancel,
+    clearActivePointer,
+  }
+}

--- a/frontend/src/lib/guestTimerStorage.js
+++ b/frontend/src/lib/guestTimerStorage.js
@@ -1,5 +1,6 @@
 const STORAGE_KEY = 'cubing-hub.guest-timer-records.v1'
 const MAX_RECORDS_PER_EVENT = 100
+const INPUT_METHODS = new Set(['UNKNOWN', 'KEYBOARD', 'TOUCH'])
 
 function getStorage() {
   if (typeof window === 'undefined' || !window.localStorage) {
@@ -40,6 +41,10 @@ function calculateEffectiveTimeMs(timeMs, penalty) {
   return timeMs
 }
 
+function normalizeInputMethod(inputMethod) {
+  return INPUT_METHODS.has(inputMethod) ? inputMethod : 'UNKNOWN'
+}
+
 function buildGuestRecord(snapshot) {
   const penalty = snapshot.penalty ?? 'NONE'
 
@@ -50,13 +55,19 @@ function buildGuestRecord(snapshot) {
     effectiveTimeMs: calculateEffectiveTimeMs(snapshot.timeMs, penalty),
     penalty,
     scramble: snapshot.scramble,
+    inputMethod: normalizeInputMethod(snapshot.inputMethod),
     createdAt: new Date().toISOString(),
   }
 }
 
 function getEventRecords(store, eventType) {
   const eventRecords = store[eventType]
-  return Array.isArray(eventRecords) ? eventRecords : []
+  return Array.isArray(eventRecords)
+    ? eventRecords.map((record) => ({
+        ...record,
+        inputMethod: normalizeInputMethod(record?.inputMethod),
+      }))
+    : []
 }
 
 function writeEventRecords(eventType, records) {

--- a/frontend/src/lib/guestTimerStorage.test.js
+++ b/frontend/src/lib/guestTimerStorage.test.js
@@ -24,6 +24,7 @@ describe('guestTimerStorage', () => {
       timeMs: 8123,
       penalty: 'NONE',
       scramble: "R U R' U'",
+      inputMethod: 'TOUCH',
     })
 
     const records = getGuestTimerRecords('WCA_333')
@@ -36,6 +37,7 @@ describe('guestTimerStorage', () => {
       effectiveTimeMs: 8123,
       penalty: 'NONE',
       scramble: "R U R' U'",
+      inputMethod: 'TOUCH',
     })
   })
 
@@ -45,6 +47,7 @@ describe('guestTimerStorage', () => {
       timeMs: 8123,
       penalty: 'NONE',
       scramble: "R U R' U'",
+      inputMethod: 'TOUCH',
     })
 
     updateGuestTimerRecordPenalty('WCA_333', savedRecord.id, 'PLUS_TWO')
@@ -120,6 +123,25 @@ describe('guestTimerStorage', () => {
       id: savedRecord.id,
       penalty: 'NONE',
       effectiveTimeMs: 8123,
+    })
+  })
+
+  it('should_read_legacy_guest_records_with_unknown_input_method_without_rewriting_storage', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      WCA_333: [{
+        id: 'guest-legacy',
+        eventType: 'WCA_333',
+        timeMs: 8123,
+        effectiveTimeMs: 8123,
+        penalty: 'NONE',
+        scramble: "R U R' U'",
+        createdAt: '2026-08-10T13:00:00.000Z',
+      }],
+    }))
+
+    expect(getGuestTimerRecords('WCA_333')[0]).toMatchObject({
+      id: 'guest-legacy',
+      inputMethod: 'UNKNOWN',
     })
   })
 

--- a/frontend/src/lib/pendingTimerSolveStorage.js
+++ b/frontend/src/lib/pendingTimerSolveStorage.js
@@ -1,0 +1,124 @@
+import { isPracticeEventSupported } from '../constants/eventOptions.js'
+
+export const PENDING_TIMER_SOLVE_SCHEMA_VERSION = 1
+
+const STORAGE_KEY_PREFIX = 'cubing-hub.timer.pending.v1:'
+const RECOVERY_DISCARD_MESSAGE = '저장 대기 기록을 복구할 수 없습니다. 기록을 버린 뒤 새로 측정해주세요.'
+const INPUT_METHODS = new Set(['UNKNOWN', 'KEYBOARD', 'TOUCH'])
+const PENALTIES = new Set(['NONE', 'PLUS_TWO', 'DNF'])
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function getSessionStorage() {
+  if (typeof window === 'undefined' || !window.sessionStorage) {
+    throw new Error('저장 대기 기록을 보존할 수 없습니다.')
+  }
+
+  return window.sessionStorage
+}
+
+function isValidUserId(userId) {
+  return Number.isSafeInteger(userId) && userId > 0
+}
+
+export function getPendingTimerSolveKey(userId) {
+  return isValidUserId(userId) ? `${STORAGE_KEY_PREFIX}${userId}` : null
+}
+
+export function isUuidV4(value) {
+  return typeof value === 'string' && UUID_V4_PATTERN.test(value)
+}
+
+function normalizeSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object' || !isValidUserId(snapshot.userId)) {
+    return null
+  }
+
+  if (
+    snapshot.schemaVersion !== PENDING_TIMER_SOLVE_SCHEMA_VERSION
+    || !isPracticeEventSupported(snapshot.eventType)
+    || !Number.isSafeInteger(snapshot.timeMs)
+    || snapshot.timeMs < 1
+    || !PENALTIES.has(snapshot.penalty)
+    || typeof snapshot.scramble !== 'string'
+    || snapshot.scramble.trim().length === 0
+    || !INPUT_METHODS.has(snapshot.inputMethod)
+    || !isUuidV4(snapshot.clientSubmissionId)
+    || typeof snapshot.savedAt !== 'string'
+    || Number.isNaN(Date.parse(snapshot.savedAt))
+  ) {
+    return null
+  }
+
+  return {
+    schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+    userId: snapshot.userId,
+    eventType: snapshot.eventType,
+    timeMs: snapshot.timeMs,
+    penalty: snapshot.penalty,
+    scramble: snapshot.scramble,
+    inputMethod: snapshot.inputMethod,
+    clientSubmissionId: snapshot.clientSubmissionId,
+    savedAt: snapshot.savedAt,
+  }
+}
+
+export function savePendingTimerSolve(snapshot) {
+  const normalizedSnapshot = normalizeSnapshot(snapshot)
+
+  if (!normalizedSnapshot) {
+    throw new Error('저장 대기 기록 형식이 올바르지 않습니다.')
+  }
+
+  getSessionStorage().setItem(
+    getPendingTimerSolveKey(normalizedSnapshot.userId),
+    JSON.stringify(normalizedSnapshot),
+  )
+
+  return normalizedSnapshot
+}
+
+export function clearPendingTimerSolve(userId) {
+  const key = getPendingTimerSolveKey(userId)
+
+  if (!key) {
+    return
+  }
+
+  try {
+    getSessionStorage().removeItem(key)
+  } catch {
+    // Storage failure must not make logout or discard crash the Timer UI.
+  }
+}
+
+export function loadPendingTimerSolve(userId) {
+  const key = getPendingTimerSolveKey(userId)
+
+  if (!key) {
+    return { snapshot: null, recoveryMessage: null, canDiscard: false }
+  }
+
+  let rawValue
+
+  try {
+    rawValue = getSessionStorage().getItem(key)
+  } catch {
+    return { snapshot: null, recoveryMessage: RECOVERY_DISCARD_MESSAGE, canDiscard: false }
+  }
+
+  if (!rawValue) {
+    return { snapshot: null, recoveryMessage: null, canDiscard: false }
+  }
+
+  try {
+    const normalizedSnapshot = normalizeSnapshot(JSON.parse(rawValue))
+
+    if (normalizedSnapshot?.userId === userId) {
+      return { snapshot: normalizedSnapshot, recoveryMessage: null, canDiscard: false }
+    }
+  } catch {
+    // The malformed record is never submitted; the user can explicitly discard it.
+  }
+
+  return { snapshot: null, recoveryMessage: RECOVERY_DISCARD_MESSAGE, canDiscard: true }
+}

--- a/frontend/src/lib/pendingTimerSolveStorage.test.js
+++ b/frontend/src/lib/pendingTimerSolveStorage.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearPendingTimerSolve,
+  getPendingTimerSolveKey,
+  isUuidV4,
+  loadPendingTimerSolve,
+  PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+  savePendingTimerSolve,
+} from './pendingTimerSolveStorage.js'
+
+const USER_ID = 41
+const SNAPSHOT = {
+  schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+  userId: USER_ID,
+  eventType: 'WCA_333',
+  timeMs: 1235,
+  penalty: 'NONE',
+  scramble: "R U R' U'",
+  inputMethod: 'KEYBOARD',
+  clientSubmissionId: 'd9428888-122b-4d3e-a58e-790c4e5f97ad',
+  savedAt: '2026-08-10T13:00:00.000Z',
+}
+
+describe('pendingTimerSolveStorage', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should_store_and_load_a_valid_owner_scoped_snapshot', () => {
+    savePendingTimerSolve(SNAPSHOT)
+
+    expect(getPendingTimerSolveKey(USER_ID)).toBe('cubing-hub.timer.pending.v1:41')
+    expect(loadPendingTimerSolve(USER_ID)).toEqual({
+      snapshot: SNAPSHOT,
+      recoveryMessage: null,
+      canDiscard: false,
+    })
+  })
+
+  it('should_not_expose_another_users_pending_snapshot', () => {
+    savePendingTimerSolve(SNAPSHOT)
+
+    expect(loadPendingTimerSolve(42)).toEqual({
+      snapshot: null,
+      recoveryMessage: null,
+      canDiscard: false,
+    })
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toEqual(SNAPSHOT)
+  })
+
+  it('should_accept_only_uuid_v4_submission_identifiers', () => {
+    expect(isUuidV4('d9428888-122b-4d3e-a58e-790c4e5f97ad')).toBe(true)
+    expect(isUuidV4('d9428888-122b-1d3e-a58e-790c4e5f97ad')).toBe(false)
+    expect(isUuidV4('019feafe-7b47-7363-bfcf-c2fd96b1eb1a')).toBe(false)
+  })
+
+  it('should_never_submit_invalid_json_and_allow_the_owner_to_discard_it', () => {
+    const key = getPendingTimerSolveKey(USER_ID)
+    window.sessionStorage.setItem(key, '{not-valid-json')
+
+    expect(loadPendingTimerSolve(USER_ID)).toEqual({
+      snapshot: null,
+      recoveryMessage: '저장 대기 기록을 복구할 수 없습니다. 기록을 버린 뒤 새로 측정해주세요.',
+      canDiscard: true,
+    })
+    expect(window.sessionStorage.getItem(key)).toBe('{not-valid-json')
+  })
+
+  it.each([
+    [{ ...SNAPSHOT, schemaVersion: 2 }],
+    [{ ...SNAPSHOT, userId: 42 }],
+    [{ ...SNAPSHOT, eventType: 'WCA_222' }],
+    [{ ...SNAPSHOT, timeMs: 0 }],
+    [{ ...SNAPSHOT, inputMethod: 'STACKMAT' }],
+    [{ ...SNAPSHOT, clientSubmissionId: 'not-a-uuid' }],
+  ])('should_keep_an_unsupported_or_corrupt_snapshot_for_explicit_discard', (invalidSnapshot) => {
+    const key = getPendingTimerSolveKey(USER_ID)
+    window.sessionStorage.setItem(key, JSON.stringify(invalidSnapshot))
+
+    expect(loadPendingTimerSolve(USER_ID)).toMatchObject({
+      snapshot: null,
+      canDiscard: true,
+    })
+    expect(window.sessionStorage.getItem(key)).toBe(JSON.stringify(invalidSnapshot))
+  })
+
+  it('should_clear_only_the_selected_owner_pending_snapshot', () => {
+    savePendingTimerSolve(SNAPSHOT)
+    savePendingTimerSolve({ ...SNAPSHOT, userId: 42 })
+
+    clearPendingTimerSolve(USER_ID)
+
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+    expect(loadPendingTimerSolve(42).snapshot).toEqual({ ...SNAPSHOT, userId: 42 })
+  })
+})

--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -217,7 +217,9 @@ export default function TimerPage() {
 
   const isSupported = isPracticeEventSupported(selectedEvent)
   const hasScramble = Boolean(scrambleData?.scramble)
-  const timerEnabled = isSupported && hasScramble && !isLoadingScramble
+  const canDiscardCorruptPendingSolve = discardablePendingOwnerId !== null
+    && discardablePendingOwnerId === authenticatedUserId
+  const timerEnabled = isSupported && hasScramble && !isLoadingScramble && !canDiscardCorruptPendingSolve
   const ao5 = useMemo(() => calculateAverageOf(recentStatsRecords, 5), [recentStatsRecords])
   const ao12 = useMemo(() => calculateAverageOf(recentStatsRecords, 12), [recentStatsRecords])
   const scrambleVisualUrl = useMemo(() => {
@@ -564,7 +566,6 @@ export default function TimerPage() {
   const canResolvePendingSolve = Boolean(
     stoppedSolveSnapshot && (saveStatus === 'error' || saveStatus === 'recovery'),
   )
-  const canDiscardCorruptPendingSolve = discardablePendingOwnerId === authenticatedUserId
   const isEventSelectionLocked = Boolean(stoppedSolveSnapshot || canDiscardCorruptPendingSolve)
 
   return (

--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -3,16 +3,25 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Activity, Box, Gauge, Trash2 } from 'lucide-react'
 import { toast } from 'react-toastify'
 import { deleteRecord, getMyRecords, getScramble, saveRecord, updateRecordPenalty } from '../api.js'
-import { eventOptions, findEventOption } from '../constants/eventOptions.js'
+import { eventOptions, isPracticeEventSupported } from '../constants/eventOptions.js'
 import { useAuth } from '../context/useAuth.js'
 import { useCubeTimer } from '../hooks/useCubeTimer.js'
+import {
+  clearPendingTimerSolve,
+  isUuidV4,
+  loadPendingTimerSolve,
+  PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+  savePendingTimerSolve,
+} from '../lib/pendingTimerSolveStorage.js'
 import { deleteGuestTimerRecord, getGuestTimerRecords, saveGuestTimerRecord, updateGuestTimerRecordPenalty } from '../lib/guestTimerStorage.js'
-import { calculateAverageOf, filterLatestRecordsByEvent, formatAverageResult, formatRecordTime } from '../utils/recordStats.js'
+import { calculateAverageOf, formatAverageResult, formatRecordTime } from '../utils/recordStats.js'
 import { buildVisualCubeUrl } from '../utils/visualCube.js'
 
-const RECENT_STATS_FETCH_SIZE = 100
+const RECENT_STATS_FETCH_SIZE = 12
 const RECENT_STATS_LIMIT = 12
 const RECENT_SAVED_LIMIT = 5
+const RECORD_INPUT_METHODS = new Set(['UNKNOWN', 'KEYBOARD', 'TOUCH'])
+const RECORD_PENALTIES = new Set(['NONE', 'PLUS_TWO', 'DNF'])
 
 export function getTimerMessage(status, isSupported, hasScramble) {
   if (!isSupported) {
@@ -82,18 +91,6 @@ export function getDisplayTime(record) {
   return formatRecordTime(record.effectiveTimeMs ?? record.timeMs, { padSeconds: true })
 }
 
-export function createSavedRecord({ id, eventType, timeMs, penalty, scramble, createdAt = new Date().toISOString() }) {
-  return {
-    id,
-    eventType,
-    timeMs,
-    effectiveTimeMs: penalty === 'DNF' ? null : penalty === 'PLUS_TWO' ? timeMs + 2000 : timeMs,
-    penalty,
-    scramble,
-    createdAt,
-  }
-}
-
 export function applyPenaltyUpdateToSavedRecord(record, recordId, nextRecord) {
   return record.id === recordId
     ? {
@@ -105,8 +102,98 @@ export function applyPenaltyUpdateToSavedRecord(record, recordId, nextRecord) {
     : record
 }
 
+function compareServerRecordOrder(left, right) {
+  const createdAtDifference = Date.parse(right.createdAt) - Date.parse(left.createdAt)
+
+  if (createdAtDifference !== 0) {
+    return createdAtDifference
+  }
+
+  return Number(right.id) - Number(left.id)
+}
+
+export function upsertRecentSavedRecord(records, nextRecord) {
+  return [nextRecord, ...records.filter((record) => record.id !== nextRecord.id)]
+    .sort(compareServerRecordOrder)
+    .slice(0, RECENT_SAVED_LIMIT)
+}
+
+export function toRecordCreatePayload(snapshot) {
+  return {
+    eventType: snapshot.eventType,
+    timeMs: snapshot.timeMs,
+    penalty: snapshot.penalty,
+    scramble: snapshot.scramble,
+    inputMethod: snapshot.inputMethod,
+    clientSubmissionId: snapshot.clientSubmissionId,
+  }
+}
+
+function getAuthenticatedUserId(currentUser) {
+  return Number.isSafeInteger(currentUser?.userId) && currentUser.userId > 0
+    ? currentUser.userId
+    : null
+}
+
+function createClientSubmissionId() {
+  const clientSubmissionId = globalThis.crypto?.randomUUID?.()
+
+  if (!isUuidV4(clientSubmissionId)) {
+    throw new Error('기록 저장 식별자를 만들 수 없습니다. 다시 시도해주세요.')
+  }
+
+  return clientSubmissionId
+}
+
+function isCanonicalRecord(record, snapshot) {
+  if (
+    !record
+    || record.id == null
+    || record.eventType !== snapshot.eventType
+    || record.timeMs !== snapshot.timeMs
+    || record.penalty !== snapshot.penalty
+    || record.scramble !== snapshot.scramble
+    || record.inputMethod !== snapshot.inputMethod
+    || !RECORD_PENALTIES.has(record.penalty)
+    || !RECORD_INPUT_METHODS.has(record.inputMethod)
+    || !Number.isSafeInteger(record.timeMs)
+    || record.timeMs < 1
+    || typeof record.createdAt !== 'string'
+    || Number.isNaN(Date.parse(record.createdAt))
+  ) {
+    return false
+  }
+
+  return record.penalty === 'DNF'
+    ? record.effectiveTimeMs == null
+    : Number.isSafeInteger(record.effectiveTimeMs)
+}
+
+function buildStoppedSolveSnapshot({ eventType, timeMs, scramble, inputMethod, userId }) {
+  const sharedSnapshot = {
+    eventType,
+    timeMs,
+    penalty: 'NONE',
+    scramble,
+    inputMethod: RECORD_INPUT_METHODS.has(inputMethod) ? inputMethod : 'UNKNOWN',
+  }
+
+  if (userId == null) {
+    return sharedSnapshot
+  }
+
+  return {
+    schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+    userId,
+    ...sharedSnapshot,
+    clientSubmissionId: createClientSubmissionId(),
+    savedAt: new Date().toISOString(),
+  }
+}
+
 export default function TimerPage() {
-  const { isAuthenticated } = useAuth()
+  const { currentUser, isAuthenticated } = useAuth()
+  const authenticatedUserId = getAuthenticatedUserId(currentUser)
   const [selectedEvent, setSelectedEvent] = useState('WCA_333')
   const [scrambleData, setScrambleData] = useState(null)
   const [scrambleMessage, setScrambleMessage] = useState(null)
@@ -121,11 +208,14 @@ export default function TimerPage() {
   const [deletingRecordId, setDeletingRecordId] = useState(null)
   const [stoppedSolveSnapshot, setStoppedSolveSnapshot] = useState(null)
   const [saveStatus, setSaveStatus] = useState('idle')
+  const [discardablePendingOwnerId, setDiscardablePendingOwnerId] = useState(null)
   const activePersistKeyRef = useRef(null)
   const completedStoppedSolveRef = useRef(false)
+  const recoveredPendingOwnerIdRef = useRef(null)
+  const previousAuthenticatedUserIdRef = useRef(null)
+  const authenticatedUserIdRef = useRef(authenticatedUserId)
 
-  const currentEvent = useMemo(() => findEventOption(selectedEvent), [selectedEvent])
-  const isSupported = Boolean(currentEvent?.supported)
+  const isSupported = isPracticeEventSupported(selectedEvent)
   const hasScramble = Boolean(scrambleData?.scramble)
   const timerEnabled = isSupported && hasScramble && !isLoadingScramble
   const ao5 = useMemo(() => calculateAverageOf(recentStatsRecords, 5), [recentStatsRecords])
@@ -145,16 +235,21 @@ export default function TimerPage() {
     status,
     finalTime,
     formattedTime,
+    inputMethod,
     handlePointerDown,
     handlePointerUp,
     handlePointerCancel,
     resetTimer,
+    restoreStoppedSolve,
   } = useCubeTimer({
     enabled: timerEnabled,
   })
 
+  useEffect(() => {
+    authenticatedUserIdRef.current = authenticatedUserId
+  }, [authenticatedUserId])
+
   const loadRecentStatistics = useCallback(async (eventType) => {
-    /* v8 ignore next -- callers only invoke this on authenticated supported-event paths */
     if (!isAuthenticated || !eventType) {
       setRecentStatsRecords([])
       setRecentStatsError(null)
@@ -165,8 +260,12 @@ export default function TimerPage() {
     setRecentStatsError(null)
 
     try {
-      const response = await getMyRecords({ page: 1, size: RECENT_STATS_FETCH_SIZE })
-      setRecentStatsRecords(filterLatestRecordsByEvent(response.data.items, eventType, RECENT_STATS_LIMIT))
+      const response = await getMyRecords({
+        eventType,
+        page: 1,
+        size: RECENT_STATS_FETCH_SIZE,
+      })
+      setRecentStatsRecords(Array.isArray(response.data?.items) ? response.data.items.slice(0, RECENT_STATS_LIMIT) : [])
       setRecentStatsError(null)
     } catch (error) {
       setRecentStatsRecords([])
@@ -187,6 +286,7 @@ export default function TimerPage() {
 
   const loadScramble = useCallback(async (eventType) => {
     setIsLoadingScramble(true)
+    setHasScrambleVisualError(false)
     setScrambleMessage(null)
     setSaveNotice(null)
 
@@ -218,10 +318,6 @@ export default function TimerPage() {
   }, [isSupported, loadScramble, resetTimer, selectedEvent])
 
   useEffect(() => {
-    setHasScrambleVisualError(false)
-  }, [scrambleVisualUrl])
-
-  useEffect(() => {
     if (!isSupported) {
       setRecentSavedRecords([])
       setRecentStatsRecords([])
@@ -238,6 +334,61 @@ export default function TimerPage() {
     setRecentSavedRecords([])
     loadRecentStatistics(selectedEvent)
   }, [isAuthenticated, isSupported, loadGuestStatistics, loadRecentStatistics, selectedEvent])
+
+  useEffect(() => {
+    if (status !== 'stopped' && completedStoppedSolveRef.current) {
+      setSaveNotice(null)
+      setSaveStatus('idle')
+      setStoppedSolveSnapshot(null)
+      completedStoppedSolveRef.current = false
+    }
+  }, [status])
+
+  useEffect(() => {
+    const previousUserId = previousAuthenticatedUserIdRef.current
+
+    if (previousUserId != null && previousUserId !== authenticatedUserId) {
+      clearPendingTimerSolve(previousUserId)
+      resetTimer()
+      setStoppedSolveSnapshot(null)
+      setSaveStatus('idle')
+      setSaveNotice(null)
+      setDiscardablePendingOwnerId(null)
+      completedStoppedSolveRef.current = false
+    }
+
+    if (previousUserId !== authenticatedUserId) {
+      recoveredPendingOwnerIdRef.current = null
+    }
+
+    previousAuthenticatedUserIdRef.current = authenticatedUserId
+  }, [authenticatedUserId, resetTimer])
+
+  useEffect(() => {
+    if (!isAuthenticated || authenticatedUserId == null || recoveredPendingOwnerIdRef.current === authenticatedUserId) {
+      return
+    }
+
+    recoveredPendingOwnerIdRef.current = authenticatedUserId
+    const { snapshot, recoveryMessage, canDiscard } = loadPendingTimerSolve(authenticatedUserId)
+
+    if (recoveryMessage) {
+      setSaveNotice(recoveryMessage)
+      setDiscardablePendingOwnerId(canDiscard ? authenticatedUserId : null)
+    }
+
+    if (!snapshot) {
+      return
+    }
+
+    completedStoppedSolveRef.current = false
+    setSelectedEvent(snapshot.eventType)
+    setStoppedSolveSnapshot(snapshot)
+    setDiscardablePendingOwnerId(null)
+    setSaveStatus('recovery')
+    setSaveNotice('저장하지 못한 기록을 복구했습니다. 저장 재시도 또는 버리기를 선택해주세요.')
+    restoreStoppedSolve(snapshot)
+  }, [authenticatedUserId, isAuthenticated, restoreStoppedSolve])
 
   const handleEventChange = (event) => {
     setSelectedEvent(event.target.value)
@@ -277,9 +428,7 @@ export default function TimerPage() {
       if (isAuthenticated) {
         const response = await updateRecordPenalty(recordId, { penalty })
         setRecentSavedRecords((current) =>
-          current.map((record) =>
-            applyPenaltyUpdateToSavedRecord(record, recordId, response.data),
-          ),
+          current.map((record) => applyPenaltyUpdateToSavedRecord(record, recordId, response.data)),
         )
         await loadRecentStatistics(selectedEvent)
         toast.success(response.message)
@@ -296,67 +445,88 @@ export default function TimerPage() {
   }
 
   useEffect(() => {
-    if (status !== 'stopped' || !finalTime || !isSupported || !scrambleData?.scramble || stoppedSolveSnapshot || completedStoppedSolveRef.current) {
+    if (
+      status !== 'stopped'
+      || !Number.isSafeInteger(finalTime)
+      || finalTime < 1
+      || !isSupported
+      || !scrambleData?.scramble
+      || stoppedSolveSnapshot
+      || completedStoppedSolveRef.current
+      || saveStatus !== 'idle'
+    ) {
       return
     }
 
-    const roundedTime = Math.max(1, Math.round(finalTime))
-    const nextSnapshot = {
-      key: `${selectedEvent}:${roundedTime}:${scrambleData.scramble}`,
-      eventType: selectedEvent,
-      timeMs: roundedTime,
-      penalty: 'NONE',
-      scramble: scrambleData.scramble,
-    }
+    try {
+      if (isAuthenticated && authenticatedUserId == null) {
+        throw new Error('계정 정보를 확인할 수 없습니다. 다시 로그인해주세요.')
+      }
 
-    setStoppedSolveSnapshot(nextSnapshot)
-    setSaveStatus('idle')
-    setSaveNotice(null)
-  }, [finalTime, isSupported, scrambleData?.scramble, selectedEvent, status, stoppedSolveSnapshot])
+      setStoppedSolveSnapshot(buildStoppedSolveSnapshot({
+        eventType: selectedEvent,
+        timeMs: finalTime,
+        scramble: scrambleData.scramble,
+        inputMethod,
+        userId: isAuthenticated ? authenticatedUserId : null,
+      }))
+      setSaveNotice(null)
+    } catch (error) {
+      setSaveStatus('error')
+      setSaveNotice(error.message)
+    }
+  }, [authenticatedUserId, finalTime, inputMethod, isAuthenticated, isSupported, saveStatus, scrambleData?.scramble, selectedEvent, status, stoppedSolveSnapshot])
 
   const persistStoppedSolve = useCallback(async (snapshot) => {
-    /* v8 ignore next -- saveStatus prevents duplicate in-flight calls for the same snapshot */
-    if (!snapshot || activePersistKeyRef.current === snapshot.key) {
+    const persistKey = snapshot?.clientSubmissionId ?? `guest:${snapshot?.eventType}:${snapshot?.timeMs}:${snapshot?.scramble}`
+
+    if (!snapshot || activePersistKeyRef.current === persistKey) {
       return
     }
 
-    activePersistKeyRef.current = snapshot.key
+    activePersistKeyRef.current = persistKey
     setSaveStatus('saving')
     setSaveNotice('기록 저장 중...')
 
     try {
       if (isAuthenticated) {
-        const response = await saveRecord({
-          eventType: snapshot.eventType,
-          timeMs: snapshot.timeMs,
-          penalty: snapshot.penalty,
-          scramble: snapshot.scramble,
-        })
+        if (snapshot.userId == null || snapshot.userId !== authenticatedUserIdRef.current) {
+          throw new Error('현재 계정의 저장 대기 기록이 아닙니다.')
+        }
 
-        setRecentSavedRecords((current) => [
-          createSavedRecord({
-            id: response.data?.id ?? Date.now(),
-            eventType: snapshot.eventType,
-            timeMs: snapshot.timeMs,
-            penalty: snapshot.penalty,
-            scramble: snapshot.scramble,
-          }),
-          ...current,
-        ].slice(0, RECENT_SAVED_LIMIT))
-        await loadRecentStatistics(snapshot.eventType)
+        savePendingTimerSolve(snapshot)
+        const response = await saveRecord(toRecordCreatePayload(snapshot))
+        const serverRecord = response.data
+
+        if (!isCanonicalRecord(serverRecord, snapshot)) {
+          throw new Error('저장 결과를 확인할 수 없습니다. 다시 시도해주세요.')
+        }
+
+        if (snapshot.userId !== authenticatedUserIdRef.current) {
+          return
+        }
+
+        clearPendingTimerSolve(snapshot.userId)
+        setRecentSavedRecords((current) => upsertRecentSavedRecord(current, serverRecord))
+        setStoppedSolveSnapshot(null)
+        completedStoppedSolveRef.current = true
+        setSaveStatus('success')
+        setSaveNotice(null)
         toast.success(response.message)
+        resetTimer()
+        await loadRecentStatistics(snapshot.eventType)
+        await loadScramble(snapshot.eventType)
       } else {
         saveGuestTimerRecord(snapshot)
         loadGuestStatistics(snapshot.eventType)
         toast.success('게스트 기록이 저장되었습니다.')
+        setStoppedSolveSnapshot(null)
+        completedStoppedSolveRef.current = true
+        setSaveStatus('success')
+        setSaveNotice(null)
+        resetTimer()
+        await loadScramble(snapshot.eventType)
       }
-
-      setStoppedSolveSnapshot(null)
-      completedStoppedSolveRef.current = true
-      setSaveStatus('success')
-      setSaveNotice(null)
-      resetTimer()
-      await loadScramble(snapshot.eventType)
     } catch (error) {
       setSaveStatus('error')
       setSaveNotice(error.message)
@@ -373,17 +543,29 @@ export default function TimerPage() {
     persistStoppedSolve(stoppedSolveSnapshot)
   }, [persistStoppedSolve, saveStatus, status, stoppedSolveSnapshot])
 
-  useEffect(() => {
-    if (status !== 'stopped') {
-      setSaveNotice(null)
-      setSaveStatus('idle')
-      setStoppedSolveSnapshot(null)
-      completedStoppedSolveRef.current = false
+  const handleDiscardStoppedSolve = async () => {
+    const pendingOwnerId = stoppedSolveSnapshot?.userId ?? discardablePendingOwnerId
+
+    if (pendingOwnerId != null) {
+      clearPendingTimerSolve(pendingOwnerId)
     }
-  }, [status])
+
+    setStoppedSolveSnapshot(null)
+    setDiscardablePendingOwnerId(null)
+    setSaveStatus('idle')
+    setSaveNotice(null)
+    completedStoppedSolveRef.current = true
+    resetTimer()
+    await loadScramble(selectedEvent)
+  }
 
   const timerMessage = getTimerMessage(status, isSupported, hasScramble)
   const statusLabel = getStatusLabel(status)
+  const canResolvePendingSolve = Boolean(
+    stoppedSolveSnapshot && (saveStatus === 'error' || saveStatus === 'recovery'),
+  )
+  const canDiscardCorruptPendingSolve = discardablePendingOwnerId === authenticatedUserId
+  const isEventSelectionLocked = Boolean(stoppedSolveSnapshot || canDiscardCorruptPendingSolve)
 
   return (
     <section className="page-grid timer-page">
@@ -420,7 +602,7 @@ export default function TimerPage() {
           <div className="timer-toolbar">
             <div className="field timer-event-field">
               <label htmlFor="event-type">종목</label>
-              <select id="event-type" value={selectedEvent} onChange={handleEventChange}>
+              <select id="event-type" value={selectedEvent} onChange={handleEventChange} disabled={isEventSelectionLocked}>
                 {eventOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
@@ -444,10 +626,22 @@ export default function TimerPage() {
             <h2 className="timer-value">{formattedTime}</h2>
             <p className="helper-text timer-helper">{timerMessage}</p>
             {saveNotice ? <p className="helper-text timer-save-notice">{saveNotice}</p> : null}
-            {saveStatus === 'error' && stoppedSolveSnapshot ? (
-              <button className="ghost-button" type="button" onClick={() => persistStoppedSolve(stoppedSolveSnapshot)}>
-                저장 재시도
-              </button>
+            {canResolvePendingSolve ? (
+              <div className="timer-actions timer-actions-row">
+                <button className="ghost-button" type="button" onClick={() => persistStoppedSolve(stoppedSolveSnapshot)}>
+                  저장 재시도
+                </button>
+                <button className="ghost-button" type="button" onClick={handleDiscardStoppedSolve}>
+                  기록 버리기
+                </button>
+              </div>
+            ) : null}
+            {canDiscardCorruptPendingSolve ? (
+              <div className="timer-actions timer-actions-row">
+                <button className="ghost-button" type="button" onClick={handleDiscardStoppedSolve}>
+                  기록 버리기
+                </button>
+              </div>
             ) : null}
           </div>
 

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'react-toastify'
 import { deleteRecord, getMyRecords, getScramble, saveRecord, updateRecordPenalty } from '../api.js'
 import { useAuth } from '../context/useAuth.js'
 import { useCubeTimer } from '../hooks/useCubeTimer.js'
+import {
+  clearPendingTimerSolve,
+  loadPendingTimerSolve,
+  PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+  savePendingTimerSolve,
+} from '../lib/pendingTimerSolveStorage.js'
 import {
   deleteGuestTimerRecord,
   getGuestTimerRecords,
@@ -12,11 +18,12 @@ import {
 } from '../lib/guestTimerStorage.js'
 import TimerPage, {
   applyPenaltyUpdateToSavedRecord,
-  createSavedRecord,
   getDisplayTime,
   getPenaltyLabel,
   getStatusLabel,
   getTimerMessage,
+  toRecordCreatePayload,
+  upsertRecentSavedRecord,
 } from './TimerPage.jsx'
 
 vi.mock('../api.js', () => ({
@@ -50,6 +57,23 @@ vi.mock('../lib/guestTimerStorage.js', () => ({
   updateGuestTimerRecordPenalty: vi.fn(),
 }))
 
+const USER_ID = 1
+const CLIENT_SUBMISSION_ID = 'd9428888-122b-4d3e-a58e-790c4e5f97ad'
+
+function createCanonicalRecord(overrides = {}) {
+  return {
+    id: 101,
+    eventType: 'WCA_333',
+    timeMs: 1235,
+    penalty: 'NONE',
+    effectiveTimeMs: 1235,
+    scramble: "R U R' U'",
+    inputMethod: 'KEYBOARD',
+    createdAt: '2026-08-10T13:00:00.000Z',
+    ...overrides,
+  }
+}
+
 function createRecentRecord(overrides = {}) {
   return {
     id: 1,
@@ -57,27 +81,99 @@ function createRecentRecord(overrides = {}) {
     timeMs: 8000,
     effectiveTimeMs: 8000,
     penalty: 'NONE',
-    createdAt: '2026-04-22T20:00:00',
+    scramble: "R U R' U'",
+    inputMethod: 'KEYBOARD',
+    createdAt: '2026-04-22T20:00:00.000Z',
     ...overrides,
   }
 }
 
+function createRecordsResponse(items = createRecentStatsRecords()) {
+  return {
+    data: {
+      items,
+      page: 1,
+      size: 12,
+      totalElements: items.length,
+      totalPages: 1,
+      hasNext: false,
+      hasPrevious: false,
+    },
+  }
+}
+
+function createRecentStatsRecords() {
+  return Array.from({ length: 12 }, (_, index) => createRecentRecord({
+    id: index + 1,
+    timeMs: 8000 + (index * 1000),
+    effectiveTimeMs: 8000 + (index * 1000),
+    createdAt: `2026-04-22T20:${String(59 - index).padStart(2, '0')}:00.000Z`,
+  }))
+}
+
+function createStoppedTimer(overrides = {}) {
+  return {
+    status: 'stopped',
+    finalTime: 1235,
+    formattedTime: '01.235',
+    inputMethod: 'KEYBOARD',
+    handlePointerDown: vi.fn(),
+    handlePointerUp: vi.fn(),
+    handlePointerCancel: vi.fn(),
+    resetTimer: vi.fn(),
+    restoreStoppedSolve: vi.fn(),
+    ...overrides,
+  }
+}
+
+function createIdleTimer(overrides = {}) {
+  return createStoppedTimer({
+    status: 'idle',
+    finalTime: null,
+    formattedTime: '00.000',
+    inputMethod: null,
+    ...overrides,
+  })
+}
+
+function createPendingSnapshot(overrides = {}) {
+  return {
+    schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+    userId: USER_ID,
+    eventType: 'WCA_333',
+    timeMs: 1235,
+    penalty: 'NONE',
+    scramble: "R U R' U'",
+    inputMethod: 'KEYBOARD',
+    clientSubmissionId: CLIENT_SUBMISSION_ID,
+    savedAt: '2026-08-10T13:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function createCurrentPendingSnapshotExpectation() {
+  return {
+    ...createPendingSnapshot(),
+    savedAt: expect.any(String),
+  }
+}
+
 describe('TimerPage', () => {
+  let timerState
+
   beforeEach(() => {
     vi.clearAllMocks()
+    window.sessionStorage.clear()
     vi.stubGlobal('confirm', vi.fn(() => true))
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn(() => CLIENT_SUBMISSION_ID),
+    })
 
+    timerState = createStoppedTimer()
+    vi.mocked(useCubeTimer).mockImplementation(() => timerState)
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: true,
-    })
-    vi.mocked(useCubeTimer).mockReturnValue({
-      status: 'stopped',
-      finalTime: 8123,
-      formattedTime: '08.123',
-      handlePointerDown: vi.fn(),
-      handlePointerUp: vi.fn(),
-      handlePointerCancel: vi.fn(),
-      resetTimer: vi.fn(),
+      currentUser: { userId: USER_ID },
     })
     vi.mocked(getGuestTimerRecords).mockReturnValue([])
     vi.mocked(getScramble).mockResolvedValue({
@@ -88,47 +184,18 @@ describe('TimerPage', () => {
     })
     vi.mocked(saveRecord).mockResolvedValue({
       message: '기록이 저장되었습니다.',
-      data: {
-        id: 101,
-      },
+      data: createCanonicalRecord(),
     })
-    vi.mocked(getMyRecords).mockResolvedValue({
-      data: {
-        items: [
-          createRecentRecord({ id: 1, timeMs: 8000, effectiveTimeMs: 8000, createdAt: '2026-04-22T20:00:00' }),
-          createRecentRecord({ id: 2, timeMs: 9000, effectiveTimeMs: 9000, createdAt: '2026-04-22T19:59:00' }),
-          createRecentRecord({ id: 3, timeMs: 10000, effectiveTimeMs: 10000, createdAt: '2026-04-22T19:58:00' }),
-          createRecentRecord({ id: 4, timeMs: 11000, effectiveTimeMs: 11000, createdAt: '2026-04-22T19:57:00' }),
-          createRecentRecord({ id: 5, timeMs: 12000, effectiveTimeMs: 12000, createdAt: '2026-04-22T19:56:00' }),
-          createRecentRecord({ id: 6, timeMs: 13000, effectiveTimeMs: 13000, createdAt: '2026-04-22T19:55:00' }),
-          createRecentRecord({ id: 7, timeMs: 14000, effectiveTimeMs: 14000, createdAt: '2026-04-22T19:54:00' }),
-          createRecentRecord({ id: 8, timeMs: 15000, effectiveTimeMs: 15000, createdAt: '2026-04-22T19:53:00' }),
-          createRecentRecord({ id: 9, timeMs: 16000, effectiveTimeMs: 16000, createdAt: '2026-04-22T19:52:00' }),
-          createRecentRecord({ id: 10, timeMs: 17000, effectiveTimeMs: 17000, createdAt: '2026-04-22T19:51:00' }),
-          createRecentRecord({ id: 11, timeMs: 18000, effectiveTimeMs: 18000, createdAt: '2026-04-22T19:50:00' }),
-          createRecentRecord({ id: 12, timeMs: 19000, effectiveTimeMs: 19000, createdAt: '2026-04-22T19:49:00' }),
-        ],
-        page: 1,
-        size: 100,
-        totalElements: 12,
-        totalPages: 1,
-        hasNext: false,
-        hasPrevious: false,
-      },
-    })
+    vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse())
   })
 
-  it('should_render_scramble_visual_when_supported_scramble_is_loaded', async () => {
-    render(<TimerPage />)
-
-    const scrambleVisual = await screen.findByRole('img', { name: '현재 스크램블 시각화' })
-
-    expect(scrambleVisual).toBeInTheDocument()
-    expect(scrambleVisual).toHaveAttribute('src', expect.stringContaining('alg=R+U+R%27+U%27'))
-    expect(scrambleVisual).toHaveAttribute('src', expect.stringContaining('sch=wrgyob'))
+  afterEach(() => {
+    clearPendingTimerSolve(USER_ID)
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
-  it('should_format_timer_helper_values', () => {
+  it('should_keep_helper_formatting_and_use_server_effective_time', () => {
     expect(getTimerMessage('idle', false, false)).toBe('이 종목은 아직 구현되지 않았습니다.')
     expect(getTimerMessage('idle', true, false)).toBe('스크램블을 불러와야 타이머를 시작할 수 있습니다.')
     expect(getTimerMessage('holding', true, true)).toBe('계속 누르고 있으면 준비됩니다.')
@@ -144,127 +211,258 @@ describe('TimerPage', () => {
     expect(getPenaltyLabel('PLUS_TWO')).toBe('+2')
     expect(getPenaltyLabel('DNF')).toBe('DNF')
     expect(getPenaltyLabel('NONE')).toBe('기본')
-    expect(getDisplayTime({ penalty: 'DNF', timeMs: 8000 })).toBe('DNF')
-    expect(getDisplayTime({ penalty: 'NONE', effectiveTimeMs: 8123, timeMs: 8123 })).toBe('08.123')
-    expect(getDisplayTime({ penalty: 'NONE', timeMs: 8456 })).toBe('08.456')
-    expect(applyPenaltyUpdateToSavedRecord(
-      createRecentRecord({ id: 1, effectiveTimeMs: 8000 }),
-      1,
-      { penalty: 'PLUS_TWO', timeMs: 8000, effectiveTimeMs: 10000 },
-    )).toMatchObject({
-      id: 1,
-      penalty: 'PLUS_TWO',
-      effectiveTimeMs: 10000,
-    })
-    expect(applyPenaltyUpdateToSavedRecord(
-      createRecentRecord({ id: 1, effectiveTimeMs: 8000 }),
-      2,
-      { penalty: 'PLUS_TWO', timeMs: 8000, effectiveTimeMs: 10000 },
-    )).toMatchObject({
-      id: 1,
-      penalty: 'NONE',
-      effectiveTimeMs: 8000,
-    })
-    expect(createSavedRecord({
-      id: 'guest-1',
-      eventType: 'WCA_333',
-      timeMs: 8000,
-      penalty: 'PLUS_TWO',
-      scramble: "R U R'",
-      createdAt: '2026-04-22T20:00:00',
-    })).toEqual({
-      id: 'guest-1',
-      eventType: 'WCA_333',
-      timeMs: 8000,
-      effectiveTimeMs: 10000,
-      penalty: 'PLUS_TWO',
-      scramble: "R U R'",
-      createdAt: '2026-04-22T20:00:00',
-    })
-    expect(createSavedRecord({
-      id: 'guest-2',
-      eventType: 'WCA_333',
-      timeMs: 9000,
-      penalty: 'DNF',
-      scramble: 'F R U',
-    })).toMatchObject({
-      id: 'guest-2',
-      effectiveTimeMs: null,
-      penalty: 'DNF',
-    })
+    expect(getDisplayTime(createCanonicalRecord({ penalty: 'DNF', effectiveTimeMs: null }))).toBe('DNF')
+    expect(getDisplayTime(createCanonicalRecord({ penalty: 'PLUS_TWO', effectiveTimeMs: 3235 }))).toBe('03.235')
   })
 
-  it('should_fallback_to_text_only_when_scramble_visual_fails_to_load', async () => {
-    vi.mocked(useCubeTimer).mockReturnValue({
-      status: 'idle',
-      finalTime: null,
-      formattedTime: '00.000',
-      handlePointerDown: vi.fn(),
-      handlePointerUp: vi.fn(),
-      handlePointerCancel: vi.fn(),
-      resetTimer: vi.fn(),
-    })
+  it('should_render_the_supported_scramble_visual_with_its_expected_parameters', async () => {
+    timerState = createIdleTimer()
 
     render(<TimerPage />)
 
     const scrambleVisual = await screen.findByRole('img', { name: '현재 스크램블 시각화' })
-    fireEvent.error(scrambleVisual)
 
-    expect(await screen.findByText('스크램블 이미지를 불러오지 못해 텍스트만 표시합니다.')).toBeInTheDocument()
+    expect(scrambleVisual).toHaveAttribute('src', expect.stringContaining('alg=R+U+R%27+U%27'))
+    expect(scrambleVisual).toHaveAttribute('src', expect.stringContaining('sch=wrgyob'))
   })
 
-  it('should_render_ao5_and_ao12_from_recent_records', async () => {
+  it('should_submit_the_canonical_stopped_snapshot_with_keyboard_provenance_and_filtered_history_query', async () => {
     render(<TimerPage />)
 
-    expect(await screen.findByText('10.000')).toBeInTheDocument()
-    expect(screen.getByText('13.500')).toBeInTheDocument()
-    expect(getMyRecords).toHaveBeenCalledWith({ page: 1, size: 100 })
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledWith({
+        eventType: 'WCA_333',
+        timeMs: 1235,
+        penalty: 'NONE',
+        scramble: "R U R' U'",
+        inputMethod: 'KEYBOARD',
+        clientSubmissionId: CLIENT_SUBMISSION_ID,
+      })
+    })
+
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1)
+    expect(getMyRecords).toHaveBeenCalledWith({
+      eventType: 'WCA_333',
+      page: 1,
+      size: 12,
+    })
+    expect(await screen.findByText('01.235')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(timerState.resetTimer).toHaveBeenCalled()
+      expect(getScramble).toHaveBeenCalledTimes(2)
+    })
   })
 
-  it('should_update_recent_record_penalty_when_penalty_update_succeeds', async () => {
+  it('should_use_the_server_canonical_record_and_deduplicate_a_replayed_record_by_id', () => {
+    const existing = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T12:00:00.000Z' })
+    const replayed = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T13:00:00.000Z' })
+
+    expect(upsertRecentSavedRecord([existing], replayed)).toEqual([replayed])
+    expect(upsertRecentSavedRecord([
+      createCanonicalRecord({ id: 100, createdAt: '2026-08-10T13:00:00.000Z' }),
+      existing,
+    ], replayed).map((record) => record.id)).toEqual([101, 100])
+    expect(toRecordCreatePayload(createPendingSnapshot())).toEqual({
+      eventType: 'WCA_333',
+      timeMs: 1235,
+      penalty: 'NONE',
+      scramble: "R U R' U'",
+      inputMethod: 'KEYBOARD',
+      clientSubmissionId: CLIENT_SUBMISSION_ID,
+    })
+  })
+
+  it('should_keep_the_same_pending_payload_and_uuid_when_the_first_save_fails', async () => {
+    vi.mocked(saveRecord)
+      .mockRejectedValueOnce(new Error('기록 저장 실패'))
+      .mockResolvedValueOnce({
+        message: '기록이 저장되었습니다.',
+        data: createCanonicalRecord(),
+      })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('기록 저장 실패')).toBeInTheDocument()
+    const firstPayload = saveRecord.mock.calls[0][0]
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(2)
+    })
+
+    expect(saveRecord.mock.calls[1][0]).toEqual(firstPayload)
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1)
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+  })
+
+  it('should_recover_a_response_lost_pending_solve_without_auto_post_and_replay_without_duplicate_ui_record', async () => {
+    vi.mocked(saveRecord).mockRejectedValueOnce(new Error('응답을 받지 못했습니다.'))
+    const firstRender = render(<TimerPage />)
+
+    expect(await screen.findByText('응답을 받지 못했습니다.')).toBeInTheDocument()
+    const originalPayload = saveRecord.mock.calls[0][0]
+    firstRender.unmount()
+
+    const restoreStoppedSolve = vi.fn()
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+      restoreStoppedSolve,
+    })
+    vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse([createCanonicalRecord()]))
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord(),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('저장하지 못한 기록을 복구했습니다. 저장 재시도 또는 버리기를 선택해주세요.')).toBeInTheDocument()
+    expect(saveRecord).toHaveBeenCalledTimes(1)
+    expect(restoreStoppedSolve).toHaveBeenCalledWith(expect.objectContaining({
+      timeMs: 1235,
+      clientSubmissionId: CLIENT_SUBMISSION_ID,
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(2)
+    })
+
+    expect(saveRecord.mock.calls[1][0]).toEqual(originalPayload)
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+    expect(screen.getAllByRole('button', { name: '삭제' })).toHaveLength(1)
+  })
+
+  it('should_keep_the_pending_snapshot_and_offer_discard_when_server_returns_conflict', async () => {
+    vi.mocked(saveRecord).mockRejectedValue(Object.assign(
+      new Error('clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.'),
+      { status: 409 },
+    ))
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('clientSubmissionId가 다른 기록 요청에 이미 사용되었습니다.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '저장 재시도' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '기록 버리기' })).toBeInTheDocument()
+    expect(screen.getByLabelText('종목')).toBeDisabled()
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1)
+  })
+
+  it('should_allow_the_user_to_discard_a_recovered_pending_solve_without_auto_submit', async () => {
+    savePendingTimerSolve(createPendingSnapshot())
+    const restoreStoppedSolve = vi.fn()
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+      restoreStoppedSolve,
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByRole('button', { name: '기록 버리기' })).toBeInTheDocument()
+    expect(saveRecord).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: '기록 버리기' }))
+
+    await waitFor(() => {
+      expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+    })
+    expect(saveRecord).not.toHaveBeenCalled()
+  })
+
+  it('should_offer_discard_without_retrying_a_corrupt_pending_snapshot', async () => {
+    window.sessionStorage.setItem('cubing-hub.timer.pending.v1:1', '{invalid-json')
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('저장 대기 기록을 복구할 수 없습니다. 기록을 버린 뒤 새로 측정해주세요.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '기록 버리기' })).toBeInTheDocument()
+    expect(screen.getByLabelText('종목')).toBeDisabled()
+    expect(saveRecord).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: '기록 버리기' }))
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem('cubing-hub.timer.pending.v1:1')).toBeNull()
+    })
+    expect(screen.getByLabelText('종목')).not.toBeDisabled()
+    expect(saveRecord).not.toHaveBeenCalled()
+  })
+
+  it('should_not_read_or_retry_another_accounts_pending_solve', async () => {
+    savePendingTimerSolve(createPendingSnapshot())
+    const restoreStoppedSolve = vi.fn()
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+      restoreStoppedSolve,
+    })
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      currentUser: { userId: 2 },
+    })
+
+    render(<TimerPage />)
+
+    await screen.findByText("R U R' U'")
+    expect(restoreStoppedSolve).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createPendingSnapshot())
+  })
+
+  it('should_save_guest_record_with_the_same_canonical_time_and_touch_provenance', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: false,
+      currentUser: null,
+    })
+    timerState = createStoppedTimer({ inputMethod: 'TOUCH' })
+    vi.mocked(saveGuestTimerRecord).mockReturnValue(createRecentRecord({
+      id: 'guest-1',
+      timeMs: 1235,
+      effectiveTimeMs: 1235,
+      inputMethod: 'TOUCH',
+    }))
+
+    render(<TimerPage />)
+
+    await waitFor(() => {
+      expect(saveGuestTimerRecord).toHaveBeenCalledWith({
+        eventType: 'WCA_333',
+        timeMs: 1235,
+        penalty: 'NONE',
+        scramble: "R U R' U'",
+        inputMethod: 'TOUCH',
+      })
+    })
+    expect(saveRecord).not.toHaveBeenCalled()
+  })
+
+  it('should_keep_penalty_and_delete_actions_working_with_server_canonical_records', async () => {
     vi.mocked(updateRecordPenalty).mockResolvedValue({
       message: '기록 페널티가 수정되었습니다.',
-      data: {
-        id: 101,
-        timeMs: 8123,
-        effectiveTimeMs: 10123,
+      data: createCanonicalRecord({
         penalty: 'PLUS_TWO',
-      },
+        effectiveTimeMs: 3235,
+      }),
     })
-
-    render(<TimerPage />)
-
-    await waitFor(() => {
-      expect(saveRecord).toHaveBeenCalled()
-    })
-
-    fireEvent.click(await screen.findByRole('button', { name: '+2' }))
-
-    await waitFor(() => {
-      expect(updateRecordPenalty).toHaveBeenCalledWith(101, { penalty: 'PLUS_TWO' })
-    })
-
-    expect(await screen.findByText('10.123')).toBeInTheDocument()
-    expect(toast.success).toHaveBeenCalledWith('기록 페널티가 수정되었습니다.')
-  })
-
-  it('should_show_error_message_when_penalty_update_fails', async () => {
-    vi.mocked(updateRecordPenalty).mockRejectedValue(new Error('기록 수정 실패'))
-
-    render(<TimerPage />)
-
-    await waitFor(() => {
-      expect(saveRecord).toHaveBeenCalled()
-    })
-
-    fireEvent.click(await screen.findByRole('button', { name: 'DNF' }))
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('기록 수정 실패')
-    })
-  })
-
-  it('should_delete_recent_record_when_delete_succeeds', async () => {
     vi.mocked(deleteRecord).mockResolvedValue({
       message: '기록이 삭제되었습니다.',
       data: null,
@@ -275,18 +473,22 @@ describe('TimerPage', () => {
     await waitFor(() => {
       expect(saveRecord).toHaveBeenCalled()
     })
+    fireEvent.click(screen.getByRole('button', { name: '+2' }))
 
-    fireEvent.click(await screen.findByRole('button', { name: '삭제' }))
+    await waitFor(() => {
+      expect(updateRecordPenalty).toHaveBeenCalledWith(101, { penalty: 'PLUS_TWO' })
+    })
+    expect(await screen.findByText('03.235')).toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }))
     await waitFor(() => {
       expect(deleteRecord).toHaveBeenCalledWith(101)
     })
-
-    expect(toast.success).toHaveBeenCalledWith('기록이 삭제되었습니다.')
     expect(screen.getByText('현재 세션에서 저장된 기록이 아직 없습니다.')).toBeInTheDocument()
   })
 
-  it('should_show_error_message_when_delete_fails', async () => {
+  it('should_keep_the_recent_record_when_penalty_or_delete_requests_fail', async () => {
+    vi.mocked(updateRecordPenalty).mockRejectedValue(new Error('기록 수정 실패'))
     vi.mocked(deleteRecord).mockRejectedValue(new Error('기록 삭제 실패'))
 
     render(<TimerPage />)
@@ -295,14 +497,21 @@ describe('TimerPage', () => {
       expect(saveRecord).toHaveBeenCalled()
     })
 
-    fireEvent.click(await screen.findByRole('button', { name: '삭제' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DNF' }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('기록 수정 실패')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('기록 삭제 실패')
     })
+    expect(screen.getAllByText('01.235')).not.toHaveLength(0)
   })
 
-  it('should_not_delete_recent_record_when_delete_confirmation_is_cancelled', async () => {
+  it('should_not_delete_a_recent_record_when_the_confirmation_is_cancelled', async () => {
     vi.stubGlobal('confirm', vi.fn(() => false))
 
     render(<TimerPage />)
@@ -311,51 +520,17 @@ describe('TimerPage', () => {
       expect(saveRecord).toHaveBeenCalled()
     })
 
-    fireEvent.click(await screen.findByRole('button', { name: '삭제' }))
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }))
 
     expect(deleteRecord).not.toHaveBeenCalled()
   })
 
-  it('should_save_guest_record_to_local_storage_when_user_is_not_authenticated', async () => {
+  it('should_keep_guest_penalty_and_delete_actions_on_the_existing_local_storage_path', async () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: false,
+      currentUser: null,
     })
-    vi.mocked(saveGuestTimerRecord).mockReturnValue(
-      createRecentRecord({
-        id: 'guest-1',
-        scramble: "R U R' U'",
-      }),
-    )
-
-    render(<TimerPage />)
-
-    await waitFor(() => {
-      expect(saveGuestTimerRecord).toHaveBeenCalledWith({
-        key: "WCA_333:8123:R U R' U'",
-        eventType: 'WCA_333',
-        timeMs: 8123,
-        penalty: 'NONE',
-        scramble: "R U R' U'",
-      })
-    })
-
-    expect(saveRecord).not.toHaveBeenCalled()
-    expect(toast.success).toHaveBeenCalledWith('게스트 기록이 저장되었습니다.')
-  })
-
-  it('should_update_guest_record_penalty_and_delete_guest_record_when_user_is_not_authenticated', async () => {
-    vi.mocked(useAuth).mockReturnValue({
-      isAuthenticated: false,
-    })
-    vi.mocked(useCubeTimer).mockReturnValue({
-      status: 'idle',
-      finalTime: null,
-      formattedTime: '00.000',
-      handlePointerDown: vi.fn(),
-      handlePointerUp: vi.fn(),
-      handlePointerCancel: vi.fn(),
-      resetTimer: vi.fn(),
-    })
+    timerState = createIdleTimer()
     vi.mocked(getGuestTimerRecords).mockReturnValue([
       createRecentRecord({
         id: 'guest-1',
@@ -379,10 +554,40 @@ describe('TimerPage', () => {
     expect(toast.success).toHaveBeenCalledWith('게스트 기록이 삭제되었습니다.')
   })
 
-  it('should_render_unsupported_event_messages_when_selected_event_is_not_supported', async () => {
+  it('should_render_ao5_and_ao12_from_the_server_filtered_recent_records', async () => {
     render(<TimerPage />)
 
-    expect(await screen.findByText("R U R' U'")).toBeInTheDocument()
+    expect(await screen.findByText('10.000')).toBeInTheDocument()
+    expect(screen.getByText('13.500')).toBeInTheDocument()
+    expect(getMyRecords).toHaveBeenCalledWith({ eventType: 'WCA_333', page: 1, size: 12 })
+  })
+
+  it('should_fallback_to_text_only_when_scramble_visual_fails_without_a_reset_race', async () => {
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+    })
+
+    render(<TimerPage />)
+
+    const scrambleVisual = await screen.findByRole('img', { name: '현재 스크램블 시각화' })
+    fireEvent.error(scrambleVisual)
+
+    expect(screen.getByText('스크램블 이미지를 불러오지 못해 텍스트만 표시합니다.')).toBeInTheDocument()
+  })
+
+  it('should_render_unsupported_event_message_without_requesting_an_unsupported_scramble', async () => {
+    timerState = createStoppedTimer({
+      status: 'idle',
+      finalTime: null,
+      formattedTime: '00.000',
+      inputMethod: null,
+    })
+
+    render(<TimerPage />)
+    await screen.findByText("R U R' U'")
 
     fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
 
@@ -390,103 +595,49 @@ describe('TimerPage', () => {
     expect(screen.getByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')).toBeInTheDocument()
   })
 
-  it('should_show_scramble_and_recent_stats_errors_when_related_requests_fail', async () => {
+  it('should_render_scramble_and_recent_history_errors_without_starting_the_timer', async () => {
+    timerState = createIdleTimer()
     vi.mocked(getScramble).mockRejectedValueOnce(new Error('스크램블 조회 실패'))
     vi.mocked(getMyRecords).mockRejectedValueOnce(new Error('최근 기록 조회 실패'))
-    vi.mocked(useCubeTimer).mockReturnValue({
-      status: 'idle',
-      finalTime: null,
-      formattedTime: '00.000',
-      handlePointerDown: vi.fn(),
-      handlePointerUp: vi.fn(),
-      handlePointerCancel: vi.fn(),
-      resetTimer: vi.fn(),
-    })
 
     render(<TimerPage />)
 
     expect(await screen.findByText('스크램블 조회 실패')).toBeInTheDocument()
     expect(await screen.findByText('최근 기록 조회 실패')).toBeInTheDocument()
+    expect(saveRecord).not.toHaveBeenCalled()
   })
 
-  it('should_show_empty_authenticated_stats_message_when_no_saved_records_exist', async () => {
-    vi.mocked(useCubeTimer).mockReturnValue({
-      status: 'idle',
-      finalTime: null,
-      formattedTime: '00.000',
-      handlePointerDown: vi.fn(),
-      handlePointerUp: vi.fn(),
-      handlePointerCancel: vi.fn(),
-      resetTimer: vi.fn(),
-    })
-    vi.mocked(getMyRecords).mockResolvedValue({
-      data: {
-        items: [],
-        page: 1,
-        size: 100,
-        totalElements: 0,
-        totalPages: 0,
-        hasNext: false,
-        hasPrevious: false,
-      },
-    })
+  it('should_render_the_authenticated_empty_average_message_when_the_filtered_history_is_empty', async () => {
+    timerState = createIdleTimer()
+    vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse([]))
 
     render(<TimerPage />)
 
     expect(await screen.findByText('아직 Ao를 계산할 저장 기록이 없습니다.')).toBeInTheDocument()
   })
 
-  it('should_prevent_default_when_context_menu_is_opened_on_timer_surface', async () => {
+  it('should_prevent_the_context_menu_on_the_timer_surface', async () => {
+    timerState = createIdleTimer()
+
     render(<TimerPage />)
 
-    const timerSurface = await screen.findByText('08.123')
+    const timerValue = await screen.findByText('00.000')
     const contextMenuEvent = new MouseEvent('contextmenu', {
       bubbles: true,
       cancelable: true,
     })
     const preventDefaultSpy = vi.spyOn(contextMenuEvent, 'preventDefault')
 
-    fireEvent(timerSurface.closest('.timer-touch-surface'), contextMenuEvent)
+    fireEvent(timerValue.closest('.timer-touch-surface'), contextMenuEvent)
 
     expect(preventDefaultSpy).toHaveBeenCalled()
   })
 
-  it('should_retry_record_save_when_auto_save_fails', async () => {
-    vi.mocked(saveRecord)
-      .mockRejectedValueOnce(new Error('기록 저장 실패'))
-      .mockResolvedValueOnce({
-        message: '기록이 저장되었습니다.',
-        data: {
-          id: 101,
-        },
-      })
-
-    render(<TimerPage />)
-
-    expect(await screen.findByText('기록 저장 실패')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
-
-    await waitFor(() => {
-      expect(saveRecord).toHaveBeenCalledTimes(2)
-    })
-
-    expect(toast.success).toHaveBeenCalledWith('기록이 저장되었습니다.')
-  })
-
-  it('should_create_recent_saved_record_with_fallback_id_when_save_response_has_no_id', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(24680)
-    vi.mocked(saveRecord).mockResolvedValue({
-      message: '기록이 저장되었습니다.',
-      data: null,
-    })
-
-    render(<TimerPage />)
-
-    expect(await screen.findByText('08.123')).toBeInTheDocument()
-    await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith('기록이 저장되었습니다.')
-      expect(screen.getAllByRole('button', { name: '삭제' })).toHaveLength(1)
-    })
+  it('should_apply_a_penalty_update_only_to_the_matching_recent_record', () => {
+    expect(applyPenaltyUpdateToSavedRecord(
+      createRecentRecord({ id: 1 }),
+      1,
+      { penalty: 'PLUS_TWO', timeMs: 8000, effectiveTimeMs: 10000 },
+    )).toMatchObject({ penalty: 'PLUS_TWO', effectiveTimeMs: 10000 })
   })
 })

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -381,7 +381,7 @@ describe('TimerPage', () => {
     expect(saveRecord).not.toHaveBeenCalled()
   })
 
-  it('should_offer_discard_without_retrying_a_corrupt_pending_snapshot', async () => {
+  it('should_disable_timer_input_until_a_corrupt_pending_snapshot_is_discarded', async () => {
     window.sessionStorage.setItem('cubing-hub.timer.pending.v1:1', '{invalid-json')
     timerState = createStoppedTimer({
       status: 'idle',
@@ -396,6 +396,9 @@ describe('TimerPage', () => {
     expect(screen.getByRole('button', { name: '기록 버리기' })).toBeInTheDocument()
     expect(screen.getByLabelText('종목')).toBeDisabled()
     expect(saveRecord).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    })
 
     fireEvent.click(screen.getByRole('button', { name: '기록 버리기' }))
 
@@ -404,6 +407,9 @@ describe('TimerPage', () => {
     })
     expect(screen.getByLabelText('종목')).not.toBeDisabled()
     expect(saveRecord).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
+    })
   })
 
   it('should_not_read_or_retry_another_accounts_pending_solve', async () => {
@@ -454,6 +460,7 @@ describe('TimerPage', () => {
       })
     })
     expect(saveRecord).not.toHaveBeenCalled()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
   })
 
   it('should_keep_penalty_and_delete_actions_working_with_server_canonical_records', async () => {

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -246,7 +246,8 @@ describe('TimerPage', () => {
       page: 1,
       size: 12,
     })
-    expect(await screen.findByText('01.235')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: '01.235' })).toBeInTheDocument()
+    expect(await screen.findByText('01.235', { selector: '.timer-recent-time' })).toBeInTheDocument()
 
     await waitFor(() => {
       expect(timerState.resetTimer).toHaveBeenCalled()
@@ -591,7 +592,8 @@ describe('TimerPage', () => {
 
     fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
 
-    expect(await screen.findByText('이 종목은 아직 구현되지 않았습니다.')).toBeInTheDocument()
+    expect(await screen.findByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.timer-helper' })).toBeInTheDocument()
+    expect(screen.getByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.message.info' })).toBeInTheDocument()
     expect(screen.getByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')).toBeInTheDocument()
   })
 

--- a/frontend/src/utils/recordStats.test.js
+++ b/frontend/src/utils/recordStats.test.js
@@ -44,6 +44,18 @@ describe('recordStats', () => {
     expect(calculateAverageOf(records, 5)).toBe(12667)
   })
 
+  it('should_use_server_effective_plus_two_values_and_round_the_trimmed_average', () => {
+    const records = [
+      createRecord({ effectiveTimeMs: 10000 }),
+      createRecord({ penalty: 'PLUS_TWO', timeMs: 9001, effectiveTimeMs: 11001 }),
+      createRecord({ effectiveTimeMs: 12000 }),
+      createRecord({ effectiveTimeMs: 13001 }),
+      createRecord({ effectiveTimeMs: 14000 }),
+    ]
+
+    expect(calculateAverageOf(records, 5)).toBe(12001)
+  })
+
   it('should_return_dnf_when_two_or_more_dnfs_exist_in_recent_records', () => {
     const records = [
       createRecord({ effectiveTimeMs: 10000 }),


### PR DESCRIPTION
## Summary

- Practice Timer의 browser event 처리와 상태 전이를 분리했습니다.
- canonical stopped time, input provenance, Record Foundation API 소비를 연결했습니다.
- response loss/reload에서도 동일 solve를 안전하게 재시도하는 single pending recovery를 추가했습니다.

## Timer Core

- pure `timerMachine` reducer와 `useCubeTimer` orchestration으로 상태·clock·RAF 책임을 분리했습니다.
- keyboard, touch/pen adapter가 semantic press/release/cancel만 Core에 전달합니다.

## Canonical Time

- stop에서 `performance.now()` elapsed를 한 번 `Math.round()`한 integer millisecond로 확정합니다.
- stopped display, authenticated payload, pending snapshot, guest save가 그 값을 공유합니다.

## Input Provenance

- solve 시작 input에 따라 `KEYBOARD` 또는 `TOUCH`를 저장합니다.
- stop input은 provenance를 덮어쓰지 않으며 legacy/guest 값은 `UNKNOWN`으로 읽습니다.

## Idempotent Submission

- authenticated stopped solve에 browser-native UUID v4 `clientSubmissionId`를 한 번 생성합니다.
- retry는 immutable snapshot과 같은 identity/payload를 재사용하고, 409을 새 UUID로 우회하지 않습니다.
- create 성공 후 frontend는 추측한 객체 대신 server canonical Record response를 사용합니다.

## Pending Recovery

- `sessionStorage`에 userId-scoped single pending snapshot을 POST보다 먼저 보관합니다.
- reload recovery는 자동 submit하지 않고 Retry/Discard를 제공합니다.
- corrupt snapshot은 server에 제출하지 않으며 explicit discard만 제공합니다.

## Recent History

- Timer Ao 통계는 `eventType=WCA_333&page=1&size=12` server history를 사용합니다.
- canonical response는 server Record ID로 recent UI에 upsert/deduplicate합니다.

## Guest Compatibility

- 기존 guest localStorage key와 최대 보관 수를 유지했습니다.
- legacy guest record의 inputMethod 누락은 `UNKNOWN`으로 정상화합니다.

## Tests

- Timer state transition, canonicalization, adapter, provenance, pending storage/recovery/replay, history query, dedup, guest, penalty/delete, Ao fixture를 보강했습니다.
- local Node/npm 및 승인된 validation wrapper가 없어 local runtime test/build는 실행하지 않았습니다. PR Validate가 최종 검증 기준입니다.

## Flaky Test Stabilization

- `TimerPage` scramble visual fallback의 image error 뒤 reset effect race를 fetch 시작 경계로 이동해 제거했습니다.

## Out of Scope

- backend/Flyway/DB, CI workflow, deploy/runtime
- Stackmat, Smart Timer, Smart Cube, Session, Daily Challenge, Verified Record, Competition
- multi-solve offline queue, background sync, import/export

## Known Risks

- local frontend runtime을 실행하지 못했으므로 JSX/runtime integration은 PR Validate에서 확인해야 합니다.
- 오래된 browser에서 `crypto.randomUUID()`가 없으면 authenticated 저장은 error state로 남으며 fallback dependency를 추가하지 않았습니다.