### PR TITLE
chore: add isolated V2.1 smoke environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ frontend/coverage/
 .env
 .env.local
 homeserver/.env
+homeserver/.env.smoke
 homeserver/.deploy-state/
 homeserver/docker-compose.workbench.yml
 

--- a/docs/06-quality/quality-gates.md
+++ b/docs/06-quality/quality-gates.md
@@ -2,13 +2,14 @@
 doc_type: quality
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
 related:
   - .github/workflows/validate.yml
   - AGENTS.md
+  - homeserver/docs/release-smoke-runbook.md
 ---
 # Quality Gates
 
@@ -46,5 +47,7 @@ shell syntax, runtime config detection, deploy·backup mock tests, Node configur
 ## Release gate
 
 main push는 release validation을 시작한다. production deploy enable 상태에서는 GHCR publish와 Mac mini deploy로 이어질 수 있으므로 merge와 deploy는 별도 승인 대상이다.
+
+V2.1처럼 browser/device runtime path가 중요한 release는 automated Validate 이후 isolated release smoke를 수행한다. smoke는 최신 `dev` source를 production Dockerfile로 build하고 disposable MySQL·Redis에 Flyway를 적용하지만 production resource에 연결하지 않는다. exact 실행과 수동 checklist는 [Smoke Runbook](../../homeserver/docs/release-smoke-runbook.md)을 따른다.
 
 정확한 workflow step과 path 분류는 [validate.yml](../../.github/workflows/validate.yml)과 classifier script가 Source of Truth다.

--- a/docs/07-operations/environments.md
+++ b/docs/07-operations/environments.md
@@ -2,12 +2,13 @@
 doc_type: operation
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
 related:
   - docs/03-architecture/deployment-architecture.md
+  - homeserver/docs/release-smoke-runbook.md
 ---
 # Environments
 
@@ -16,6 +17,7 @@ related:
 | test | 자동 test | Testcontainers MySQL, test Redis, create-drop schema | application-test.yaml, CI |
 | local development | 기능 개발·benchmark | root Compose helper와 local profile | docker-compose.yml, application-local.yaml |
 | CI | validation·artifact build | GitHub-hosted Ubuntu·ARM64 runner | .github/workflows |
+| release smoke | main merge 전 browser/device 수동 smoke | 최신 `dev` source, disposable Docker MySQL·Redis·Mailpit volume/network | `homeserver/docker-compose.smoke.yml`, [Smoke Runbook](../../homeserver/docs/release-smoke-runbook.md) |
 | production | public service | Mac mini Docker Compose, MySQL·Redis·host images | homeserver config와 active runbook |
 
 ## Test
@@ -37,3 +39,7 @@ infra/docker/docker-compose.prod.yml은 latest tag, S3 환경변수, host 80·44
 ## Observed runtime fact
 
 현재 실행 중 container, image digest, health, backup 시각은 repository만으로 확인할 수 없다. 실제 상태 확인은 별도 read-only 운영 요청과 승인 경계를 따른다.
+
+## Release smoke
+
+release smoke는 production을 대체하거나 production resource를 재사용하는 개발환경이 아니다. `cubing-hub-smoke` Compose project가 source에서 production Dockerfile을 빌드하고 fresh data services와 loopback Web port를 사용한다. command-level 실행, disposable data removal, browser/device checklist와 Tailscale HTTPS의 별도 승인 경계는 [Smoke Runbook](../../homeserver/docs/release-smoke-runbook.md)이 Source of Truth다.

--- a/docs/07-operations/local-development.md
+++ b/docs/07-operations/local-development.md
@@ -2,12 +2,13 @@
 doc_type: operation
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
 related:
   - docs/07-operations/environments.md
+  - homeserver/docs/release-smoke-runbook.md
   - AGENTS.md
 ---
 # Local Development
@@ -27,6 +28,10 @@ version과 task는 repository configuration이 Source of Truth다.
 Mac mini host에는 Java나 Node.js를 새로 설치하거나 version을 바꾸지 않는다. 현재 repository에는 backend·frontend 전체 검증용 개발 container wrapper가 없으므로 이 host에서는 CI 결과를 전체 검증 기준으로 사용한다.
 
 root docker-compose.yml은 기존 local helper이며 fixed container name과 host port를 사용한다. 실행 전 다른 project·production resource와 겹치지 않는지 확인하고, 운영 .env·network·volume을 참조하지 않는다. 이 문서 작업에서는 실행하지 않았다.
+
+## Release smoke와 구분
+
+V2.1 release smoke는 local development helper가 아니라 최신 `dev` release candidate를 production Dockerfile 경로로 실행하는 별도 Compose project다. smoke stack은 production Compose·`.env`·network·volume을 참조하지 않으며, command와 manual browser/device 절차는 [Smoke Runbook](../../homeserver/docs/release-smoke-runbook.md)을 따른다.
 
 ## Secret
 

--- a/homeserver/.env.smoke.example
+++ b/homeserver/.env.smoke.example
@@ -1,0 +1,12 @@
+# Copy this file to homeserver/.env.smoke. These values are disposable smoke-only
+# credentials, not production secrets. Never source homeserver/.env here.
+SMOKE_DB_NAME=cubing_hub_smoke
+SMOKE_DB_USERNAME=cubing_hub_smoke
+SMOKE_DB_PASSWORD=replace-with-smoke-only-db-password
+SMOKE_MYSQL_ROOT_PASSWORD=replace-with-smoke-only-root-password
+SMOKE_JWT_SECRET=replace-with-smoke-only-jwt-secret-at-least-32-characters
+
+# The Web Dockerfile receives this build-time value. smoke.localhost resolves
+# to loopback in supported browsers and remains distinct from localhost guard.
+SMOKE_ORIGIN=http://smoke.localhost:18080
+SMOKE_REFRESH_COOKIE_SECURE=false

--- a/homeserver/docker-compose.smoke.yml
+++ b/homeserver/docker-compose.smoke.yml
@@ -1,0 +1,186 @@
+name: cubing-hub-smoke
+
+services:
+  api-build:
+    image: gradle:8.14.4-jdk17
+    working_dir: /workspace/backend
+    user: "${SMOKE_UID:-501}:${SMOKE_GID:-20}"
+    command:
+      - ./gradlew
+      - bootJar
+      - -x
+      - test
+      - -x
+      - asciidoctor
+      - --no-daemon
+    environment:
+      GRADLE_USER_HOME: /tmp/gradle
+    volumes:
+      - type: bind
+        source: ..
+        target: /workspace
+    tmpfs:
+      - /tmp/gradle:size=1g,mode=1777
+    networks:
+      - smoke-build
+    profiles:
+      - build
+
+  mysql:
+    image: mysql:8.0.46
+    environment:
+      MYSQL_DATABASE: ${SMOKE_DB_NAME:-cubing_hub_smoke}
+      MYSQL_USER: ${SMOKE_DB_USERNAME:-cubing_hub_smoke}
+      MYSQL_PASSWORD: ${SMOKE_DB_PASSWORD:?SMOKE_DB_PASSWORD must be set}
+      MYSQL_ROOT_PASSWORD: ${SMOKE_MYSQL_ROOT_PASSWORD:?SMOKE_MYSQL_ROOT_PASSWORD must be set}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_0900_ai_ci
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - mysqladmin ping -h 127.0.0.1 -u root --password="$${MYSQL_ROOT_PASSWORD}" --silent
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+    volumes:
+      - type: volume
+        source: smoke-mysql-data
+        target: /var/lib/mysql
+    networks:
+      - smoke-application
+
+  redis:
+    image: redis:7.2.14-alpine
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 10s
+    networks:
+      - smoke-application
+
+  mailpit:
+    image: axllent/mailpit:v1.27.7
+    networks:
+      - smoke-application
+
+  api:
+    build:
+      context: ..
+      dockerfile: homeserver/docker/backend.Dockerfile
+    init: true
+    read_only: true
+    pids_limit: 256
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:size=128m,mode=1777
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${SMOKE_DB_NAME:-cubing_hub_smoke}?sslMode=DISABLED&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+      DB_USERNAME: ${SMOKE_DB_USERNAME:-cubing_hub_smoke}
+      DB_PASSWORD: ${SMOKE_DB_PASSWORD:?SMOKE_DB_PASSWORD must be set}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      JWT_SECRET: ${SMOKE_JWT_SECRET:?SMOKE_JWT_SECRET must be set}
+      JWT_EXPIRATION: 1800000
+      JWT_REFRESH_EXPIRATION: 604800000
+      CORS_ALLOWED_ORIGINS: ${SMOKE_ORIGIN:-http://smoke.localhost:18080}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: validate
+      SPRING_FLYWAY_ENABLED: "true"
+      AUTH_REFRESH_COOKIE_SECURE: ${SMOKE_REFRESH_COOKIE_SECURE:-false}
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_AUTH: "false"
+      SMTP_STARTTLS_ENABLE: "false"
+      SMTP_FROM_ADDRESS: smoke@smoke.localhost
+      RANKING_REDIS_REBUILD_MODE: startup
+      MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health
+      MONITORING_PROMETHEUS_PERMIT_ALL: "false"
+      POST_IMAGES_LOCAL_ROOT_PATH: /data/post-images
+      POST_IMAGES_KEY_PREFIX: smoke/posts
+      POST_IMAGES_PUBLIC_BASE_URL: ${SMOKE_ORIGIN:-http://smoke.localhost:18080}/uploads
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget -qO- http://127.0.0.1:8080/actuator/health | grep -q '"status":"UP"'
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 45s
+    volumes:
+      - type: volume
+        source: smoke-post-images
+        target: /data/post-images
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - smoke-application
+
+  web:
+    build:
+      context: ..
+      dockerfile: homeserver/docker/frontend.Dockerfile
+      args:
+        VITE_API_BASE_URL: ${SMOKE_ORIGIN:-http://smoke.localhost:18080}
+    init: true
+    read_only: true
+    pids_limit: 100
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /var/cache/nginx:size=32m,mode=0755
+      - /var/run:size=4m,mode=0755
+      - /tmp:size=16m,mode=1777
+    ports:
+      - "127.0.0.1:18080:80"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget -qO- http://127.0.0.1/actuator/health | grep -q '"status":"UP"'
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 45s
+    volumes:
+      - type: bind
+        source: ./nginx/smoke.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+      - type: volume
+        source: smoke-post-images
+        target: /data/post-images
+        read_only: true
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - smoke-application
+      - smoke-ingress
+
+volumes:
+  smoke-mysql-data:
+  smoke-post-images:
+
+networks:
+  smoke-application:
+    internal: true
+  smoke-build:
+    internal: false
+  smoke-ingress:
+    internal: false

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -2,17 +2,20 @@
 doc_type: operation
 status: active
 created: 2026-06-19
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
 related:
   - docs/07-operations/deployment-runbook.md
+  - homeserver/docs/release-smoke-runbook.md
 ---
 
 # Mac mini 운영 Runbook
 
 > 중앙 문서 체계의 역할과 승인 경계는 [Deployment Runbook Gateway](../../docs/07-operations/deployment-runbook.md)에서 확인한다. 이 문서가 command-level 운영 절차의 Source of Truth다.
+
+> main merge 전 browser/device 검증은 production deployment 절차가 아니라 별도 [V2.1 Release Smoke Runbook](release-smoke-runbook.md)을 따른다. 해당 smoke stack은 production container, DB, Redis, volume, network, `.env`를 사용하지 않는다.
 
 ## 배포 전 확인
 

--- a/homeserver/docs/release-smoke-runbook.md
+++ b/homeserver/docs/release-smoke-runbook.md
@@ -1,0 +1,118 @@
+---
+doc_type: operation
+status: active
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - homeserver/docker-compose.smoke.yml
+  - homeserver/scripts/smoke-v2-1.sh
+  - docs/06-quality/quality-gates.md
+  - docs/07-operations/environments.md
+---
+# V2.1 Release Smoke Runbook
+
+## 목적과 절대 경계
+
+이 절차는 main merge 전에 최신 `dev` source를 production Dockerfile 경로로 build하여 실제 browser/device smoke를 수행한다. production deployment가 아니며 다음을 절대 사용하거나 변경하지 않는다.
+
+- production Compose, container, DB, Redis, volume, network, `.env`, Cloudflare Tunnel
+- `/Users/homeserver/Server/**` application data 또는 runtime config
+- production domain, GitHub variable/Environment, deploy workflow
+
+Compose project는 고정된 `cubing-hub-smoke`다. Web만 `127.0.0.1:18080`에 노출하며 MySQL, Redis, API, Mailpit은 host port를 노출하지 않는다. MySQL·post image volume은 project-scoped disposable data이며 Gradle cache는 one-shot builder의 tmpfs에만 둔다. Redis와 Mailpit data는 persistent volume을 사용하지 않는다.
+
+## 시작 전 확인
+
+repository checkout에서 release candidate의 exact branch/SHA와 clean working tree를 확인한다. smoke build는 Docker 내부 Gradle을 쓰며 host에 Java/Node를 설치하지 않는다. `api-build`는 Docker socket을 mount하지 않으므로 test container가 필요한 Gradle test와 Asciidoctor는 실행하지 않고 runtime JAR만 생성한다. full backend/frontend test는 CI Validate가 기준이다.
+
+운영 resource는 read-only inventory만 확인한다. Memory Pressure가 yellow/red, swap 증가, disk 부족, 운영 health 저하가 있으면 start하지 않는다.
+
+```bash
+memory_pressure
+vm_stat
+df -h
+docker system df
+docker ps
+docker stats --no-stream
+```
+
+## Smoke env 준비
+
+production `.env`를 복사하거나 source하지 않는다.
+
+```bash
+cp homeserver/.env.smoke.example homeserver/.env.smoke
+```
+
+copy 뒤 `replace-with-`로 시작하는 세 credential을 새로운 smoke-only 값으로 바꾼다. tracked example에는 actual secret을 두지 않으며, local `.env.smoke`를 공유하거나 production에 재사용하지 않는다. 기본 origin은 `http://smoke.localhost:18080`이며 supported browser의 loopback hostname을 사용한다.
+
+## Start, status, Flyway, logs
+
+`up`은 one-shot Gradle builder로 JAR를 만든 뒤 production API/Web Dockerfile을 build하고 `--wait`로 smoke services의 health를 기다린다.
+
+```bash
+homeserver/scripts/smoke-v2-1.sh up
+homeserver/scripts/smoke-v2-1.sh status
+homeserver/scripts/smoke-v2-1.sh flyway
+homeserver/scripts/smoke-v2-1.sh logs
+```
+
+정상 Flyway history에는 V1, V2, V3가 모두 `success`여야 한다. `up`은 default origin일 때 Web root와 same-origin `/actuator/health`를 loopback HTTP로 추가 확인한다. browser URL은 <http://smoke.localhost:18080>이다.
+
+## Stop과 full destroy
+
+테스트 뒤 일반 종료는 volume을 보존한다.
+
+```bash
+homeserver/scripts/smoke-v2-1.sh down
+```
+
+fresh database가 필요할 때만 아래 명령을 사용한다. 이는 `cubing-hub-smoke` project의 disposable volume과 application, ingress, one-shot builder network만 제거하며 production resource를 대상으로 하지 않는다.
+
+```bash
+homeserver/scripts/smoke-v2-1.sh destroy
+```
+
+## Browser manual smoke checklist
+
+### Auth와 Timer
+
+1. smoke account로 login하고 logout한다. 새 account가 필요하면 email verification request를 보내고, smoke-only Mailpit message는 host port를 열지 않고 Web container를 통해 확인한다.
+
+   ```bash
+   docker compose --project-name cubing-hub-smoke \
+     --env-file homeserver/.env.smoke \
+     --file homeserver/docker-compose.smoke.yml \
+     exec -T web wget -qO- http://mailpit:8025/api/v1/messages
+   ```
+
+2. Keyboard Space 300ms hold, ready, start, stop을 확인한다. stopped display time과 saved Record raw time이 같다.
+3. Touch/Pen solve도 확인하고 API/Record에서 `inputMethod=TOUCH`인지 확인한다. Keyboard solve는 `KEYBOARD`여야 한다.
+4. NONE, PLUS_TWO, DNF와 delete를 실행하고 PB, ranking, Ao5/Ao12 결과를 확인한다. Ao5는 5 solves, Ao12는 12 solves 후 확인한다.
+
+### Pending recovery와 idempotency
+
+1. authenticated solve의 save request를 Browser DevTools Network request blocking 또는 offline mode로 response-loss처럼 만든다. production network나 service를 끊지 않는다.
+2. reload 후 pending scramble, stopped time, Retry/Discard UI가 snapshot과 일치하는지 확인한다. 자동 POST는 발생하면 안 된다.
+3. Retry는 같은 UUID/payload를 사용하고 server canonical response 뒤 pending을 제거하며 recent Record가 ID 기준 한 건만 남아야 한다.
+4. response loss 뒤 다른 tab/session에서 penalty를 PLUS_TWO 또는 DNF로 바꾸고 Retry한다. current canonical penalty/effective time을 받아들이고 pending이 제거되어야 한다.
+5. DevTools Application에서 current owner의 `cubing-hub.timer.pending.v1:*` value를 invalid JSON으로 바꾼 뒤 reload한다. Timer input은 locked이고 explicit Discard 후에만 다시 활성화되어야 한다.
+6. account A pending을 만든 뒤 logout/login으로 account B에 전환한다. B는 A pending을 보거나 Retry할 수 없어야 한다.
+
+### Guest
+
+로그아웃 상태에서 guest solve, reload, PLUS_TWO, DNF, delete를 확인한다. legacy guest item에 `inputMethod`가 없을 때 UNKNOWN으로 읽히며 existing localStorage key와 최대 100 record behavior가 유지되어야 한다.
+
+## iPhone / Touch smoke (별도 승인)
+
+Tailscale Serve 변경은 별도 승인 없이는 실행하지 않는다. 현재 Serve config와 사용하지 않는 HTTPS port를 먼저 read-only로 확인한 뒤, dedicated port root에만 smoke Web을 publish한다. 예시는 기존 Serve path를 덮어쓰지 않는 dedicated port 방식이다.
+
+```bash
+# 별도 승인 후에만; exact port collision을 status로 먼저 확인한다.
+tailscale serve --https=18080 --bg http://127.0.0.1:18080
+```
+
+이 경우 browser base URL도 Tailscale HTTPS origin으로 맞춰야 하므로 `SMOKE_ORIGIN=https://<tailnet-host>:18080`, `SMOKE_REFRESH_COOKIE_SECURE=true`로 smoke env를 조정하고 Web image를 다시 build한다. 그 뒤 iPhone Safari에서 touch start/stop, `TOUCH` provenance, authenticated save를 확인한다. PWA 설치는 V2.1 release blocker가 아니다.

--- a/homeserver/nginx/smoke.conf
+++ b/homeserver/nginx/smoke.conf
@@ -1,0 +1,54 @@
+upstream cubinghub_smoke_api {
+    server api:8080;
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+
+    location /api {
+        proxy_pass http://cubinghub_smoke_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+
+    location = /actuator/health {
+        proxy_pass http://cubinghub_smoke_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+
+    location ^~ /actuator/ {
+        return 404;
+    }
+
+    location /uploads/ {
+        alias /data/post-images/;
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -18,6 +18,11 @@ const [
   setupGuide,
   runbook,
   backupRestoreGuide,
+  smokeCompose,
+  smokeEnvExample,
+  smokeNginx,
+  smokeScript,
+  smokeRunbook,
 ] = await Promise.all([
   read("../docker-compose.yml"),
   read("../docker-compose.admin.yml"),
@@ -34,6 +39,11 @@ const [
   read("../docs/mac-mini-server-setup.md"),
   read("../docs/home-server-runbook.md"),
   read("../docs/db-backup-restore.md"),
+  read("../docker-compose.smoke.yml"),
+  read("../.env.smoke.example"),
+  read("../nginx/smoke.conf"),
+  read("./smoke-v2-1.sh"),
+  read("../docs/release-smoke-runbook.md"),
 ]);
 
 test("should_isolateDataServicesAndGiveOnlyApiOutboundAccess_when_productionRuns", () => {
@@ -590,6 +600,75 @@ test("should_keepAdminDatabaseAccessOnLoopbackOnly", () => {
   assert.match(adminCompose, /127\.0\.0\.1:3307:3307/);
   assert.match(adminCompose, /TCP:db:3306/);
   assert.doesNotMatch(serviceBlock(compose, "db"), /\n\s+ports:/);
+});
+
+test("should_keepV21SmokeEnvironmentDisposableAndIsolatedFromProduction", () => {
+  assert.match(smokeCompose, /^name: cubing-hub-smoke$/m);
+  assert.doesNotMatch(smokeCompose, /\bcontainer_name:|\bexternal:|\bedge\b/);
+  assert.doesNotMatch(
+    smokeCompose,
+    /POST_IMAGES_HOST_DIR|API_IMAGE|WEB_IMAGE|\/Users\/homeserver\/Server|env_file:/,
+  );
+  assert.match(
+    smokeCompose,
+    /dockerfile: homeserver\/docker\/backend\.Dockerfile/,
+  );
+  assert.match(
+    smokeCompose,
+    /dockerfile: homeserver\/docker\/frontend\.Dockerfile/,
+  );
+  assert.match(
+    smokeCompose,
+    /127\.0\.0\.1:18080:80/,
+  );
+
+  for (const serviceName of ["mysql", "redis", "mailpit", "api"]) {
+    assert.doesNotMatch(serviceBlock(smokeCompose, serviceName), /\n\s+ports:/);
+  }
+
+  assert.match(
+    serviceBlock(smokeCompose, "mysql"),
+    /source: smoke-mysql-data/,
+  );
+  assert.match(
+    serviceBlock(smokeCompose, "api"), /source: smoke-post-images/);
+  assert.match(smokeCompose, /smoke-application:\n    internal: true/);
+  assert.match(serviceBlock(smokeCompose, "api-build"), /smoke-build/);
+  assert.doesNotMatch(serviceBlock(smokeCompose, "api-build"), /docker\.sock/);
+  assert.match(
+    smokeNginx,
+    /upstream cubinghub_smoke_api \{\n    server api:8080;/,
+  );
+  assert.match(smokeNginx, /location \/api/);
+  assert.doesNotMatch(smokeNginx, /cloudflare|cubing-hub\.com/);
+  assert.match(
+    smokeEnvExample,
+    /SMOKE_ORIGIN=http:\/\/smoke\.localhost:18080/,
+  );
+  for (const variableName of [
+    "SMOKE_DB_PASSWORD",
+    "SMOKE_MYSQL_ROOT_PASSWORD",
+    "SMOKE_JWT_SECRET",
+  ]) {
+    assert.match(
+      smokeEnvExample,
+      new RegExp(`^${variableName}=replace-with-`, "m"),
+    );
+  }
+  assert.doesNotMatch(
+    smokeEnvExample,
+    /\/Users\/homeserver\/Server|api\.cubing-hub\.com|ghp_|github_pat_|BEGIN .*PRIVATE KEY/,
+  );
+  assert.match(smokeScript, /readonly PROJECT_NAME="cubing-hub-smoke"/);
+  assert.match(smokeScript, /--project-name "\$\{PROJECT_NAME\}"/);
+  assert.match(smokeScript, /Replace every smoke credential placeholder/);
+  assert.match(
+    smokeScript,
+    /destroy\)\n    compose --profile build down --volumes --remove-orphans/,
+  );
+  assert.doesNotMatch(smokeScript, /docker\.sock|docker system prune|volume prune/);
+  assert.match(smokeRunbook, /smoke-v2-1\.sh up/);
+  assert.match(smokeRunbook, /Tailscale Serve 변경은 별도 승인/);
 });
 
 test("should_failFrontendBuildWithoutProductionApiUrl", () => {

--- a/homeserver/scripts/smoke-v2-1.sh
+++ b/homeserver/scripts/smoke-v2-1.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly PROJECT_NAME="cubing-hub-smoke"
+readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly REPOSITORY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly COMPOSE_FILE="${REPOSITORY_DIR}/homeserver/docker-compose.smoke.yml"
+readonly ENV_FILE="${REPOSITORY_DIR}/homeserver/.env.smoke"
+readonly DEFAULT_SMOKE_ORIGIN="http://smoke.localhost:18080"
+
+usage() {
+  cat <<'USAGE'
+Usage: homeserver/scripts/smoke-v2-1.sh <up|status|logs|flyway|down|destroy>
+
+up       Build the smoke API artifact and start the isolated stack.
+status   Show only cubing-hub-smoke service status.
+logs     Show only cubing-hub-smoke logs.
+flyway   Print Flyway history from the smoke MySQL service.
+down     Stop/remove smoke containers and network while retaining smoke volumes.
+destroy  Remove only smoke containers, network, and disposable smoke volumes.
+USAGE
+}
+
+require_smoke_env() {
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    printf 'Missing %s. Copy homeserver/.env.smoke.example first.\n' "${ENV_FILE}" >&2
+    exit 1
+  fi
+
+  if /usr/bin/grep -Eq '/Users/homeserver/Server|api\.cubing-hub\.com|cubing-hub\.com' "${ENV_FILE}"; then
+    printf 'Smoke environment file must not reference a production path or origin.\n' >&2
+    exit 1
+  fi
+
+  if /usr/bin/grep -Eq '^SMOKE_(DB_PASSWORD|MYSQL_ROOT_PASSWORD|JWT_SECRET)=($|replace-with-)' "${ENV_FILE}"; then
+    printf 'Replace every smoke credential placeholder in %s before starting.\n' "${ENV_FILE}" >&2
+    exit 1
+  fi
+}
+
+compose() {
+  SMOKE_UID="$(/usr/bin/id -u)" \
+  SMOKE_GID="$(/usr/bin/id -g)" \
+    /usr/local/bin/docker compose \
+      --project-name "${PROJECT_NAME}" \
+      --env-file "${ENV_FILE}" \
+      --file "${COMPOSE_FILE}" \
+      "$@"
+}
+
+verify_local_origin() {
+  local smoke_origin
+  smoke_origin="$(/usr/bin/sed -n 's/^SMOKE_ORIGIN=//p' "${ENV_FILE}" | /usr/bin/tail -n 1)"
+
+  if [[ -z "${smoke_origin}" ]]; then
+    smoke_origin="${DEFAULT_SMOKE_ORIGIN}"
+  fi
+
+  if [[ "${smoke_origin}" != "${DEFAULT_SMOKE_ORIGIN}" ]]; then
+    printf 'Stack is healthy. HTTP probe is skipped because SMOKE_ORIGIN is %s.\n' "${smoke_origin}"
+    return
+  fi
+
+  /usr/bin/curl \
+    --fail \
+    --silent \
+    --show-error \
+    --resolve smoke.localhost:18080:127.0.0.1 \
+    "${DEFAULT_SMOKE_ORIGIN}/actuator/health"
+  /usr/bin/curl \
+    --fail \
+    --silent \
+    --show-error \
+    --resolve smoke.localhost:18080:127.0.0.1 \
+    "${DEFAULT_SMOKE_ORIGIN}/" \
+    >/dev/null
+}
+
+if [[ "$#" -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+require_smoke_env
+
+case "$1" in
+  up)
+    compose --profile build run --rm api-build
+    compose up --detach --build --wait --wait-timeout 180
+    compose ps
+    verify_local_origin
+    ;;
+  status)
+    compose ps
+    ;;
+  logs)
+    compose logs --tail 200
+    ;;
+  flyway)
+    compose exec -T mysql sh -ec \
+      'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" mysql -h 127.0.0.1 -u root -e "SELECT installed_rank, version, description, success FROM flyway_schema_history ORDER BY installed_rank" "$MYSQL_DATABASE"'
+    ;;
+  down)
+    compose --profile build down --remove-orphans
+    ;;
+  destroy)
+    compose --profile build down --volumes --remove-orphans
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds an isolated `cubing-hub-smoke` Docker Compose project for V2.1 release smoke.
- Builds current source with the existing production API/Web Dockerfiles.
- Uses fresh disposable MySQL, Redis, Mailpit, same-origin smoke Nginx, Flyway V1–V3, and loopback-only Web access.
- Adds a fixed-project helper, isolation regression coverage, and command-level browser/device smoke runbook.

## Isolation

- No production Compose, `.env`, container, DB, Redis, volume, network, Cloudflare, or Tailscale runtime changes.
- Web only publishes `127.0.0.1:18080`; API/MySQL/Redis/Mailpit remain internal.
- Normal shutdown preserves only smoke volumes; guarded `destroy` removes only smoke resources.

## Validation

- `docker compose ... config --quiet`
- smoke Nginx `nginx -t`
- Docker Node 20 `operations-config.test.mjs` (18 passing)
- Actual smoke build/up: all services healthy, loopback Web 200, proxied API health 200, Flyway V1/V2/V3 success

## Manual smoke

Browser/device checks remain intentionally manual and are documented in `homeserver/docs/release-smoke-runbook.md`. Tailscale Serve remains a separately approved operation.

## Scope

Smoke config, helper/test, and operations/quality documentation only. No application business logic, Flyway migration, workflow, deployment, or production runtime changes.