### PR TITLE
fix: handle idempotent replay after penalty updates

### DIFF
--- a/docs/00-product/prd.md
+++ b/docs/00-product/prd.md
@@ -201,12 +201,12 @@ V2.1은 다음 기능을 구현하지 않고, 나중에 추가할 때 현재 Rec
 - versioned export에서 stable logical identity와 timestamp를 어떻게 표현할 것인가
 - legacy client transition 뒤 `clientSubmissionId`를 언제 required request field로 전환할 것인가
 
-## Pre-implementation Gate 결과
+## Implementation / Release Gate 상태
 
 1. 사용자 확인 기준 현재 `records`, `user_pbs` data가 없으므로 event distribution audit blocker를 제거했다.
 2. V2.1 Practice Timer·Scramble·Record·Ranking event를 WCA_333으로 확정했다.
 3. Input Method, idempotency, canonical create response와 pending recovery의 API·data·architecture 계약을 문서화했다.
 4. forward-only additive migration, old application compatibility와 실제 MySQL upgrade test 방식을 확정했다.
-5. application code, test와 migration을 변경하려면 별도 구현 승인과 branch 준비가 필요하다.
+5. Record Foundation과 Timer Foundation은 각각 별도 branch와 dev PR로 구현·통합됐다. dev → main 전에는 integrated Validate와 release smoke checklist를 다시 확인한다.
 
-제품·기술 결정 gate는 닫혔으며 실행 승인 전에는 application code와 migration을 변경하지 않는다.
+제품·기술 결정 gate는 닫혔다. 구현 뒤 발견되는 acceptance defect는 기존 제품 범위를 넓히지 않는 별도 corrective change로 해소한 뒤 release gate를 다시 판단한다.

--- a/docs/01-domain/solve-model.md
+++ b/docs/01-domain/solve-model.md
@@ -43,13 +43,16 @@ Keyboard, Touch, Manual, Stackmat, Smart Timer, Smart Cube는 Input Method 후�
 - time_ms: 0보다 큰 raw integer millisecond
 - penalty: NONE, PLUS_TWO, DNF
 - scramble: 비어 있지 않은 문자열 snapshot
+- input_method: UNKNOWN, KEYBOARD, TOUCH provenance. legacy null은 UNKNOWN으로 정규화
+- client_submission_id: optional UUID v4 retry identity
+- client_submission_payload_hash: 최초 normalized create payload의 internal SHA-256 fingerprint
 - created_at, updated_at: UTC instant 기반 persistence timestamp
 
-현재 entity에는 Input Method, submission identity, comment, device, video evidence, session id, challenge, verification, competition reference가 없다. `created_at`은 실제 solve 발생 시각으로 재정의하지 않는다.
+현재 entity에는 comment, device, video evidence, session id, challenge, verification, competition reference가 없다. `created_at`은 실제 solve 발생 시각으로 재정의하지 않는다.
 
 ## V2.1 Input Provenance
 
-V2.1은 Practice Record에 Input Method provenance를 추가하는 방향을 사용한다.
+V2.1은 Practice Record의 Input Method provenance를 보존한다.
 
 현재 값의 기준은 다음과 같다.
 
@@ -64,7 +67,7 @@ TOUCH
 - Stackmat, Smart Timer, Smart Cube 값을 DB ENUM에 미리 선등록하지 않는다.
 - Input Method는 Record 생성 뒤 변경하지 않는 provenance다.
 
-Java application enum은 `InputMethod`를 사용하고 DB는 `VARCHAR(32)` nullable column으로 확장한다. 새 Timer는 항상 현재 값을 쓰고, legacy null·미지정 request는 API에서 UNKNOWN으로 정규화한다. Input Method는 Record 생성 뒤 수정하지 않는다.
+Java application enum은 `InputMethod`를 사용하고 DB는 `VARCHAR(32)` nullable column에 저장한다. 새 Timer는 항상 현재 값을 쓰고, legacy null·미지정 request는 API에서 UNKNOWN으로 정규화한다. Input Method는 Record 생성 뒤 수정하지 않는다.
 
 알 수 없는 API enum 값은 UNKNOWN으로 조용히 바꾸지 않고 400으로 거절한다. Future 값은 reader가 먼저 이해하도록 배포한 뒤 writer에서 활성화한다. 정확한 column과 rollout은 [Data Dictionary](../04-data/data-dictionary.md)와 [Migration Policy](../04-data/migration-policy.md)를 따른다.
 
@@ -104,6 +107,8 @@ Record 저장, penalty 변경, 삭제로 최선 기록이 달라지면 해당 �
 `clientSubmissionId`는 authenticated Practice Record create command의 retry identity다. Record의 public ID나 정렬 기준이 아니며 사용자 범위에서만 유일하다. UUID 자체로 chronological ordering을 만들지 않는다.
 
 같은 identity의 payload 충돌 판정을 위해 최초 server-normalized logical payload의 fingerprint를 불변 보존한다. logical payload는 eventType, canonical timeMs, penalty, exact scramble, normalized Input Method로 구성한다. `created_at`과 이후 penalty PATCH 결과는 최초 create payload에 포함하지 않는다.
+
+같은 fingerprint replay는 duplicate를 만들지 않고 기존 Record의 현재 canonical 상태를 반환한다. 따라서 최초 create 뒤 penalty가 PATCH되면 replay response의 penalty와 effective time은 최초 pending snapshot과 달라질 수 있다. client는 event, raw time, scramble, Input Method 같은 create 불변값을 확인하되 mutable penalty와 effective time은 server result의 내부 일관성으로 검증한다.
 
 ## Event capability 경계
 

--- a/docs/03-architecture/backend-architecture.md
+++ b/docs/03-architecture/backend-architecture.md
@@ -40,7 +40,7 @@ related:
 
 ## V2.1 Timer / Record 목표 구조
 
-아래 Record Foundation backend 경계는 V3 migration, application service와 executable test에 반영됐다. Timer Core, stopped time canonicalization, frontend provenance wiring과 pending solve recovery는 다음 Timer Foundation slice의 책임이다.
+아래 Record Foundation backend 경계는 V3 migration, application service와 executable test에 반영됐다. Timer Core, stopped time canonicalization, frontend provenance wiring과 pending solve recovery도 Timer Foundation slice에서 이 backend contract를 소비하도록 구현됐다.
 
 ### Practice Record boundary
 
@@ -54,7 +54,7 @@ related:
 - user-scoped identity는 DB `UNIQUE(user_id, client_submission_id)`로 최종 보장한다. identity가 없는 legacy request는 기존 non-idempotent create로 처리한다.
 - server는 `v1`, eventType, canonical timeMs, penalty, exact scramble, normalized Input Method 순서로 각 UTF-8 byte length를 4-byte big-endian integer로 붙인 `v1` sequence를 만들고 SHA-256 fingerprint를 계산해 최초 create payload와 함께 불변 보존한다. JSON serialization 결과에는 의존하지 않는다.
 - 같은 user·identity·fingerprint는 기존 Record를 반환하고, fingerprint가 다르면 409 Conflict다. 현재 penalty가 이후 PATCH로 바뀌어도 최초 fingerprint 비교에는 영향을 주지 않는다.
-- 일반 replay는 Record create와 같은 201 Created, 같은 Location과 canonical body를 반환한다. 이렇게 해야 기존 client의 status contract를 바꾸지 않는다.
+- 일반 replay는 Record create와 같은 201 Created, 같은 Location과 현재 canonical Record body를 반환한다. 최초 create 뒤 penalty PATCH가 있으면 response의 penalty와 effective time은 최초 request와 달라질 수 있다. 이렇게 해야 기존 client의 status contract를 바꾸지 않는다.
 - pre-check replay는 repository mutation 전에 반환한다. Concurrent race에서는 Record insert를 flush해 unique 위반을 PB·Redis 계산보다 먼저 확정한다.
 - unique loser의 `DataIntegrityViolationException`은 이미 rollback-only인 transaction 안에서 처리하지 않는다. Non-transactional submission coordinator가 create transaction 실패를 받은 뒤 새 read transaction에서 winner를 조회하고 fingerprint를 비교한다.
 - replay와 unique loser는 PB 재계산과 Redis sync를 실행하지 않는다. Winner만 현재 PB·Redis 흐름을 한 번 수행한다.

--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -145,13 +145,12 @@ function createClientSubmissionId() {
   return clientSubmissionId
 }
 
-function isCanonicalRecord(record, snapshot) {
+export function isCanonicalRecord(record, snapshot) {
   if (
     !record
     || record.id == null
     || record.eventType !== snapshot.eventType
     || record.timeMs !== snapshot.timeMs
-    || record.penalty !== snapshot.penalty
     || record.scramble !== snapshot.scramble
     || record.inputMethod !== snapshot.inputMethod
     || !RECORD_PENALTIES.has(record.penalty)
@@ -164,9 +163,15 @@ function isCanonicalRecord(record, snapshot) {
     return false
   }
 
-  return record.penalty === 'DNF'
-    ? record.effectiveTimeMs == null
-    : Number.isSafeInteger(record.effectiveTimeMs)
+  if (record.penalty === 'NONE') {
+    return record.effectiveTimeMs === record.timeMs
+  }
+
+  if (record.penalty === 'PLUS_TWO') {
+    return record.effectiveTimeMs === record.timeMs + 2000
+  }
+
+  return record.effectiveTimeMs == null
 }
 
 function buildStoppedSolveSnapshot({ eventType, timeMs, scramble, inputMethod, userId }) {

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -22,6 +22,7 @@ import TimerPage, {
   getPenaltyLabel,
   getStatusLabel,
   getTimerMessage,
+  isCanonicalRecord,
   toRecordCreatePayload,
   upsertRecentSavedRecord,
 } from './TimerPage.jsx'
@@ -274,6 +275,31 @@ describe('TimerPage', () => {
     })
   })
 
+  it('should_accept_current_mutable_penalty_state_but_reject_inconsistent_canonical_records', () => {
+    const snapshot = createPendingSnapshot()
+
+    expect(isCanonicalRecord(createCanonicalRecord(), snapshot)).toBe(true)
+    expect(isCanonicalRecord(createCanonicalRecord({
+      penalty: 'PLUS_TWO',
+      effectiveTimeMs: 3235,
+    }), snapshot)).toBe(true)
+    expect(isCanonicalRecord(createCanonicalRecord({
+      penalty: 'DNF',
+      effectiveTimeMs: null,
+    }), snapshot)).toBe(true)
+
+    expect(isCanonicalRecord(createCanonicalRecord({ id: null }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ timeMs: 1236 }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ scramble: 'R U2' }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ eventType: 'WCA_222' }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ inputMethod: 'TOUCH' }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ penalty: 'NONE', effectiveTimeMs: 1236 }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ penalty: 'PLUS_TWO', effectiveTimeMs: 1235 }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ penalty: 'DNF', effectiveTimeMs: 3235 }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ penalty: 'UNKNOWN' }), snapshot)).toBe(false)
+    expect(isCanonicalRecord(createCanonicalRecord({ createdAt: 'not-a-date' }), snapshot)).toBe(false)
+  })
+
   it('should_keep_the_same_pending_payload_and_uuid_when_the_first_save_fails', async () => {
     vi.mocked(saveRecord)
       .mockRejectedValueOnce(new Error('기록 저장 실패'))
@@ -339,6 +365,43 @@ describe('TimerPage', () => {
     expect(saveRecord.mock.calls[1][0]).toEqual(originalPayload)
     expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
     expect(screen.getAllByRole('button', { name: '삭제' })).toHaveLength(1)
+  })
+
+  it('should_accept_a_plus_two_server_state_after_a_response_lost_replay_and_clear_the_pending_snapshot', async () => {
+    vi.mocked(saveRecord).mockRejectedValueOnce(new Error('응답을 받지 못했습니다.'))
+    const firstRender = render(<TimerPage />)
+
+    expect(await screen.findByText('응답을 받지 못했습니다.')).toBeInTheDocument()
+    const originalPayload = saveRecord.mock.calls[0][0]
+    firstRender.unmount()
+
+    const restoreStoppedSolve = vi.fn()
+    timerState = createIdleTimer({ restoreStoppedSolve })
+    vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse([
+      createCanonicalRecord({ penalty: 'PLUS_TWO', effectiveTimeMs: 3235 }),
+    ]))
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ penalty: 'PLUS_TWO', effectiveTimeMs: 3235 }),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByRole('button', { name: '저장 재시도' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(2)
+    })
+
+    expect(saveRecord.mock.calls[1][0]).toEqual(originalPayload)
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1)
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+    expect(await screen.findByText('03.235', { selector: '.timer-recent-time' })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: '삭제' })).toHaveLength(1)
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+    })
   })
 
   it('should_keep_the_pending_snapshot_and_offer_discard_when_server_returns_conflict', async () => {

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -319,7 +319,7 @@ snapshot은 age로 암호화한 뒤 local staging과 iCloud Drive project direct
 
 ## 첫 배포 검증
 
-1. Flyway history에 `V1`, `V2`가 성공 상태인지 확인한다.
+1. Flyway history에 `V1`, `V2`, `V3`가 성공 상태인지 확인한다.
 2. 회원, 기록, 게시글, 첨부 table이 빈 상태인지 확인한다.
 3. Redis key가 빈 상태인지 확인한다.
 4. 회원가입, 로그인, refresh, 기록 저장, 랭킹 반영을 확인한다.


### PR DESCRIPTION
## Release blocker

Idempotent create replay returned the existing Record's current canonical state after a penalty PATCH, but TimerPage rejected it because it compared the mutable penalty to the original pending snapshot. Pending recovery could therefore remain stuck.

## Root cause and contract clarification

- Create fingerprint remains the original immutable payload: event type, raw time, initial penalty, scramble, input method.
- A matching replay returns the existing Record's current canonical state.
- Penalty and effective time may differ after Record PATCH; immutable create fields must still match.

## Fix and regression coverage

- Accept server-current `NONE`, `PLUS_TWO`, or `DNF` state when its effective time is internally consistent.
- Continue rejecting invalid ID, createdAt, immutable field changes, unknown penalty, and inconsistent effective time.
- Cover PLUS_TWO response-lost replay, DNF validation, pending cleanup, UUID/payload reuse, and recent-record ID deduplication.

## Documentation drift cleanup

- Align V2.1 implementation/release gate, Record persistence/replay, backend architecture, and V3 Flyway runbook references.

## Scope and validation

- Frontend TimerPage/tests and specified V2.1 documents only.
- No backend, Flyway, workflow, deploy, or runtime changes.
- `git diff --check`, changed-path, docs frontmatter/H1, local-link, and secret-pattern static checks passed.
- Node/npm is not installed on the Mac mini by policy, so frontend test/lint/build will be verified by the PR Validate workflow.