### PR TITLE
fix: preserve pending scramble during recovery

### DIFF
--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -219,6 +219,8 @@ export default function TimerPage() {
   const recoveredPendingOwnerIdRef = useRef(null)
   const previousAuthenticatedUserIdRef = useRef(null)
   const authenticatedUserIdRef = useRef(authenticatedUserId)
+  const scrambleRequestIdRef = useRef(0)
+  const pendingRecoveryScrambleRef = useRef(null)
 
   const isSupported = isPracticeEventSupported(selectedEvent)
   const hasScramble = Boolean(scrambleData?.scramble)
@@ -292,6 +294,12 @@ export default function TimerPage() {
   }, [])
 
   const loadScramble = useCallback(async (eventType) => {
+    if (pendingRecoveryScrambleRef.current) {
+      return
+    }
+
+    const requestId = scrambleRequestIdRef.current + 1
+    scrambleRequestIdRef.current = requestId
     setIsLoadingScramble(true)
     setHasScrambleVisualError(false)
     setScrambleMessage(null)
@@ -299,16 +307,42 @@ export default function TimerPage() {
 
     try {
       const response = await getScramble(eventType)
-      setScrambleData(response.data)
+      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+        setScrambleData(response.data)
+      }
     } catch (error) {
-      setScrambleData(null)
-      setScrambleMessage({ type: 'error', text: error.message })
+      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+        setScrambleData(null)
+        setScrambleMessage({ type: 'error', text: error.message })
+      }
     } finally {
-      setIsLoadingScramble(false)
+      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+        setIsLoadingScramble(false)
+      }
     }
   }, [])
 
+  const protectRecoveredPendingScramble = useCallback((snapshot) => {
+    scrambleRequestIdRef.current += 1
+    pendingRecoveryScrambleRef.current = snapshot
+    setScrambleData({
+      eventType: snapshot.eventType,
+      scramble: snapshot.scramble,
+    })
+    setScrambleMessage(null)
+    setHasScrambleVisualError(false)
+    setIsLoadingScramble(false)
+  }, [])
+
+  const releaseRecoveredPendingScramble = useCallback(() => {
+    pendingRecoveryScrambleRef.current = null
+  }, [])
+
   useEffect(() => {
+    if (pendingRecoveryScrambleRef.current?.eventType === selectedEvent) {
+      return
+    }
+
     resetTimer()
     setSaveNotice(null)
     setSaveStatus('idle')
@@ -366,10 +400,16 @@ export default function TimerPage() {
 
     if (previousUserId !== authenticatedUserId) {
       recoveredPendingOwnerIdRef.current = null
+
+      if (pendingRecoveryScrambleRef.current) {
+        pendingRecoveryScrambleRef.current = null
+        scrambleRequestIdRef.current += 1
+        loadScramble(selectedEvent)
+      }
     }
 
     previousAuthenticatedUserIdRef.current = authenticatedUserId
-  }, [authenticatedUserId, resetTimer])
+  }, [authenticatedUserId, loadScramble, resetTimer, selectedEvent])
 
   useEffect(() => {
     if (!isAuthenticated || authenticatedUserId == null || recoveredPendingOwnerIdRef.current === authenticatedUserId) {
@@ -389,13 +429,14 @@ export default function TimerPage() {
     }
 
     completedStoppedSolveRef.current = false
+    protectRecoveredPendingScramble(snapshot)
     setSelectedEvent(snapshot.eventType)
     setStoppedSolveSnapshot(snapshot)
     setDiscardablePendingOwnerId(null)
     setSaveStatus('recovery')
     setSaveNotice('저장하지 못한 기록을 복구했습니다. 저장 재시도 또는 버리기를 선택해주세요.')
     restoreStoppedSolve(snapshot)
-  }, [authenticatedUserId, isAuthenticated, restoreStoppedSolve])
+  }, [authenticatedUserId, isAuthenticated, protectRecoveredPendingScramble, restoreStoppedSolve])
 
   const handleEventChange = (event) => {
     setSelectedEvent(event.target.value)
@@ -516,6 +557,7 @@ export default function TimerPage() {
         clearPendingTimerSolve(snapshot.userId)
         setRecentSavedRecords((current) => upsertRecentSavedRecord(current, serverRecord))
         setStoppedSolveSnapshot(null)
+        releaseRecoveredPendingScramble()
         completedStoppedSolveRef.current = true
         setSaveStatus('success')
         setSaveNotice(null)
@@ -540,7 +582,7 @@ export default function TimerPage() {
     } finally {
       activePersistKeyRef.current = null
     }
-  }, [isAuthenticated, loadGuestStatistics, loadRecentStatistics, loadScramble, resetTimer])
+  }, [isAuthenticated, loadGuestStatistics, loadRecentStatistics, loadScramble, releaseRecoveredPendingScramble, resetTimer])
 
   useEffect(() => {
     if (!stoppedSolveSnapshot || status !== 'stopped' || saveStatus !== 'idle') {
@@ -559,6 +601,7 @@ export default function TimerPage() {
 
     setStoppedSolveSnapshot(null)
     setDiscardablePendingOwnerId(null)
+    releaseRecoveredPendingScramble()
     setSaveStatus('idle')
     setSaveNotice(null)
     completedStoppedSolveRef.current = true

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'react-toastify'
 import { deleteRecord, getMyRecords, getScramble, saveRecord, updateRecordPenalty } from '../api.js'
@@ -150,6 +150,17 @@ function createPendingSnapshot(overrides = {}) {
     savedAt: '2026-08-10T13:00:00.000Z',
     ...overrides,
   }
+}
+
+function createDeferred() {
+  let resolve
+  let reject
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
 }
 
 function createCurrentPendingSnapshotExpectation() {
@@ -365,6 +376,86 @@ describe('TimerPage', () => {
     expect(saveRecord.mock.calls[1][0]).toEqual(originalPayload)
     expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
     expect(screen.getAllByRole('button', { name: '삭제' })).toHaveLength(1)
+  })
+
+  it('should_keep_the_recovered_pending_scramble_visible_when_an_earlier_fresh_request_resolves', async () => {
+    const pendingSnapshot = createPendingSnapshot({ scramble: 'PENDING SCRAMBLE' })
+    const initialScrambleRequest = createDeferred()
+
+    savePendingTimerSolve(pendingSnapshot)
+    timerState = createIdleTimer({ restoreStoppedSolve: vi.fn() })
+    vi.mocked(getScramble)
+      .mockReset()
+      .mockImplementationOnce(() => initialScrambleRequest.promise)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'NEXT SCRAMBLE',
+        },
+      })
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ scramble: 'PENDING SCRAMBLE' }),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByRole('button', { name: '저장 재시도' })).toBeInTheDocument()
+    expect(screen.getByText('PENDING SCRAMBLE')).toBeInTheDocument()
+    expect(saveRecord).not.toHaveBeenCalled()
+
+    await act(async () => {
+      initialScrambleRequest.resolve({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'FRESH SCRAMBLE',
+        },
+      })
+      await initialScrambleRequest.promise
+    })
+
+    expect(screen.getByText('PENDING SCRAMBLE')).toBeInTheDocument()
+    expect(screen.queryByText('FRESH SCRAMBLE')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledWith(expect.objectContaining({
+        clientSubmissionId: CLIENT_SUBMISSION_ID,
+        scramble: 'PENDING SCRAMBLE',
+      }))
+    })
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+    expect(await screen.findByText('NEXT SCRAMBLE')).toBeInTheDocument()
+  })
+
+  it('should_replace_a_recovered_scramble_with_a_fresh_scramble_after_the_account_changes', async () => {
+    const initialScrambleRequest = createDeferred()
+
+    savePendingTimerSolve(createPendingSnapshot({ scramble: 'ACCOUNT A PENDING SCRAMBLE' }))
+    timerState = createIdleTimer({ restoreStoppedSolve: vi.fn() })
+    vi.mocked(getScramble)
+      .mockReset()
+      .mockImplementationOnce(() => initialScrambleRequest.promise)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'ACCOUNT B FRESH SCRAMBLE',
+        },
+      })
+
+    const page = render(<TimerPage />)
+
+    expect(await screen.findByText('ACCOUNT A PENDING SCRAMBLE')).toBeInTheDocument()
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      currentUser: { userId: 2 },
+    })
+    page.rerender(<TimerPage />)
+
+    expect(await screen.findByText('ACCOUNT B FRESH SCRAMBLE')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
   })
 
   it('should_accept_a_plus_two_server_state_after_a_response_lost_replay_and_clear_the_pending_snapshot', async () => {


### PR DESCRIPTION
## Release blocker

Reloading an authenticated pending solve could start a fresh scramble request before recovery. Its late response could replace the scramble displayed in the recovery UI even though Retry still submitted the immutable pending snapshot scramble.

## Fix

- Restore the pending snapshot scramble as the recovery UI source.
- Invalidate an in-flight fresh scramble request when recovery begins.
- Apply fresh scramble responses only when they belong to the current request and no pending recovery lock exists.
- Release the lock only after Retry succeeds, the user Discards, or the authenticated account changes.

## Invariant

While the user resolves a valid pending solve:

```text
visible scramble
= pending snapshot scramble
= Retry payload scramble
```

## Tests

- Reproduce an unresolved initial fresh request followed by pending recovery.
- Confirm its late response cannot overwrite the pending scramble.
- Confirm Retry submits the pending scramble and then loads a new scramble.
- Confirm an account transition replaces the recovered scramble and cannot expose Account A pending state to Account B.
- Existing pending/replay, conflict, corrupt-pending, guest, and account-isolation tests remain in scope for Validate.

## Scope

Frontend TimerPage and its tests only.

No backend, Flyway, workflow, smoke environment, production Compose, runtime, or PR #15 changes.

## Validation

- `git diff --check` passed.
- Local Node/npm is unavailable on the Mac mini; GitHub Actions Frontend checks and Web ARM64 image validation are required before merge.
