### PR TITLE
fix: close V2.1 final review findings

### DIFF
--- a/docs/02-requirements/features/timer.md
+++ b/docs/02-requirements/features/timer.md
@@ -100,11 +100,11 @@ solve stop
 - retry는 같은 `clientSubmissionId`와 snapshot을 사용한다.
 - server save 뒤 response만 유실됐어도 retry가 기존 Record를 반환하고 duplicate를 만들지 않아야 한다.
 - 실패나 reload 뒤에는 자동 submit하지 않고 stopped solve와 재시도·버리기 선택을 제공한다.
-- canonical save가 확정된 뒤에는 next scramble이 UI에 정상 commit될 때까지 Timer input을 잠근다. recent history·statistics refresh의 지연이나 실패가 이전 scramble을 다시 측정 가능하게 만들면 안 된다.
+- canonical save가 확정된 뒤에는 next scramble이 UI에 정상 commit될 때까지 Timer input을 잠근다. 현재 event context의 유효한 scramble commit만 lock을 해제하며 stale·invalidated response, pending recovery, unsupported event, scramble failure는 해제할 수 없다. recent history·statistics refresh의 지연이나 실패가 이전 scramble을 다시 측정 가능하게 만들면 안 된다.
 - pending에는 schema version, userId, eventType, timeMs, penalty, scramble, Input Method, `clientSubmissionId`, recovery용 savedAt만 저장한다.
 - access token, refresh token과 credential은 저장하지 않는다.
 - storage key와 snapshot userId가 현재 authenticated user와 일치할 때만 복구한다.
-- logout이나 명시적 session clear는 현재 user의 pending을 제거한다. access token 만료, refresh network failure, passive auth loss만으로 pending을 제거하지 않으며 같은 userId가 다시 인증되면 recovery할 수 있어야 한다. 다른 account pending을 읽거나 제출하지 않는다.
+- logout이나 명시적 session clear는 현재 user의 pending을 제거한다. access token 만료, refresh network failure, passive auth loss만으로 pending을 제거하지 않으며 같은 userId가 다시 인증되면 recovery할 수 있어야 한다. `userId`가 있는 authenticated-origin pending은 같은 account가 인증된 경우에만 Record API로 재시도할 수 있고, 인증이 없는 동안 guest 저장으로 전환하거나 API를 호출하지 않는다. 다른 account pending을 읽거나 제출하지 않는다.
 - malformed JSON, schema mismatch, invalid field는 server에 제출하지 않고 일반 안내와 명시적 discard를 제공한다. corrupt pending이 남아 있는 동안 Timer input도 비활성화해 새 solve가 해당 entry를 덮어쓰지 못하게 한다.
 - sessionStorage page session과 명시적 discard를 사용하며 V2.1에서 임의의 시간 만료 정책을 추가하지 않는다. `savedAt`은 recovery metadata이지 `occurred_at`이 아니다.
 - 여러 solve를 쌓는 offline queue와 background sync는 만들지 않는다.

--- a/docs/02-requirements/features/timer.md
+++ b/docs/02-requirements/features/timer.md
@@ -2,7 +2,7 @@
 doc_type: requirement
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -100,10 +100,11 @@ solve stop
 - retry는 같은 `clientSubmissionId`와 snapshot을 사용한다.
 - server save 뒤 response만 유실됐어도 retry가 기존 Record를 반환하고 duplicate를 만들지 않아야 한다.
 - 실패나 reload 뒤에는 자동 submit하지 않고 stopped solve와 재시도·버리기 선택을 제공한다.
+- canonical save가 확정된 뒤에는 next scramble이 UI에 정상 commit될 때까지 Timer input을 잠근다. recent history·statistics refresh의 지연이나 실패가 이전 scramble을 다시 측정 가능하게 만들면 안 된다.
 - pending에는 schema version, userId, eventType, timeMs, penalty, scramble, Input Method, `clientSubmissionId`, recovery용 savedAt만 저장한다.
 - access token, refresh token과 credential은 저장하지 않는다.
 - storage key와 snapshot userId가 현재 authenticated user와 일치할 때만 복구한다.
-- logout이나 명시적 session clear는 현재 user의 pending을 제거한다. 다른 account pending을 읽거나 제출하지 않는다.
+- logout이나 명시적 session clear는 현재 user의 pending을 제거한다. access token 만료, refresh network failure, passive auth loss만으로 pending을 제거하지 않으며 같은 userId가 다시 인증되면 recovery할 수 있어야 한다. 다른 account pending을 읽거나 제출하지 않는다.
 - malformed JSON, schema mismatch, invalid field는 server에 제출하지 않고 일반 안내와 명시적 discard를 제공한다. corrupt pending이 남아 있는 동안 Timer input도 비활성화해 새 solve가 해당 entry를 덮어쓰지 못하게 한다.
 - sessionStorage page session과 명시적 discard를 사용하며 V2.1에서 임의의 시간 만료 정책을 추가하지 않는다. `savedAt`은 recovery metadata이지 `occurred_at`이 아니다.
 - 여러 solve를 쌓는 offline queue와 background sync는 만들지 않는다.
@@ -130,6 +131,7 @@ Ao5와 Ao12는 최근 같은 event의 completed Practice Record를 대상으로 
 - canonical ordering은 `created_at DESC, id DESC`이며 같은 timestamp에서도 순서가 결정적이어야 한다.
 - eventType을 생략하는 기존 all-event history contract는 유지한다.
 - Timer는 선택 event의 최근 12개를 server에서 직접 요청해 Ao5/Ao12를 계산한다.
+- statistics/history async response는 request를 시작한 event와 현재 event context가 같을 때만 반영한다. event 변경 뒤 stale response가 이전 event의 Ao를 되살리면 안 된다.
 - Record 생성 응답은 기존 client compatibility를 깨지 않는 additive evolution으로 server-authoritative 표현을 제공해야 한다.
 
 ## V2.1 Event Support

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -38,7 +38,6 @@ export function AuthProvider({ children }) {
       setAccessTokenState(nextToken)
 
       if (!nextToken) {
-        clearPendingTimerSolve(currentUserRef.current?.userId)
         setCurrentUser(null)
         setIsSessionSyncing(false)
       }

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
+import MockAdapter from 'axios-mock-adapter'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearStoredAccessToken, getStoredAccessToken, setStoredAccessToken } from '../authStorage.js'
 import { clearRefreshCookie, getMe, refreshSession } from '../api.js'
+import apiClient from '../lib/apiClient.js'
 import { clearPendingTimerSolve, loadPendingTimerSolve, PENDING_TIMER_SOLVE_SCHEMA_VERSION, savePendingTimerSolve } from '../lib/pendingTimerSolveStorage.js'
 import { AuthProvider } from './AuthContext.jsx'
 import { useAuth } from './useAuth.js'
@@ -532,6 +534,69 @@ describe('AuthProvider', () => {
     })
 
     expect(loadPendingTimerSolve(42).snapshot).toBeNull()
+    clearPendingTimerSolve(41)
+  })
+
+  it('should_preserve_the_current_users_pending_solve_when_a_record_401_refresh_fails_and_allow_the_same_account_to_sign_in_again', async () => {
+    vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
+      status: 400,
+      isNetworkError: false,
+    }))
+    vi.mocked(getMe).mockResolvedValue({
+      data: {
+        userId: 41,
+        nickname: 'AccountA',
+        role: 'ROLE_USER',
+      },
+    })
+    const requestMock = new MockAdapter(apiClient)
+    requestMock.onPost('/api/records').replyOnce(401)
+    requestMock.onPost('/api/auth/refresh').networkErrorOnce()
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountA')
+    })
+
+    const pendingSnapshot = {
+      schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+      userId: 41,
+      eventType: 'WCA_333',
+      timeMs: 1235,
+      penalty: 'NONE',
+      scramble: "R U R' U'",
+      inputMethod: 'KEYBOARD',
+      clientSubmissionId: 'd9428888-122b-4d3e-a58e-790c4e5f97ad',
+      savedAt: '2026-08-10T13:00:00.000Z',
+    }
+    savePendingTimerSolve(pendingSnapshot)
+
+    await expect(apiClient.post('/api/records', { timeMs: 1235 })).rejects.toThrow('Network Error')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated')).toHaveTextContent('false')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toEqual(pendingSnapshot)
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountA')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toEqual(pendingSnapshot)
+
+    requestMock.restore()
     clearPendingTimerSolve(41)
   })
 

--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -221,6 +221,10 @@ export default function TimerPage() {
   const previousAuthenticatedUserIdRef = useRef(null)
   const authenticatedUserIdRef = useRef(authenticatedUserId)
   const scrambleRequestIdRef = useRef(0)
+  const scrambleContextRef = useRef({
+    eventType: selectedEvent,
+    isSupported: isPracticeEventSupported(selectedEvent),
+  })
   const pendingRecoveryScrambleRef = useRef(null)
   const statisticsRequestIdRef = useRef(0)
   const statisticsContextRef = useRef({ eventType: selectedEvent, isAuthenticated })
@@ -265,6 +269,11 @@ export default function TimerPage() {
   useEffect(() => {
     authenticatedUserIdRef.current = authenticatedUserId
   }, [authenticatedUserId])
+
+  useEffect(() => {
+    scrambleContextRef.current = { eventType: selectedEvent, isSupported }
+    scrambleRequestIdRef.current += 1
+  }, [isSupported, selectedEvent])
 
   useEffect(() => {
     statisticsContextRef.current = { eventType: selectedEvent, isAuthenticated }
@@ -327,13 +336,19 @@ export default function TimerPage() {
     setIsLoadingRecentStats(false)
   }, [])
 
-  const loadScramble = useCallback(async (eventType, { unlockNextSolve = false } = {}) => {
+  const loadScramble = useCallback(async (eventType) => {
     if (pendingRecoveryScrambleRef.current) {
       return
     }
 
     const requestId = scrambleRequestIdRef.current + 1
     scrambleRequestIdRef.current = requestId
+    const isCurrentRequest = () => (
+      requestId === scrambleRequestIdRef.current
+      && scrambleContextRef.current.isSupported
+      && scrambleContextRef.current.eventType === eventType
+      && !pendingRecoveryScrambleRef.current
+    )
     setIsLoadingScramble(true)
     setHasScrambleVisualError(false)
     setScrambleMessage(null)
@@ -341,23 +356,21 @@ export default function TimerPage() {
 
     try {
       const response = await getScramble(eventType)
-      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+      if (isCurrentRequest()) {
         if (!response.data?.scramble) {
           throw new Error('스크램블을 불러오지 못했습니다. 다시 시도해주세요.')
         }
 
         setScrambleData(response.data)
-        if (unlockNextSolve) {
-          setIsNextSolveTransition(false)
-        }
+        setIsNextSolveTransition(false)
       }
     } catch (error) {
-      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+      if (isCurrentRequest()) {
         setScrambleData(null)
         setScrambleMessage({ type: 'error', text: error.message })
       }
     } finally {
-      if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+      if (isCurrentRequest()) {
         setIsLoadingScramble(false)
       }
     }
@@ -391,6 +404,7 @@ export default function TimerPage() {
     completedStoppedSolveRef.current = false
 
     if (!isSupported) {
+      setIsLoadingScramble(false)
       setScrambleData(null)
       setScrambleMessage({ type: 'info', text: '이 종목은 아직 구현되지 않았습니다.' })
       return
@@ -428,6 +442,19 @@ export default function TimerPage() {
 
   useEffect(() => {
     const previousUserId = previousAuthenticatedUserIdRef.current
+    const hasOwnedPendingAfterPassiveAuthLoss = previousUserId != null
+      && authenticatedUserId == null
+      && stoppedSolveSnapshot?.userId === previousUserId
+      && loadPendingTimerSolve(previousUserId).snapshot != null
+    const hasStoppedSolveForAnotherAuthenticatedUser = stoppedSolveSnapshot?.userId != null
+      && authenticatedUserId != null
+      && stoppedSolveSnapshot.userId !== authenticatedUserId
+    const shouldPreserveRecoveredPendingScramble = pendingRecoveryScrambleRef.current
+      && stoppedSolveSnapshot?.userId != null
+      && (
+        hasOwnedPendingAfterPassiveAuthLoss
+        || stoppedSolveSnapshot.userId === authenticatedUserId
+      )
 
     if (previousUserId != null && authenticatedUserId != null && previousUserId !== authenticatedUserId) {
       clearPendingTimerSolve(previousUserId)
@@ -439,10 +466,40 @@ export default function TimerPage() {
       completedStoppedSolveRef.current = false
     }
 
+    if (hasStoppedSolveForAnotherAuthenticatedUser) {
+      resetTimer()
+      setStoppedSolveSnapshot(null)
+      setSaveStatus('idle')
+      setSaveNotice(null)
+      setDiscardablePendingOwnerId(null)
+      completedStoppedSolveRef.current = false
+    }
+
+    if (
+      hasOwnedPendingAfterPassiveAuthLoss
+    ) {
+      setSaveStatus('error')
+      setSaveNotice('저장 대기 기록을 다시 저장하려면 같은 계정으로 로그인해주세요.')
+    }
+
+    if (
+      previousUserId != null
+      && authenticatedUserId == null
+      && stoppedSolveSnapshot?.userId === previousUserId
+      && !hasOwnedPendingAfterPassiveAuthLoss
+    ) {
+      resetTimer()
+      setStoppedSolveSnapshot(null)
+      setSaveStatus('idle')
+      setSaveNotice(null)
+      setDiscardablePendingOwnerId(null)
+      completedStoppedSolveRef.current = false
+    }
+
     if (previousUserId !== authenticatedUserId) {
       recoveredPendingOwnerIdRef.current = null
 
-      if (pendingRecoveryScrambleRef.current) {
+      if (pendingRecoveryScrambleRef.current && !shouldPreserveRecoveredPendingScramble) {
         pendingRecoveryScrambleRef.current = null
         scrambleRequestIdRef.current += 1
         loadScramble(selectedEvent)
@@ -450,7 +507,7 @@ export default function TimerPage() {
     }
 
     previousAuthenticatedUserIdRef.current = authenticatedUserId
-  }, [authenticatedUserId, loadScramble, resetTimer, selectedEvent])
+  }, [authenticatedUserId, loadScramble, resetTimer, selectedEvent, stoppedSolveSnapshot])
 
   useEffect(() => {
     if (!isAuthenticated || authenticatedUserId == null || recoveredPendingOwnerIdRef.current === authenticatedUserId) {
@@ -578,9 +635,9 @@ export default function TimerPage() {
     setSaveNotice('기록 저장 중...')
 
     try {
-      if (isAuthenticated) {
-        if (snapshot.userId == null || snapshot.userId !== authenticatedUserIdRef.current) {
-          throw new Error('현재 계정의 저장 대기 기록이 아닙니다.')
+      if (snapshot.userId != null) {
+        if (!isAuthenticated || snapshot.userId !== authenticatedUserId) {
+          throw new Error('저장 대기 기록을 다시 저장하려면 같은 계정으로 로그인해주세요.')
         }
 
         savePendingTimerSolve(snapshot)
@@ -606,7 +663,7 @@ export default function TimerPage() {
         toast.success(response.message)
         resetTimer()
         void loadRecentStatistics(snapshot.eventType)
-        await loadScramble(snapshot.eventType, { unlockNextSolve: true })
+        await loadScramble(snapshot.eventType)
       } else {
         saveGuestTimerRecord(snapshot)
         loadGuestStatistics(snapshot.eventType)
@@ -617,7 +674,7 @@ export default function TimerPage() {
         setIsNextSolveTransition(true)
         setSaveNotice(null)
         resetTimer()
-        await loadScramble(snapshot.eventType, { unlockNextSolve: true })
+        await loadScramble(snapshot.eventType)
       }
     } catch (error) {
       setSaveStatus('error')
@@ -625,7 +682,7 @@ export default function TimerPage() {
     } finally {
       activePersistKeyRef.current = null
     }
-  }, [isAuthenticated, loadGuestStatistics, loadRecentStatistics, loadScramble, releaseRecoveredPendingScramble, resetTimer])
+  }, [authenticatedUserId, isAuthenticated, loadGuestStatistics, loadRecentStatistics, loadScramble, releaseRecoveredPendingScramble, resetTimer])
 
   useEffect(() => {
     if (!stoppedSolveSnapshot || status !== 'stopped' || saveStatus !== 'idle') {
@@ -650,7 +707,7 @@ export default function TimerPage() {
     setSaveNotice(null)
     completedStoppedSolveRef.current = true
     resetTimer()
-    await loadScramble(selectedEvent, { unlockNextSolve: true })
+    await loadScramble(selectedEvent)
   }
 
   const timerMessage = getTimerMessage(status, isSupported, hasScramble)

--- a/frontend/src/pages/TimerPage.jsx
+++ b/frontend/src/pages/TimerPage.jsx
@@ -214,6 +214,7 @@ export default function TimerPage() {
   const [stoppedSolveSnapshot, setStoppedSolveSnapshot] = useState(null)
   const [saveStatus, setSaveStatus] = useState('idle')
   const [discardablePendingOwnerId, setDiscardablePendingOwnerId] = useState(null)
+  const [isNextSolveTransition, setIsNextSolveTransition] = useState(false)
   const activePersistKeyRef = useRef(null)
   const completedStoppedSolveRef = useRef(false)
   const recoveredPendingOwnerIdRef = useRef(null)
@@ -221,12 +222,19 @@ export default function TimerPage() {
   const authenticatedUserIdRef = useRef(authenticatedUserId)
   const scrambleRequestIdRef = useRef(0)
   const pendingRecoveryScrambleRef = useRef(null)
+  const statisticsRequestIdRef = useRef(0)
+  const statisticsContextRef = useRef({ eventType: selectedEvent, isAuthenticated })
 
   const isSupported = isPracticeEventSupported(selectedEvent)
   const hasScramble = Boolean(scrambleData?.scramble)
   const canDiscardCorruptPendingSolve = discardablePendingOwnerId !== null
     && discardablePendingOwnerId === authenticatedUserId
-  const timerEnabled = isSupported && hasScramble && !isLoadingScramble && !canDiscardCorruptPendingSolve
+  const timerEnabled = isSupported
+    && hasScramble
+    && !isLoadingScramble
+    && !isNextSolveTransition
+    && !stoppedSolveSnapshot
+    && !canDiscardCorruptPendingSolve
   const ao5 = useMemo(() => calculateAverageOf(recentStatsRecords, 5), [recentStatsRecords])
   const ao12 = useMemo(() => calculateAverageOf(recentStatsRecords, 12), [recentStatsRecords])
   const scrambleVisualUrl = useMemo(() => {
@@ -258,10 +266,30 @@ export default function TimerPage() {
     authenticatedUserIdRef.current = authenticatedUserId
   }, [authenticatedUserId])
 
+  useEffect(() => {
+    statisticsContextRef.current = { eventType: selectedEvent, isAuthenticated }
+    statisticsRequestIdRef.current += 1
+  }, [isAuthenticated, selectedEvent])
+
   const loadRecentStatistics = useCallback(async (eventType) => {
+    const requestId = statisticsRequestIdRef.current + 1
+    statisticsRequestIdRef.current = requestId
+    const isCurrentRequest = () => (
+      requestId === statisticsRequestIdRef.current
+      && statisticsContextRef.current.isAuthenticated
+      && statisticsContextRef.current.eventType === eventType
+    )
+
     if (!isAuthenticated || !eventType) {
-      setRecentStatsRecords([])
-      setRecentStatsError(null)
+      if (isCurrentRequest()) {
+        setRecentStatsRecords([])
+        setRecentStatsError(null)
+        setIsLoadingRecentStats(false)
+      }
+      return
+    }
+
+    if (!isCurrentRequest()) {
       return
     }
 
@@ -274,13 +302,19 @@ export default function TimerPage() {
         page: 1,
         size: RECENT_STATS_FETCH_SIZE,
       })
-      setRecentStatsRecords(Array.isArray(response.data?.items) ? response.data.items.slice(0, RECENT_STATS_LIMIT) : [])
-      setRecentStatsError(null)
+      if (isCurrentRequest()) {
+        setRecentStatsRecords(Array.isArray(response.data?.items) ? response.data.items.slice(0, RECENT_STATS_LIMIT) : [])
+        setRecentStatsError(null)
+      }
     } catch (error) {
-      setRecentStatsRecords([])
-      setRecentStatsError(error.message)
+      if (isCurrentRequest()) {
+        setRecentStatsRecords([])
+        setRecentStatsError(error.message)
+      }
     } finally {
-      setIsLoadingRecentStats(false)
+      if (isCurrentRequest()) {
+        setIsLoadingRecentStats(false)
+      }
     }
   }, [isAuthenticated])
 
@@ -293,7 +327,7 @@ export default function TimerPage() {
     setIsLoadingRecentStats(false)
   }, [])
 
-  const loadScramble = useCallback(async (eventType) => {
+  const loadScramble = useCallback(async (eventType, { unlockNextSolve = false } = {}) => {
     if (pendingRecoveryScrambleRef.current) {
       return
     }
@@ -308,7 +342,14 @@ export default function TimerPage() {
     try {
       const response = await getScramble(eventType)
       if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
+        if (!response.data?.scramble) {
+          throw new Error('스크램블을 불러오지 못했습니다. 다시 시도해주세요.')
+        }
+
         setScrambleData(response.data)
+        if (unlockNextSolve) {
+          setIsNextSolveTransition(false)
+        }
       }
     } catch (error) {
       if (requestId === scrambleRequestIdRef.current && !pendingRecoveryScrambleRef.current) {
@@ -388,7 +429,7 @@ export default function TimerPage() {
   useEffect(() => {
     const previousUserId = previousAuthenticatedUserIdRef.current
 
-    if (previousUserId != null && previousUserId !== authenticatedUserId) {
+    if (previousUserId != null && authenticatedUserId != null && previousUserId !== authenticatedUserId) {
       clearPendingTimerSolve(previousUserId)
       resetTimer()
       setStoppedSolveSnapshot(null)
@@ -560,11 +601,12 @@ export default function TimerPage() {
         releaseRecoveredPendingScramble()
         completedStoppedSolveRef.current = true
         setSaveStatus('success')
+        setIsNextSolveTransition(true)
         setSaveNotice(null)
         toast.success(response.message)
         resetTimer()
-        await loadRecentStatistics(snapshot.eventType)
-        await loadScramble(snapshot.eventType)
+        void loadRecentStatistics(snapshot.eventType)
+        await loadScramble(snapshot.eventType, { unlockNextSolve: true })
       } else {
         saveGuestTimerRecord(snapshot)
         loadGuestStatistics(snapshot.eventType)
@@ -572,9 +614,10 @@ export default function TimerPage() {
         setStoppedSolveSnapshot(null)
         completedStoppedSolveRef.current = true
         setSaveStatus('success')
+        setIsNextSolveTransition(true)
         setSaveNotice(null)
         resetTimer()
-        await loadScramble(snapshot.eventType)
+        await loadScramble(snapshot.eventType, { unlockNextSolve: true })
       }
     } catch (error) {
       setSaveStatus('error')
@@ -603,10 +646,11 @@ export default function TimerPage() {
     setDiscardablePendingOwnerId(null)
     releaseRecoveredPendingScramble()
     setSaveStatus('idle')
+    setIsNextSolveTransition(true)
     setSaveNotice(null)
     completedStoppedSolveRef.current = true
     resetTimer()
-    await loadScramble(selectedEvent)
+    await loadScramble(selectedEvent, { unlockNextSolve: true })
   }
 
   const timerMessage = getTimerMessage(status, isSupported, hasScramble)

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -267,6 +267,77 @@ describe('TimerPage', () => {
     })
   })
 
+  it('should_keep_timer_input_locked_until_the_next_scramble_is_committed_after_an_authenticated_save', async () => {
+    const delayedStatistics = createDeferred()
+    const delayedNextScramble = createDeferred()
+
+    vi.mocked(getMyRecords)
+      .mockResolvedValueOnce(createRecordsResponse())
+      .mockImplementationOnce(() => delayedStatistics.promise)
+    vi.mocked(getScramble)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'CURRENT SCRAMBLE',
+        },
+      })
+      .mockImplementationOnce(() => delayedNextScramble.promise)
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ scramble: 'CURRENT SCRAMBLE' }),
+    })
+
+    render(<TimerPage />)
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(1)
+      expect(getScramble).toHaveBeenCalledTimes(2)
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    })
+
+    await act(async () => {
+      delayedStatistics.resolve(createRecordsResponse())
+      await delayedStatistics.promise
+    })
+
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    expect(screen.queryByText('CURRENT SCRAMBLE')).not.toBeInTheDocument()
+
+    await act(async () => {
+      delayedNextScramble.resolve({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'NEXT SCRAMBLE',
+        },
+      })
+      await delayedNextScramble.promise
+    })
+
+    expect(await screen.findByText('NEXT SCRAMBLE')).toBeInTheDocument()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
+  })
+
+  it('should_keep_timer_input_locked_when_the_next_scramble_fails_after_save', async () => {
+    vi.mocked(getScramble)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'CURRENT SCRAMBLE',
+        },
+      })
+      .mockRejectedValueOnce(new Error('다음 스크램블 조회 실패'))
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ scramble: 'CURRENT SCRAMBLE' }),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('다음 스크램블 조회 실패')).toBeInTheDocument()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    expect(screen.queryByText('CURRENT SCRAMBLE')).not.toBeInTheDocument()
+  })
+
   it('should_use_the_server_canonical_record_and_deduplicate_a_replayed_record_by_id', () => {
     const existing = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T12:00:00.000Z' })
     const replayed = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T13:00:00.000Z' })
@@ -586,7 +657,58 @@ describe('TimerPage', () => {
     await screen.findByText("R U R' U'")
     expect(restoreStoppedSolve).not.toHaveBeenCalled()
     expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
-    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createPendingSnapshot())
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+  })
+
+  it('should_preserve_a_pending_snapshot_across_passive_auth_loss_and_recover_it_only_for_the_same_account', async () => {
+    vi.mocked(saveRecord).mockRejectedValueOnce(new Error('응답을 받지 못했습니다.'))
+    const page = render(<TimerPage />)
+
+    expect(await screen.findByText('응답을 받지 못했습니다.')).toBeInTheDocument()
+    const originalPayload = saveRecord.mock.calls[0][0]
+
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: false,
+      currentUser: null,
+    })
+    page.rerender(<TimerPage />)
+
+    await waitFor(() => {
+      expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+    })
+    page.unmount()
+
+    timerState = createIdleTimer({ restoreStoppedSolve: vi.fn() })
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      currentUser: { userId: 2 },
+    })
+    const otherAccountPage = render(<TimerPage />)
+
+    await screen.findByText("R U R' U'")
+    expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+    otherAccountPage.unmount()
+
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      currentUser: { userId: USER_ID },
+    })
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord(),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByRole('button', { name: '저장 재시도' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(2)
+    })
+    expect(saveRecord.mock.calls[1][0]).toEqual(originalPayload)
+    expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
   })
 
   it('should_save_guest_record_with_the_same_canonical_time_and_touch_provenance', async () => {
@@ -756,6 +878,67 @@ describe('TimerPage', () => {
     expect(await screen.findByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.timer-helper' })).toBeInTheDocument()
     expect(screen.getByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.message.info' })).toBeInTheDocument()
     expect(screen.getByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')).toBeInTheDocument()
+  })
+
+  it('should_ignore_stale_statistics_after_the_selected_event_becomes_unsupported', async () => {
+    const staleStatistics = createDeferred()
+    timerState = createIdleTimer()
+    vi.mocked(getMyRecords).mockImplementationOnce(() => staleStatistics.promise)
+
+    render(<TimerPage />)
+
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
+    expect(await screen.findByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')).toBeInTheDocument()
+
+    await act(async () => {
+      staleStatistics.resolve(createRecordsResponse(Array.from({ length: 5 }, (_, index) => createRecentRecord({
+        id: index + 1,
+        timeMs: 12345,
+        effectiveTimeMs: 12345,
+      }))))
+      await staleStatistics.promise
+    })
+
+    expect(screen.queryByText('12.345')).not.toBeInTheDocument()
+    expect(screen.getByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')).toBeInTheDocument()
+  })
+
+  it('should_apply_only_the_latest_statistics_request_when_the_event_context_changes_twice', async () => {
+    const firstStatistics = createDeferred()
+    const latestStatistics = createDeferred()
+    timerState = createIdleTimer()
+    vi.mocked(getMyRecords)
+      .mockImplementationOnce(() => firstStatistics.promise)
+      .mockImplementationOnce(() => latestStatistics.promise)
+
+    render(<TimerPage />)
+
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
+    await screen.findByText('이 종목은 아직 Ao 통계를 지원하지 않습니다.')
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_333' } })
+
+    await act(async () => {
+      latestStatistics.resolve(createRecordsResponse(Array.from({ length: 5 }, (_, index) => createRecentRecord({
+        id: index + 21,
+        timeMs: 15000,
+        effectiveTimeMs: 15000,
+      }))))
+      await latestStatistics.promise
+    })
+
+    expect(await screen.findByText('15.000')).toBeInTheDocument()
+
+    await act(async () => {
+      firstStatistics.resolve(createRecordsResponse(Array.from({ length: 5 }, (_, index) => createRecentRecord({
+        id: index + 1,
+        timeMs: 9000,
+        effectiveTimeMs: 9000,
+      }))))
+      await firstStatistics.promise
+    })
+
+    expect(screen.getByText('15.000')).toBeInTheDocument()
+    expect(screen.queryByText('09.000')).not.toBeInTheDocument()
   })
 
   it('should_render_scramble_and_recent_history_errors_without_starting_the_timer', async () => {

--- a/frontend/src/pages/TimerPage.test.jsx
+++ b/frontend/src/pages/TimerPage.test.jsx
@@ -338,6 +338,111 @@ describe('TimerPage', () => {
     expect(screen.queryByText('CURRENT SCRAMBLE')).not.toBeInTheDocument()
   })
 
+  it('should_remain_locked_after_a_next_scramble_failure_until_a_fresh_scramble_commits', async () => {
+    timerState = createStoppedTimer()
+    vi.mocked(getScramble)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'CURRENT SCRAMBLE',
+        },
+      })
+      .mockRejectedValueOnce(new Error('다음 스크램블 조회 실패'))
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'RECOVERED NEXT SCRAMBLE',
+        },
+      })
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ scramble: 'CURRENT SCRAMBLE' }),
+    })
+
+    render(<TimerPage />)
+
+    expect(await screen.findByText('다음 스크램블 조회 실패')).toBeInTheDocument()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    expect(screen.queryByText('CURRENT SCRAMBLE')).not.toBeInTheDocument()
+
+    timerState = createIdleTimer()
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
+    await screen.findByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.timer-helper' })
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_333' } })
+
+    expect(await screen.findByText('RECOVERED NEXT SCRAMBLE')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
+    })
+  })
+
+  it('should_unlock_after_a_fresh_current_scramble_commits_when_an_event_change_invalidates_the_post_save_request', async () => {
+    const delayedNextScramble = createDeferred()
+    const delayedFreshScramble = createDeferred()
+
+    vi.mocked(getScramble)
+      .mockResolvedValueOnce({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'CURRENT SCRAMBLE',
+        },
+      })
+      .mockImplementationOnce(() => delayedNextScramble.promise)
+      .mockImplementationOnce(() => delayedFreshScramble.promise)
+    vi.mocked(saveRecord).mockResolvedValue({
+      message: '기록이 저장되었습니다.',
+      data: createCanonicalRecord({ scramble: 'CURRENT SCRAMBLE' }),
+    })
+
+    render(<TimerPage />)
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(1)
+      expect(getScramble).toHaveBeenCalledTimes(2)
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+    })
+
+    timerState = createIdleTimer()
+
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_222' } })
+    expect(await screen.findByText('이 종목은 아직 구현되지 않았습니다.', { selector: '.timer-helper' })).toBeInTheDocument()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: false })
+
+    fireEvent.change(screen.getByLabelText('종목'), { target: { value: 'WCA_333' } })
+    await waitFor(() => {
+      expect(getScramble).toHaveBeenCalledTimes(3)
+    })
+
+    await act(async () => {
+      delayedFreshScramble.resolve({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'FRESH SCRAMBLE',
+        },
+      })
+      await delayedFreshScramble.promise
+    })
+
+    expect(await screen.findByText('FRESH SCRAMBLE')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
+    })
+
+    await act(async () => {
+      delayedNextScramble.resolve({
+        data: {
+          eventType: 'WCA_333',
+          scramble: 'STALE NEXT SCRAMBLE',
+        },
+      })
+      await delayedNextScramble.promise
+    })
+
+    expect(screen.getByText('FRESH SCRAMBLE')).toBeInTheDocument()
+    expect(screen.queryByText('STALE NEXT SCRAMBLE')).not.toBeInTheDocument()
+    expect(useCubeTimer).toHaveBeenLastCalledWith({ enabled: true })
+  })
+
   it('should_use_the_server_canonical_record_and_deduplicate_a_replayed_record_by_id', () => {
     const existing = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T12:00:00.000Z' })
     const replayed = createCanonicalRecord({ id: 101, createdAt: '2026-08-10T13:00:00.000Z' })
@@ -660,6 +765,27 @@ describe('TimerPage', () => {
     expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
   })
 
+  it('should_discard_the_in_memory_snapshot_after_explicit_logout_clears_its_pending_entry', async () => {
+    vi.mocked(saveRecord).mockRejectedValueOnce(new Error('응답을 받지 못했습니다.'))
+    const page = render(<TimerPage />)
+
+    expect(await screen.findByText('응답을 받지 못했습니다.')).toBeInTheDocument()
+    clearPendingTimerSolve(USER_ID)
+    timerState = createIdleTimer()
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: false,
+      currentUser: null,
+    })
+
+    page.rerender(<TimerPage />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+      expect(loadPendingTimerSolve(USER_ID).snapshot).toBeNull()
+      expect(saveGuestTimerRecord).not.toHaveBeenCalled()
+    })
+  })
+
   it('should_preserve_a_pending_snapshot_across_passive_auth_loss_and_recover_it_only_for_the_same_account', async () => {
     vi.mocked(saveRecord).mockRejectedValueOnce(new Error('응답을 받지 못했습니다.'))
     const page = render(<TimerPage />)
@@ -676,19 +802,28 @@ describe('TimerPage', () => {
     await waitFor(() => {
       expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
     })
-    page.unmount()
+    expect(screen.getByText('저장 대기 기록을 다시 저장하려면 같은 계정으로 로그인해주세요.')).toBeInTheDocument()
 
-    timerState = createIdleTimer({ restoreStoppedSolve: vi.fn() })
+    fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))
+
+    await waitFor(() => {
+      expect(saveRecord).toHaveBeenCalledTimes(1)
+      expect(saveGuestTimerRecord).not.toHaveBeenCalled()
+      expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+    })
+
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: true,
       currentUser: { userId: 2 },
     })
-    const otherAccountPage = render(<TimerPage />)
+    timerState = createIdleTimer({ restoreStoppedSolve: vi.fn() })
+    page.rerender(<TimerPage />)
 
-    await screen.findByText("R U R' U'")
-    expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
-    expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
-    otherAccountPage.unmount()
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '저장 재시도' })).not.toBeInTheDocument()
+      expect(saveGuestTimerRecord).not.toHaveBeenCalled()
+      expect(loadPendingTimerSolve(USER_ID).snapshot).toMatchObject(createCurrentPendingSnapshotExpectation())
+    })
 
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: true,
@@ -699,7 +834,7 @@ describe('TimerPage', () => {
       data: createCanonicalRecord(),
     })
 
-    render(<TimerPage />)
+    page.rerender(<TimerPage />)
 
     expect(await screen.findByRole('button', { name: '저장 재시도' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: '저장 재시도' }))

--- a/homeserver/docs/release-smoke-runbook.md
+++ b/homeserver/docs/release-smoke-runbook.md
@@ -91,7 +91,8 @@ homeserver/scripts/smoke-v2-1.sh destroy
 
 2. Keyboard Space 300ms hold, ready, start, stop을 확인한다. stopped display time과 saved Record raw time이 같다.
 3. Touch/Pen solve도 확인하고 API/Record에서 `inputMethod=TOUCH`인지 확인한다. Keyboard solve는 `KEYBOARD`여야 한다.
-4. NONE, PLUS_TWO, DNF와 delete를 실행하고 PB, ranking, Ao5/Ao12 결과를 확인한다. Ao5는 5 solves, Ao12는 12 solves 후 확인한다.
+4. authenticated save 뒤 next scramble 응답을 DevTools throttling으로 늦춘다. next scramble이 화면에 commit되기 전에는 이전 scramble로 Keyboard/Touch solve를 시작할 수 없어야 하며, statistics refresh가 늦어도 lock이 풀리면 안 된다.
+5. NONE, PLUS_TWO, DNF와 delete를 실행하고 PB, ranking, Ao5/Ao12 결과를 확인한다. Ao5는 5 solves, Ao12는 12 solves 후 확인한다.
 
 ### Pending recovery와 idempotency
 
@@ -101,6 +102,8 @@ homeserver/scripts/smoke-v2-1.sh destroy
 4. response loss 뒤 다른 tab/session에서 penalty를 PLUS_TWO 또는 DNF로 바꾸고 Retry한다. current canonical penalty/effective time을 받아들이고 pending이 제거되어야 한다.
 5. DevTools Application에서 current owner의 `cubing-hub.timer.pending.v1:*` value를 invalid JSON으로 바꾼 뒤 reload한다. Timer input은 locked이고 explicit Discard 후에만 다시 활성화되어야 한다.
 6. account A pending을 만든 뒤 logout/login으로 account B에 전환한다. B는 A pending을 보거나 Retry할 수 없어야 한다.
+7. save request의 401 뒤 refresh request를 DevTools에서 network failure로 만든다. passive sign-out 뒤에도 A의 pending은 남아야 하며, A가 다시 login하면 같은 UUID/payload로 Retry할 수 있고 canonical save 뒤에만 제거되어야 한다.
+8. WCA_333 history request를 늦춘 뒤 unsupported event로 전환한다. 늦은 WCA_333 response가 선택된 event 아래 Ao5/Ao12를 다시 표시하면 안 된다.
 
 ### Guest
 

--- a/homeserver/docs/release-smoke-runbook.md
+++ b/homeserver/docs/release-smoke-runbook.md
@@ -91,7 +91,7 @@ homeserver/scripts/smoke-v2-1.sh destroy
 
 2. Keyboard Space 300ms hold, ready, start, stop을 확인한다. stopped display time과 saved Record raw time이 같다.
 3. Touch/Pen solve도 확인하고 API/Record에서 `inputMethod=TOUCH`인지 확인한다. Keyboard solve는 `KEYBOARD`여야 한다.
-4. authenticated save 뒤 next scramble 응답을 DevTools throttling으로 늦춘다. next scramble이 화면에 commit되기 전에는 이전 scramble로 Keyboard/Touch solve를 시작할 수 없어야 하며, statistics refresh가 늦어도 lock이 풀리면 안 된다.
+4. authenticated save 뒤 next scramble 응답을 DevTools throttling으로 늦춘다. next scramble이 화면에 commit되기 전에는 이전 scramble로 Keyboard/Touch solve를 시작할 수 없어야 하며, statistics refresh가 늦어도 lock이 풀리면 안 된다. 요청 중 unsupported event를 선택했다가 WCA_333으로 돌아온 경우에도 fresh WCA_333 scramble이 commit된 뒤에만 Timer가 다시 활성화되고 늦은 이전 response는 화면을 덮어쓰면 안 된다.
 5. NONE, PLUS_TWO, DNF와 delete를 실행하고 PB, ranking, Ao5/Ao12 결과를 확인한다. Ao5는 5 solves, Ao12는 12 solves 후 확인한다.
 
 ### Pending recovery와 idempotency
@@ -102,7 +102,7 @@ homeserver/scripts/smoke-v2-1.sh destroy
 4. response loss 뒤 다른 tab/session에서 penalty를 PLUS_TWO 또는 DNF로 바꾸고 Retry한다. current canonical penalty/effective time을 받아들이고 pending이 제거되어야 한다.
 5. DevTools Application에서 current owner의 `cubing-hub.timer.pending.v1:*` value를 invalid JSON으로 바꾼 뒤 reload한다. Timer input은 locked이고 explicit Discard 후에만 다시 활성화되어야 한다.
 6. account A pending을 만든 뒤 logout/login으로 account B에 전환한다. B는 A pending을 보거나 Retry할 수 없어야 한다.
-7. save request의 401 뒤 refresh request를 DevTools에서 network failure로 만든다. passive sign-out 뒤에도 A의 pending은 남아야 하며, A가 다시 login하면 같은 UUID/payload로 Retry할 수 있고 canonical save 뒤에만 제거되어야 한다.
+7. save request의 401 뒤 refresh request를 DevTools에서 network failure로 만든다. passive sign-out 뒤에도 A의 pending은 남아야 하며, 인증이 없는 동안 Retry는 guest 저장이나 Record API 호출을 만들지 않고 same-account login이 필요하다고 안내해야 한다. A가 다시 login하면 같은 UUID/payload로 Retry할 수 있고 canonical save 뒤에만 제거되어야 한다.
 8. WCA_333 history request를 늦춘 뒤 unsupported event로 전환한다. 늦은 WCA_333 response가 선택된 event 아래 Ao5/Ao12를 다시 표시하면 안 된다.
 
 ### Guest


### PR DESCRIPTION
## Summary

- canonical save 뒤 next scramble이 commit될 때까지 Timer input을 잠금
- token refresh network failure 같은 passive auth loss에서 owner pending solve 보존
- event 변경 뒤 stale statistics/history response 무시
- authenticated-owner pending의 guest fallback 차단과 scramble transition lock 보강

## Final review findings

1. **Next scramble lock**
   - save success와 next scramble commit 사이의 old-scramble input window를 제거했습니다.
   - statistics refresh는 next scramble readiness와 독립적으로 background refresh합니다.

2. **Failed token refresh recovery**
   - access-token storage의 passive null transition은 auth state만 정리합니다.
   - explicit logout/session clear의 current-owner pending disposal policy는 유지합니다.
   - 동일 account 재로그인 recovery와 account B isolation을 regression test로 확인합니다.

3. **Stale statistics race**
   - request ID와 event/auth context guard로 obsolete statistics response를 무시합니다.

## Follow-up review findings

- `userId`가 있는 pending은 같은 account가 authenticated인 경우에만 Record API로 재시도합니다. unauthenticated Retry는 guest localStorage와 API를 모두 호출하지 않고 re-login 안내를 남깁니다.
- valid current-event scramble commit 자체가 next-solve transition lock을 해제합니다. stale/invalidated response, unsupported event, pending recovery, load failure는 lock을 해제할 수 없습니다.

## Tests

- focused TimerPage/AuthContext/useCubeTimer: 70 passed
- frontend lint, full tests: 37 files / 475 tests passed
- production frontend build passed
- `git diff --check` passed

## Compatibility

기존 pending/replay/immutable UUID and payload/recovered scramble/corrupt pending/account isolation/guest Timer contracts를 유지합니다. authenticated-origin solve는 guest 저장으로 전환되지 않습니다.

Backend API, Flyway, production Compose, deploy workflow, production runtime은 변경하지 않았습니다.

## Follow-up

merge 후 isolated smoke environment에서 next-scramble event transition, failed-refresh re-login recovery, statistics race의 manual targeted smoke가 필요합니다.