### PR TITLE
docs: design V2.2 growth and profile

### DIFF
--- a/docs/00-product/metrics.md
+++ b/docs/00-product/metrics.md
@@ -2,12 +2,13 @@
 doc_type: product
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
 related:
   - docs/00-product/prd.md
+  - docs/02-requirements/features/growth.md
 ---
 # Metrics
 
@@ -23,6 +24,19 @@ related:
 - 학습 콘텐츠 재방문과 단계 탐색
 - 게시글·댓글·Q&A의 건전한 참여
 - 향후 검증형 활동이 도입될 경우 제출 대비 검증 완료 비율
+
+## V2.2 Growth validation 후보
+
+V2.2는 숫자를 많이 노출하는 것보다 `Record → Improve → Profile → Practice`가 실제 행동으로 이어지는지 검증한다.
+
+- Record 저장 사용자의 My Growth 도달 비율
+- 첫 Growth 조회 뒤 7일 이내 재방문
+- Timer에서 Growth로 이동한 비율
+- Growth의 Next Practice action에서 Timer로 돌아간 비율
+- PB progression timeline/chart 확인
+- Growth 조회 전후 Practice Record 저장 빈도. 관찰 cohort 차이를 인과로 표현하지 않음
+
+최소 analytics event property와 사용자 인터뷰 질문은 [Growth 요구사항](../02-requirements/features/growth.md#product-validation)이 관리한다. Analytics infrastructure, target 수치와 retention 정책은 V2.2 application scope에 자동 포함하지 않는다.
 
 ## 품질·운영 지표
 

--- a/docs/00-product/prd.md
+++ b/docs/00-product/prd.md
@@ -2,7 +2,7 @@
 doc_type: product
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -11,6 +11,7 @@ related:
   - docs/00-product/roadmap.md
   - docs/01-domain/solve-model.md
   - docs/02-requirements/features/timer.md
+  - docs/02-requirements/features/growth.md
   - docs/02-requirements/user-flows.md
   - docs/06-quality/acceptance-criteria.md
   - docs/08-decisions/adr-0009-practice-event-capability.md
@@ -19,9 +20,9 @@ related:
 
 ## 상태
 
-제품 Vision과 V2.1 Foundation 범위, Practice event 지원 범위가 승인되어 이 문서는 현재 구현 계약인 `active`다. 사용자는 2026-08-10 현재 DB에 `records`와 `user_pbs` data가 없다고 확인했으며, 이 세션에서는 production query를 실행하지 않았다. 이 확인을 근거로 기존 data 분포 audit을 Event Support 결정의 blocker에서 제거했다.
+제품 Vision, V2.1 Foundation 범위와 Practice event 지원 범위는 현재 구현 계약으로 유지한다. V2.1 Event Support 결정에는 기존 data 분포 audit을 blocker로 두지 않았다.
 
-정확한 Java symbol, SQL, REST Docs와 frontend module은 구현에서 검증하지만, 그 세부 작업이 남았다는 이유만으로 아래 제품 요구사항을 미정으로 보지 않는다.
+V2.1은 main에 병합됐고 release workflow가 성공했다. V2.2 Growth & Profile은 별도 `draft`이며 아래 V2.1 current contract를 변경하지 않는다.
 
 ## Product Definition
 
@@ -207,6 +208,18 @@ V2.1은 다음 기능을 구현하지 않고, 나중에 추가할 때 현재 Rec
 2. V2.1 Practice Timer·Scramble·Record·Ranking event를 WCA_333으로 확정했다.
 3. Input Method, idempotency, canonical create response와 pending recovery의 API·data·architecture 계약을 문서화했다.
 4. forward-only additive migration, old application compatibility와 실제 MySQL upgrade test 방식을 확정했다.
-5. Record Foundation과 Timer Foundation은 각각 별도 branch와 dev PR로 구현·통합됐다. dev → main 전에는 integrated Validate와 release smoke checklist를 다시 확인한다.
+5. Record Foundation과 Timer Foundation, recovery·isolated smoke·final review correction이 dev에 통합됐다.
+6. [PR #15](https://github.com/xxh3898/cubing-hub/pull/15)로 dev가 main에 병합됐고 main SHA `b8e243ed65dd016772ffe928d3675979842383e7`의 [Publish and Deploy workflow](https://github.com/xxh3898/cubing-hub/actions/runs/31442512749)가 성공했다. Public URL smoke는 release workflow와 별도 evidence로 관리한다.
 
-제품·기술 결정 gate는 닫혔다. 구현 뒤 발견되는 acceptance defect는 기존 제품 범위를 넓히지 않는 별도 corrective change로 해소한 뒤 release gate를 다시 판단한다.
+V2.1 제품·기술 결정과 release gate는 닫혔다. 이후 발견되는 acceptance defect는 기존 제품 범위를 넓히지 않는 별도 corrective change로 다룬다.
+
+## V2.2 Design Boundary
+
+V2.2는 current Record를 성장 이해와 장기 활동 이력으로 연결하는 다음 제품 단계다. 범위와 metric은 아직 구현 계약이 아니며 다음 `draft`에서 관리한다.
+
+- [Growth 요구사항](../02-requirements/features/growth.md)
+- [Growth Metric Contract](../01-domain/growth-metrics.md)
+- [Growth Architecture](../03-architecture/growth-architecture.md)
+- [Proposed ADR-0010](../08-decisions/adr-0010-current-record-growth-read-contract.md)
+
+V2.2 설계는 Daily Challenge, Verified Record, Competition과 Organizer를 포함하지 않는다.

--- a/docs/00-product/roadmap.md
+++ b/docs/00-product/roadmap.md
@@ -2,7 +2,7 @@
 doc_type: product
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -10,14 +10,17 @@ related:
   - docs/00-product/vision.md
   - docs/00-product/prd.md
   - docs/00-product/market-validation.md
+  - docs/02-requirements/features/growth.md
 ---
 # Roadmap
 
 ## 상태
 
-단계 순서와 선행 관계는 2026-08-10 사용자 결정으로 승인됐다. 출시 날짜, sprint 수, 월별 일정, 미래 기능의 상세 범위와 시장 검증 결과는 확정되지 않았으므로 `draft`를 유지한다.
+단계 순서와 선행 관계는 제품 기준으로 유지한다. 출시 날짜, sprint 수, 월별 일정, 미래 기능의 상세 범위와 시장 검증 결과는 확정하지 않았으므로 `draft`를 유지한다.
 
-이 문서는 일정 약속이 아니라 제품·기술 gate의 순서를 관리한다.
+일정 약속이 아니라 제품·기술 gate의 순서를 관리한다.
+
+V2.1은 main에 병합됐고 release workflow가 성공했다. V2.2는 [Growth 요구사항](../02-requirements/features/growth.md)과 관련 `draft`를 정리하는 단계이며 구현·출시가 확정되지 않았다. Release workflow 결과는 public URL smoke를 대신하지 않는다.
 
 ## 단계 순서
 
@@ -36,7 +39,7 @@ V2.1 Timer / Record Foundation
 | Phase | Goal | Why now | Dependencies | In scope concept | Explicitly not included | Exit criteria |
 | --- | --- | --- | --- | --- | --- | --- |
 | V2.1 Timer / Record Foundation | Practice solve의 시간·입력·저장·조회 계약 안정화 | 이후 Growth와 Participation이 신뢰할 Record 기반 필요 | current Timer/Record 조사와 accepted product·domain decision | canonical time, WCA_333 Practice capability, input provenance, idempotency, pending solve, history·average, migration upgrade test | Session, Daily Challenge, device 연결, verification, competition | [PRD](prd.md)의 V2.1 acceptance와 migration·API compatibility gate 충족 |
-| V2.2 Growth & Profile | Record를 성장 이해와 장기 활동 이력으로 연결 | Core Loop의 Record → Improve → Profile 구간 강화 | V2.1 canonical Record와 event별 history | trend, PB progression, event별 성장·profile 표현의 검증 가능한 최소 범위 | challenge, verification, competition 운영 | 사용자가 성장 변화와 다음 Practice 행동을 이해하는지 검증 가능 |
+| V2.2 Growth & Profile | Record를 성장 이해와 장기 활동 이력으로 연결 | Core Loop의 Record → Improve → Profile 구간 강화 | V2.1 canonical Record와 event별 history | [Growth draft](../02-requirements/features/growth.md)의 current performance, direction, consistency, PB progression, activity, next Practice | challenge, verification, competition 운영 | 사용자가 성장 변화와 다음 Practice 행동을 이해하는지 검증 가능 |
 | V2.3 Daily Challenge | 같은 조건의 반복 참여 가설 검증 | Participate 가치를 낮은 운영 복잡도로 시험 | V2.1 Record 경계, V2.2 feedback, challenge 정책 결정 | issued scramble, cadence, attempt·submission의 최소 concept | Verified 판정, Competition·Organizer 전체 기능 | 반복 참여·retention 가설을 측정할 수 있고 abuse·timezone 경계가 정의됨 |
 | Validation Gate | V2.1~V2.3이 실제 Cuber 문제를 해결하는지 판단 | 신뢰·운영 비용이 큰 기능 전 증거 필요 | 사용자 인터뷰와 usage evidence | Growth, Daily Challenge, portability, verification 수요 평가 | 자동 다음 phase 진입 | 계속·수정·중단 결정과 근거가 기록됨 |
 | Verified Record PoC | 제한된 조건에서 evidence와 review 가치 검증 | 수요 확인 전 full verification system은 과도함 | Validation Gate 통과, privacy·retention·review 정책 | server-issued scramble, physical timer, one-take video, manual review 후보 검토 | WCA Official 표현, 범용 moderation platform | 제한된 PoC의 신뢰·운영비·privacy 결과가 평가됨 |

--- a/docs/01-domain/growth-metrics.md
+++ b/docs/01-domain/growth-metrics.md
@@ -1,0 +1,757 @@
+---
+doc_type: domain
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/00-product/roadmap.md
+  - docs/01-domain/solve-model.md
+  - docs/02-requirements/features/growth.md
+  - docs/02-requirements/features/profile.md
+  - docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+---
+# Growth Metrics
+
+## 문서 상태
+
+V2.2 Growth metric contract는 `draft`다. 아래 `MUST`, `SHOULD`, `NOT NOW`는 V2.2 proposal이며 current 구현이나 accepted contract를 뜻하지 않는다.
+
+```text
+Current
+- V2.1 Record, current PB projection, event history, Timer Ao5/Ao12
+
+V2.2 proposal
+- event별 private My Growth metric
+- current canonical Record 기준 재계산
+- 명명된 population과 시간 경계
+
+Future candidate
+- best Ao progression, pre-aggregation, user timezone
+
+Out of scope
+- Daily Challenge, Verification, Competition, device telemetry, AI coaching
+```
+
+## 사용자 질문과 MVP 연결
+
+| 사용자 질문 | V2.2 추천 답변 |
+| --- | --- |
+| 최근에 빨라지고 있는가 | 완료된 최근 7일 median과 직전 7일 median 비교, 최근 30일 daily median |
+| 현재 실력은 어느 정도인가 | current PB, recent Ao5, recent Ao12 |
+| PB는 어떻게 발전했는가 | current canonical Record에서 재구성한 PB progression |
+| 연습량은 늘었나 줄었나 | 7일·직전 7일·30일 solve count, 30일 daily solve count |
+| 기록의 안정성이 좋아졌는가 | latest 12와 previous 12의 interquartile range, DNF·PLUS_TWO count |
+| 다음 Practice 목표는 무엇인가 | current recent Ao12 이하의 다음 Ao12를 만드는 deterministic CTA |
+| 지금까지 얼마나 활동했는가 | event별 total solves, active days, first/latest recorded activity |
+
+## 공통 canonical contract
+
+### Population과 ordering
+
+- V2.2 public release의 지원 event는 `WCA_333` 하나다.
+- 모든 metric은 요청한 `eventType`의 현재 남아 있는 completed Practice Record만 사용한다.
+- chronological ordering은 `created_at ASC, id ASC`, recent ordering은 `created_at DESC, id DESC`다.
+- `created_at`은 실제 solve 발생 시각이 아니라 server persistence timestamp다. UI에서는 `기록된 시각`, `Practice 기록 활동`으로 표현한다.
+- Record 삭제와 penalty PATCH는 current canonical state를 바꾼다. 별도 audit가 없으므로 이전 상태를 복원한 history로 표현하지 않는다.
+
+### Effective result
+
+| Penalty | Metric value | Count policy |
+| --- | --- | --- |
+| `NONE` | `timeMs` | Record count와 rankable count에 포함 |
+| `PLUS_TWO` | `timeMs + 2000` | Record count와 rankable count에 포함, PLUS_TWO count 별도 표시 |
+| `DNF` | numeric value 없음 | Record count에는 포함, median·mean·percentile에서는 제외, DNF count 별도 표시 |
+
+`PLUS_TWO`의 2,000ms를 metric별로 다시 정의하지 않는다. Persistent `effective_time_ms`를 추가하지 않고 canonical raw time과 current penalty에서 계산한다.
+
+### Ao5와 Ao12
+
+Recent Ao5/Ao12는 V2.1의 Cubing Hub Practice rolling average를 그대로 사용한다.
+
+1. recent ordering의 같은 event Record 5개 또는 12개를 정확히 사용한다.
+2. `NONE`과 `PLUS_TWO`는 effective value를 사용한다.
+3. DNF 한 개는 worst로 제거할 수 있다.
+4. DNF가 두 개 이상이면 결과 status는 `DNF`다.
+5. best와 worst를 각각 한 개 제거한다.
+6. 나머지 산술평균을 integer millisecond로 반올림한다.
+
+Window가 부족하면 `INSUFFICIENT_DATA`, 계산 결과가 DNF면 `DNF`, 숫자 결과가 있으면 `AVAILABLE`로 구분한다. `null` 하나로 부족한 표본과 DNF를 합치지 않는다. 이 규칙을 WCA-compliant라고 표현하지 않는다.
+
+### Median
+
+Median은 이름이 지정된 population의 rankable effective value를 오름차순 정렬해 계산한다.
+
+- 홀수 `n`: 가운데 값
+- 짝수 `n`: 가운데 두 값의 산술평균을 integer millisecond로 반올림
+- DNF: numeric population에서 제외하고 같은 window의 DNF count/rate로 함께 제공
+
+`평균`이라는 일반 label 대신 `최근 7일 median`, `일별 median`처럼 population을 표시한다. 한국어 UI는 `중앙 기록`을 기본 label로 사용하고 tooltip에서 median 정의를 설명한다.
+
+### 기간과 timezone
+
+- persistence와 API instant는 UTC를 유지한다.
+- V2.2 activity day와 chart의 service boundary는 `Asia/Seoul`이다.
+- `asOfDate`는 response 생성 시점의 Asia/Seoul 날짜다.
+- 30-day chart/activity window는 `asOfDate - 29일` 00:00 inclusive부터 `asOfDate + 1일` 00:00 exclusive까지다. 오늘은 진행 중인 partial day임을 UI에 표시한다.
+- `last7DaysSolveCount`는 오늘을 포함한 7개 calendar date, `last30DaysSolveCount`는 오늘을 포함한 30개 calendar date다.
+- performance 비교는 partial day 편향을 피하기 위해 오늘을 제외한 완료 calendar day를 사용한다.
+
+```text
+recent period   = [asOfDate - 7일 00:00, asOfDate 00:00)
+previous period = [asOfDate - 14일 00:00, asOfDate - 7일 00:00)
+```
+
+Named user timezone과 V2.3 Daily Challenge timezone은 이 계약에 포함하지 않는다.
+
+### 기간 비교와 표본
+
+Performance period는 다음을 모두 만족할 때만 비교한다.
+
+- period 대표값은 해당 구간에 저장된 모든 rankable effective Record를 하나의 population으로 둔 median이다. Daily median들의 median이 아니다.
+- 각 period에 rankable Record 5개 이상
+- 각 period에 rankable Record가 있는 active day 2일 이상
+
+한쪽이 0건이면 `NO_DATA`, record는 있지만 기준보다 적으면 `INSUFFICIENT_SAMPLE`, 양쪽이 기준을 만족하면 `AVAILABLE`이다. 기록이 없는 날을 0ms solve로 넣거나 synthetic value로 보간하지 않는다.
+
+### Improvement 표현
+
+시간은 낮을수록 좋으므로 raw 증감률 대신 다음 공식을 사용한다.
+
+```text
+improvementPercent
+= (previousMedianMs - recentMedianMs) / previousMedianMs * 100
+```
+
+- 양수: `10.0% 빨라짐`
+- 음수: `10.0% 느려짐`
+- 0: `변화 없음`
+
+계산은 원래 millisecond 값으로 하고 표시는 소수점 한 자리로 반올림한다. 표본 수와 기간을 함께 표시하고 통계적 유의성이나 원인을 주장하지 않는다.
+
+### Recent consistency
+
+MVP의 consistency는 latest 12 Record와 바로 앞 previous 12 Record를 비교한다.
+
+- 각 12-record window의 DNF·PLUS_TWO count를 보존한다.
+- rankable effective value가 8개 이상일 때만 Q1·Q3와 IQR을 계산한다.
+- percentile은 sorted values에서 index `(n - 1) * p`를 사용하고 양쪽 값 사이를 linear interpolation한 뒤 integer millisecond로 반올림한다.
+- `IQR = Q3 - Q1`이다. 작은 IQR은 기록 분포가 좁다는 뜻일 뿐 더 빠르다는 뜻은 아니다.
+- current와 previous window 모두 계산 가능할 때만 `NARROWER`, `WIDER`, `UNCHANGED`를 표시한다.
+
+UI label은 `표준편차`나 `안정성 점수`가 아니라 `최근 12회 기록 범위`를 사용하고 recent Ao12와 함께 보여 준다.
+
+## 분류 요약
+
+| 분류 | Metric |
+| --- | --- |
+| MUST | Current PB, PB progression, Recent Ao5, Recent Ao12, period median comparison, 30-day daily median, total/7-day/30-day/daily solve count, active days, first/latest activity, latest-12 IQR, latest-12 DNF/+2 rate, event-specific My Growth summary |
+| SHOULD | Best Ao5/Ao12, recent best/worst tooltip, Ao progression, compact public Profile after privacy validation |
+| NOT NOW | generic recent/all-time average, 7/30-day mean, rolling mean chart, streak, standard deviation, variance, best/worst spread, Growth Redis/pre-aggregation |
+
+## Record / Performance metric 평가
+
+### Current PB
+
+```text
+Metric: Current PB single
+User question: 내 가장 빠른 current Practice Record는 무엇인가?
+Value: 익숙하고 즉시 이해되며 Ranking과도 연결된다.
+Formula: user_pbs의 요청 event projection과 근거 Record의 effective time.
+Required data: user_id, event_type, user_pbs.best_time_ms, record_id, Record created_at/penalty/time_ms.
+DNF/+2 policy: DNF 제외, PLUS_TWO는 +2000ms.
+Time boundary: 기간 제한 없음. current retained Record 기준.
+Performance cost: user/event unique lookup과 Record join으로 작다.
+Potential misleading interpretation: PB 하나가 현재의 반복 가능한 실력을 대표한다고 오해할 수 있다.
+V2.2 recommendation: MUST. Recent Ao12와 나란히 표시한다.
+```
+
+### PB progression
+
+```text
+Metric: PB progression
+User question: 내 PB가 언제, 어떤 순서로 좋아졌는가?
+Value: 장기 성장 서사를 가장 직접적으로 보여 준다.
+Formula: chronological rankable Record를 순회하며 이전 running minimum보다 strictly lower인 point만 남긴다. 같은 effective time의 뒤 Record는 새 PB가 아니다.
+Required data: record id, event_type, time_ms, penalty, created_at.
+DNF/+2 policy: DNF 제외, PLUS_TWO effective time 사용.
+Time boundary: 전체 current retained history. created_at은 recorded time이다.
+Performance cost: DB window scan O(N), response는 improvement point O(P).
+Potential misleading interpretation: penalty PATCH·삭제 이전에 보았던 immutable 역사로 오해할 수 있다.
+V2.2 recommendation: MUST. `현재 남아 있는 기록 기준` 안내와 함께 step chart/timeline으로 표시한다.
+```
+
+### Recent Ao5
+
+```text
+Metric: Recent Ao5
+User question: 바로 최근 짧은 solve 묶음의 결과는 어떤가?
+Value: Practice 직후 feedback이 빠르고 현재 Timer contract를 재사용한다.
+Formula: recent same-event Record 5개의 Cubing Hub Practice Ao5.
+Required data: 최신 5개 event Record의 time_ms, penalty, effective result, stable ordering.
+DNF/+2 policy: 공통 Ao contract.
+Time boundary: 날짜가 아니라 latest 5 Record.
+Performance cost: composite index reverse scan limit 5.
+Potential misleading interpretation: 표본이 작아 한두 solve에 민감하다.
+V2.2 recommendation: MUST. Recent Ao12보다 보조적으로 표시한다.
+```
+
+### Best Ao5
+
+```text
+Metric: Best Ao5
+User question: 지금까지 가장 좋은 5-solve 묶음은 무엇인가?
+Value: single PB보다 반복 성과를 보여 줄 수 있다.
+Formula: chronological same-event history의 모든 contiguous 5-record window에서 numeric Ao5 minimum.
+Required data: 전체 ordered Record history와 window 종료 Record id/created_at.
+DNF/+2 policy: 공통 Ao contract. DNF 결과 window는 best 후보에서 제외.
+Time boundary: 전체 current retained history.
+Performance cost: request마다 O(N) window scan이 필요하다.
+Potential misleading interpretation: current form이 아니라 과거 최고 순간으로 읽힐 수 있다.
+V2.2 recommendation: SHOULD. MVP 이후 사용자 가치와 query cost를 확인하고 추가한다.
+```
+
+### Recent Ao12
+
+```text
+Metric: Recent Ao12
+User question: 내 현재 반복 가능한 3x3 성과는 어느 정도인가?
+Value: PB보다 안정적인 current performance anchor이며 다음 Practice 목표로 바로 연결된다.
+Formula: recent same-event Record 12개의 Cubing Hub Practice Ao12.
+Required data: 최신 12개 event Record.
+DNF/+2 policy: 공통 Ao contract.
+Time boundary: 날짜가 아니라 latest 12 Record.
+Performance cost: composite index reverse scan limit 12.
+Potential misleading interpretation: Session/WCA official average로 오해할 수 있다.
+V2.2 recommendation: MUST. `최근 12회`를 label에 명시한다.
+```
+
+### Best Ao12
+
+```text
+Metric: Best Ao12
+User question: 지금까지 가장 좋은 12-solve 묶음은 무엇인가?
+Value: 장기 profile 성과 후보로 single PB를 보완한다.
+Formula: 모든 contiguous 12-record window의 numeric Ao12 minimum.
+Required data: 전체 ordered Record history와 window 종료 point.
+DNF/+2 policy: 공통 Ao contract.
+Time boundary: 전체 current retained history.
+Performance cost: O(N) history scan과 window calculation.
+Potential misleading interpretation: current performance로 오해하거나 official result처럼 읽을 수 있다.
+V2.2 recommendation: SHOULD. Public Profile 도입과 함께 별도 검증한다.
+```
+
+### Recent average
+
+```text
+Metric: Recent average
+User question: 최근 평균은 얼마인가?
+Value: 쉬운 표현처럼 보이지만 population이 없으면 의미가 없다.
+Formula: 정의하지 않는다. Recent Ao12 또는 named 7-day median으로 대체한다.
+Required data: 선택한 population에 따라 달라진다.
+DNF/+2 policy: 미정 label 자체가 정책을 숨긴다.
+Time boundary: 미정.
+Performance cost: 구현보다 contract ambiguity가 더 큰 비용이다.
+Potential misleading interpretation: 최근 N, 기간, DNF 처리, mean/Ao를 사용자가 알 수 없다.
+V2.2 recommendation: NOT NOW. UI/API field로 `recentAverage`를 만들지 않는다.
+```
+
+### Median
+
+```text
+Metric: Median
+User question: outlier 영향을 줄인 기간 대표 기록은 무엇인가?
+Value: daily/period trend를 안정적으로 비교할 수 있다.
+Formula: named rankable population의 중앙값. 짝수면 가운데 두 값 평균 후 integer 반올림.
+Required data: effective time과 정확한 period/window.
+DNF/+2 policy: DNF numeric 제외+rate 병기, PLUS_TWO 반영.
+Time boundary: daily median 또는 완료 최근 7일 median처럼 명시.
+Performance cost: MySQL 8 window/native aggregate 또는 bounded server calculation.
+Potential misleading interpretation: DNF 제외 사실을 숨기면 실제 안정성을 과대평가할 수 있다.
+V2.2 recommendation: MUST. standalone 전체 median이 아니라 daily/7-day metric에 사용한다.
+```
+
+### Best / worst recent solve
+
+```text
+Metric: Best / worst recent solve
+User question: 최근 분포의 양 끝은 어디인가?
+Value: chart tooltip과 recent window 설명에 도움이 된다.
+Formula: 명시한 recent 12 Record의 rankable effective min/max.
+Required data: 최신 12개 Record.
+DNF/+2 policy: DNF는 worst numeric으로 만들지 않고 별도 count, PLUS_TWO 반영.
+Time boundary: latest 12 Record.
+Performance cost: recent window에서 O(12).
+Potential misleading interpretation: extreme 하나를 성장 또는 퇴보로 과대해석할 수 있다.
+V2.2 recommendation: SHOULD. primary card가 아닌 tooltip/detail로 제한한다.
+```
+
+### DNF rate
+
+```text
+Metric: DNF rate
+User question: 최근 solve를 완주하지 못한 비율은 어떤가?
+Value: median/IQR이 숨기는 실패를 보완한다.
+Formula: latest 12 Record의 DNF count / Record count * 100.
+Required data: recent Record penalty.
+DNF/+2 policy: DNF가 numerator이며 numeric time으로 바꾸지 않는다.
+Time boundary: latest 12 Record. window size와 numerator를 함께 표시.
+Performance cost: recent window에서 O(12).
+Potential misleading interpretation: 적은 표본의 percentage가 크게 흔들린다.
+V2.2 recommendation: MUST. `1/12 DNF`를 먼저, percentage는 보조로 표시한다.
+```
+
+### PLUS_TWO rate
+
+```text
+Metric: PLUS_TWO rate
+User question: 최근 +2 결과가 얼마나 자주 발생했는가?
+Value: effective performance와 solve execution discipline을 구분해 볼 단서다.
+Formula: latest 12 Record의 PLUS_TWO count / Record count * 100.
+Required data: recent Record penalty.
+DNF/+2 policy: PLUS_TWO는 effective time에도 반영하고 count에도 포함한다.
+Time boundary: latest 12 Record.
+Performance cost: recent window에서 O(12).
+Potential misleading interpretation: +2 원인을 측정하지 않으므로 원인 진단으로 표현할 수 없다.
+V2.2 recommendation: MUST. consistency detail에 count 중심으로 표시한다.
+```
+
+## Trend metric 평가
+
+### 최근 7일 평균
+
+```text
+Metric: 최근 7일 arithmetic mean
+User question: 최근 일주일 기록은 평균적으로 어떤가?
+Value: 익숙하지만 outlier와 volume 편향이 크다.
+Formula: 후보로 채택하지 않는다. 완료 최근 7일 median을 사용한다.
+Required data: 7일 effective records.
+DNF/+2 policy: DNF 제외 시 rate 병기가 필수, PLUS_TWO 반영.
+Time boundary: 오늘 제외 완료 7 calendar day.
+Performance cost: range aggregate.
+Potential misleading interpretation: 한 번의 매우 느린 solve와 하루의 많은 solve가 결과를 지배한다.
+V2.2 recommendation: NOT NOW. named median으로 대체한다.
+```
+
+### 최근 30일 평균
+
+```text
+Metric: 최근 30일 arithmetic mean
+User question: 한 달 동안의 대표 성과는 무엇인가?
+Value: 장기 요약은 가능하지만 현재 변화가 희석된다.
+Formula: 후보로 채택하지 않는다. 30-day daily median series를 사용한다.
+Required data: 30일 effective records.
+DNF/+2 policy: DNF 제외+rate, PLUS_TWO 반영.
+Time boundary: 30 calendar date.
+Performance cost: range aggregate.
+Potential misleading interpretation: 연습량이 많은 날짜와 오래된 기록이 current 상태를 가린다.
+V2.2 recommendation: NOT NOW.
+```
+
+### 이전 기간 대비 변화율
+
+```text
+Metric: Recent 7 completed days vs previous 7 completed days
+User question: 최근 performance가 직전 같은 길이의 기간보다 좋아졌는가?
+Value: 방향을 한 문장으로 전달한다.
+Formula: (previousMedianMs - recentMedianMs) / previousMedianMs * 100.
+Required data: 두 period의 effective records, active day, sample count.
+DNF/+2 policy: median은 DNF 제외, 각 period DNF count/rate 병기, PLUS_TWO 반영.
+Time boundary: 오늘을 제외한 연속 7일 두 구간, Asia/Seoul.
+Performance cost: 14-day range와 median calculation.
+Potential misleading interpretation: 인과나 통계적 유의성을 뜻하지 않으며 작은 표본은 왜곡된다.
+V2.2 recommendation: MUST. 최소 표본 gate와 `빨라짐/느려짐` 문구를 사용한다.
+```
+
+### Rolling average trend
+
+```text
+Metric: Rolling mean trend
+User question: solve마다 이동 평균이 어떻게 변했는가?
+Value: 부드러운 선을 제공한다.
+Formula: window N의 arithmetic mean.
+Required data: ordered history와 window 정책.
+DNF/+2 policy: DNF 처리에 따라 선 의미가 크게 달라진다.
+Time boundary: solve sequence.
+Performance cost: O(N), payload/시각 복잡도 증가.
+Potential misleading interpretation: smoothing이 실제 변동과 활동 공백을 숨긴다.
+V2.2 recommendation: NOT NOW. daily median line을 우선 검증한다.
+```
+
+### Daily median trend
+
+```text
+Metric: 30-day daily median trend
+User question: Practice한 날의 대표 기록이 최근 어떻게 움직였는가?
+Value: 날짜·활동량과 performance를 함께 이해할 수 있다.
+Formula: 각 Asia/Seoul date의 rankable effective median.
+Required data: 30-day created_at range, effective time, penalty.
+DNF/+2 policy: DNF-only day는 median null+DNF count, PLUS_TWO 반영.
+Time boundary: 오늘 포함 최근 30 calendar date.
+Performance cost: indexed range scan+날짜 group/window aggregate, response 최대 30 point.
+Potential misleading interpretation: 적은 solve의 날과 많은 solve의 날을 같은 point로 본다.
+V2.2 recommendation: MUST. point마다 record/rankable count를 tooltip에 표시한다.
+```
+
+### PB trend
+
+```text
+Metric: PB trend
+User question: 최고 기록이 장기적으로 어떻게 내려갔는가?
+Value: 장기 성장 서사다.
+Formula: PB progression과 동일하다.
+Required data: 전체 current canonical Record history.
+DNF/+2 policy: PB progression contract와 동일.
+Time boundary: 전체 recorded history.
+Performance cost: O(N) scan.
+Potential misleading interpretation: 별도 선을 추가하면 PB progression과 중복된다.
+V2.2 recommendation: MUST를 PB progression으로 충족하고 별도 metric/API는 만들지 않는다.
+```
+
+### Ao progression
+
+```text
+Metric: Ao5/Ao12 progression
+User question: single PB가 아니라 rolling performance가 어떻게 변했는가?
+Value: 실력의 지속적 변화를 보여 줄 수 있다.
+Formula: 모든 chronological contiguous window의 Ao 결과 또는 running best Ao point.
+Required data: 전체 ordered history.
+DNF/+2 policy: 공통 Ao contract.
+Time boundary: solve sequence와 window end created_at.
+Performance cost: O(N) 계산과 더 큰 payload.
+Potential misleading interpretation: rolling points가 강하게 겹치고 chart가 과밀해진다.
+V2.2 recommendation: SHOULD. MVP에서는 recent Ao와 daily median을 먼저 검증한다.
+```
+
+## Activity metric 평가
+
+### Total solves
+
+```text
+Metric: Event total solves
+User question: 이 event를 지금까지 얼마나 기록했는가?
+Value: 장기 활동량을 가장 단순하게 보여 준다.
+Formula: current retained user/event Record count, DNF 포함.
+Required data: user_id, event_type.
+DNF/+2 policy: 둘 다 completed Practice Record count에 포함.
+Time boundary: 전체 current retained history.
+Performance cost: composite index count.
+Potential misleading interpretation: 삭제한 Record와 다른 도구의 Practice는 포함하지 않는다.
+V2.2 recommendation: MUST. `저장된 기록`이라고 표현한다.
+```
+
+### 최근 7/30일 solve count
+
+```text
+Metric: Last 7/30 calendar-day solve count
+User question: 최근 Practice 기록량은 어느 정도인가?
+Value: 단기와 한 달 활동량을 함께 보여 준다.
+Formula: 오늘 포함 각 window의 user/event Record count.
+Required data: created_at range.
+DNF/+2 policy: 둘 다 count에 포함.
+Time boundary: Asia/Seoul calendar date, 오늘은 partial day.
+Performance cost: indexed range count.
+Potential misleading interpretation: 실제 연습했지만 저장하지 않은 solve는 보이지 않는다.
+V2.2 recommendation: MUST. exact date range 또는 `오늘 포함`을 표시한다.
+```
+
+### Daily solves
+
+```text
+Metric: Daily solve count
+User question: 어떤 날에 얼마나 Practice를 기록했는가?
+Value: 활동량 증가·감소와 공백을 시각적으로 확인한다.
+Formula: 각 Asia/Seoul date의 Record count.
+Required data: 30-day created_at range.
+DNF/+2 policy: 둘 다 count에 포함.
+Time boundary: 오늘 포함 최근 30 calendar date.
+Performance cost: indexed range+date group, response 30 point.
+Potential misleading interpretation: 저장 retry 지연은 실제 solve 날짜와 다를 수 있다.
+V2.2 recommendation: MUST. daily median response의 같은 date point에 포함한다.
+```
+
+### Active days
+
+```text
+Metric: Active days
+User question: 최근 한 달에 며칠 Practice Record를 남겼는가?
+Value: solve volume과 별개로 반복 빈도를 보여 준다.
+Formula: 30-day window에서 Record 1개 이상인 distinct Asia/Seoul date count.
+Required data: created_at.
+DNF/+2 policy: 둘 다 active day를 만든다.
+Time boundary: 오늘 포함 30 calendar date.
+Performance cost: date group 결과에서 O(30).
+Potential misleading interpretation: 저장 활동일이지 실제 모든 Practice 날짜가 아니다.
+V2.2 recommendation: MUST.
+```
+
+### Longest/current practice streak
+
+```text
+Metric: Longest/current practice streak
+User question: 연속으로 며칠 Practice했는가?
+Value: 반복 동기를 줄 수 있다.
+Formula: consecutive active Asia/Seoul dates.
+Required data: 전체 distinct activity date.
+DNF/+2 policy: 둘 다 active day를 만든다.
+Time boundary: service timezone과 day cutoff에 강하게 의존.
+Performance cost: 전체 date history scan 또는 별도 projection.
+Potential misleading interpretation: 휴식일을 실패로 만들고 V2.3 engagement policy와 불필요하게 결합한다.
+V2.2 recommendation: NOT NOW. notification system도 만들지 않는다.
+```
+
+### First record date
+
+```text
+Metric: First recorded Practice activity
+User question: Cubing Hub에 기록을 남기기 시작한 시점은 언제인가?
+Value: 장기 활동 이력의 시작점을 보여 준다.
+Formula: current retained user/event Record의 minimum created_at.
+Required data: created_at.
+DNF/+2 policy: 둘 다 포함.
+Time boundary: UTC instant 응답, Asia/Seoul 표시.
+Performance cost: index first entry 또는 aggregate.
+Potential misleading interpretation: 가입일·실제 큐빙 시작일이 아니며 첫 Record를 삭제하면 바뀐다.
+V2.2 recommendation: MUST. `첫 기록`으로만 표현한다.
+```
+
+### Latest activity
+
+```text
+Metric: Latest recorded Practice activity
+User question: 마지막으로 Practice Record를 남긴 때는 언제인가?
+Value: 자신의 최근 활동 context를 제공한다.
+Formula: current retained user/event Record의 maximum created_at.
+Required data: created_at.
+DNF/+2 policy: 둘 다 포함.
+Time boundary: UTC instant 응답, Asia/Seoul 표시.
+Performance cost: index reverse first entry.
+Potential misleading interpretation: 전체 서비스 활동이나 실제 solve 발생 시각으로 오해할 수 있다.
+V2.2 recommendation: MUST for private My Growth, public Profile에는 노출하지 않는다.
+```
+
+## Consistency metric 평가
+
+### 표준편차
+
+```text
+Metric: Standard deviation
+User question: 기록이 평균 주위에서 얼마나 퍼지는가?
+Value: 익숙한 통계량이지만 outlier와 population 선택에 민감하다.
+Formula: sample 또는 population 정의가 추가로 필요하다.
+Required data: named rankable window.
+DNF/+2 policy: DNF 별도 처리, PLUS_TWO 반영.
+Time boundary: window를 명시해야 한다.
+Performance cost: SQL aggregate는 가능하다.
+Potential misleading interpretation: 큐버가 숫자의 단위를 직관적으로 해석하기 어렵고 느린 outlier가 지배한다.
+V2.2 recommendation: NOT NOW. IQR을 먼저 사용한다.
+```
+
+### Percentile range
+
+```text
+Metric: Latest-12 interquartile range
+User question: 최근 기록의 가운데 절반이 얼마나 좁게 모였는가?
+Value: outlier 영향을 줄이면서 안정성 변화를 millisecond 폭으로 보여 준다.
+Formula: latest 12 Record의 rankable Q3-Q1, previous 12와 비교.
+Required data: latest 24 Record의 time_ms, penalty, ordering.
+DNF/+2 policy: rankable value는 PLUS_TWO 반영, DNF count 병기. 각 window rankable 8개 이상 필요.
+Time boundary: solve sequence window.
+Performance cost: index reverse scan limit 24와 O(24) application calculation.
+Potential misleading interpretation: 좁지만 느릴 수 있으므로 recent Ao12와 함께 봐야 한다.
+V2.2 recommendation: MUST. UI에서는 `최근 12회 기록 범위`로 설명한다.
+```
+
+### Best/worst spread
+
+```text
+Metric: Best/worst recent spread
+User question: 최근 가장 빠른 값과 느린 값 차이는 얼마인가?
+Value: 계산과 설명이 쉽다.
+Formula: recent N rankable max-min.
+Required data: recent N records.
+DNF/+2 policy: DNF를 numeric worst로 넣지 않으면 별도 표시가 필요하다.
+Time boundary: recent N.
+Performance cost: O(N) bounded.
+Potential misleading interpretation: extreme 두 개에 지나치게 민감하고 DNF 처리에 따라 왜곡된다.
+V2.2 recommendation: NOT NOW as headline metric. best/worst tooltip만 SHOULD다.
+```
+
+### Recent N variance
+
+```text
+Metric: Recent N variance
+User question: 최근 결과의 변동성이 달라졌는가?
+Value: 기계 계산에는 유용하지만 단위가 ms squared라 사용자 해석성이 낮다.
+Formula: named window의 variance.
+Required data: recent N rankable records.
+DNF/+2 policy: DNF 별도, PLUS_TWO 반영.
+Time boundary: recent N.
+Performance cost: bounded aggregate.
+Potential misleading interpretation: 숫자 크기를 실력이나 품질 점수로 오해하기 쉽다.
+V2.2 recommendation: NOT NOW.
+```
+
+## Profile metric 평가
+
+### Profile PB
+
+```text
+Metric: Profile PB
+User question: 이 사용자를 대표하는 현재 Practice PB는 무엇인가?
+Value: 기존 Ranking과 일관된 identity signal이다.
+Formula: Current PB와 동일.
+Required data: user_pbs와 Record.
+DNF/+2 policy: Current PB와 동일.
+Time boundary: current retained records.
+Performance cost: 작은 unique lookup.
+Potential misleading interpretation: verified 또는 WCA official result처럼 보일 수 있다.
+V2.2 recommendation: MUST in private My Growth. 신규 public Profile은 만들지 않고 기존 Ranking 노출만 유지한다.
+```
+
+### Profile best Ao5/Ao12
+
+```text
+Metric: Profile best Ao5/Ao12
+User question: single이 아닌 대표 best rolling performance는 무엇인가?
+Value: public/private 대표 성과 후보다.
+Formula: Best Ao5/Ao12와 동일.
+Required data: 전체 ordered history.
+DNF/+2 policy: 공통 Ao contract.
+Time boundary: current retained history.
+Performance cost: O(N) request scan 또는 future projection.
+Potential misleading interpretation: official average나 current form으로 오해할 수 있다.
+V2.2 recommendation: SHOULD, MVP public Profile에서는 제외한다.
+```
+
+### Profile total solves
+
+```text
+Metric: Profile total solves
+User question: 이 event의 저장 활동량은 얼마인가?
+Value: 장기 참여를 보여 준다.
+Formula: Event total solves와 동일.
+Required data: user/event Record count.
+DNF/+2 policy: 둘 다 포함.
+Time boundary: current retained history.
+Performance cost: index count.
+Potential misleading interpretation: 연습량 공개는 privacy와 비교 압박을 만든다.
+V2.2 recommendation: MUST private, public에는 노출하지 않는다.
+```
+
+### Profile activity period
+
+```text
+Metric: Profile activity period
+User question: 언제부터 언제까지 기록 활동을 했는가?
+Value: 장기 이력의 context다.
+Formula: first/latest current retained Record created_at.
+Required data: min/max created_at.
+DNF/+2 policy: 둘 다 포함.
+Time boundary: UTC instant, KST 표시.
+Performance cost: index endpoints.
+Potential misleading interpretation: 가입일·전체 큐빙 경력과 다르며 공개 시 privacy 문제가 있다.
+V2.2 recommendation: MUST private, public에는 노출하지 않는다.
+```
+
+### Event-specific summary
+
+```text
+Metric: Event-specific Growth summary
+User question: 선택 event에서 내 current 성과와 활동은 무엇인가?
+Value: 서로 다른 result kind와 event 기록을 섞는 오류를 막는다.
+Formula: 모든 하위 metric에 eventType predicate를 적용한다.
+Required data: event_type dimension과 Practice capability.
+DNF/+2 policy: 각 하위 metric contract.
+Time boundary: 각 하위 metric contract.
+Performance cost: composite index의 user/event prefix를 사용한다.
+Potential misleading interpretation: 지원하지 않는 event에 empty profile을 보여 줄 수 있다.
+V2.2 recommendation: MUST. WCA_333 외 요청은 400으로 거절한다.
+```
+
+### Recent improvement
+
+```text
+Metric: Profile recent improvement
+User question: 최근 완료 7일이 그 전 7일보다 빨라졌는가?
+Value: Profile 첫 화면에서 성장 방향을 요약한다.
+Formula: canonical improvementPercent와 direction.
+Required data: 두 period median과 sample metadata.
+DNF/+2 policy: period comparison contract.
+Time boundary: 완료 calendar period, Asia/Seoul.
+Performance cost: 14-day range aggregate.
+Potential misleading interpretation: 인과·장기 추세·유의성을 뜻하지 않는다.
+V2.2 recommendation: MUST private. 작은 표본이면 결과 대신 부족 이유를 표시한다.
+```
+
+### Current Practice activity
+
+```text
+Metric: Profile current Practice activity
+User question: 최근에 얼마나 자주, 얼마나 많이 기록했는가?
+Value: performance만 보지 않고 Practice 행동을 함께 이해한다.
+Formula: 7/30-day counts, 30-day active days와 daily series 조합.
+Required data: created_at와 event_type.
+DNF/+2 policy: 모두 activity count에 포함.
+Time boundary: 오늘 포함 Asia/Seoul calendar date.
+Performance cost: 30-day indexed range aggregate.
+Potential misleading interpretation: 저장된 Record만 관찰하며 실제 전체 연습량은 아니다.
+V2.2 recommendation: MUST private. public에는 노출하지 않는다.
+```
+
+## PB progression canonical interpretation
+
+V2.2 PB progression은 별도 snapshot/event table 없이 current Record history에서 재구성한다.
+
+```text
+canonical records ordered by created_at ASC, id ASC
+→ DNF 제외
+→ effective time 계산
+→ first rankable Record emit
+→ previous running minimum보다 strictly lower면 emit
+```
+
+Progression response point는 다음 field를 사용한다.
+
+- `recordId`
+- `timeMs`
+- `penalty`
+- `effectiveTimeMs`
+- `createdAt`
+
+`eventType`은 response root에 한 번 둔다. Endpoint가 한 event만 반환하므로 point마다 복제하지 않는다.
+
+Penalty가 나중에 PATCH되면 current penalty로 전체 progression을 다시 계산한다. DNF로 바뀐 Record는 point에서 사라질 수 있고 PLUS_TWO 변경은 이후 running minimum까지 바꿀 수 있다. Record가 삭제되면 그 point와 downstream progression도 달라질 수 있다. 이 behavior는 current PB 재계산과 일치한다.
+
+따라서 V2.2는 다음을 하지 않는다.
+
+- PB snapshot/event table 추가
+- 당시 penalty 상태나 삭제된 Record 복원 주장
+- `user_pbs` row history를 progression으로 오해
+- Redis ranking에 Growth history 저장
+
+Immutable history가 필요해지면 audit/event lifecycle, correction 표시, retention을 별도 설계한다.
+
+## V2.2 MVP metric units
+
+1. `Current performance`: Current PB + Recent Ao5 + Recent Ao12
+2. `Performance direction`: 완료 최근 7일 median vs 직전 7일 + 30-day daily median
+3. `Recent consistency`: latest 12 IQR + DNF/+2 count vs previous 12
+4. `PB progression`: current canonical PB step history
+5. `Practice activity`: 7/30-day count, active days, daily count, total, first/latest
+6. `Next Practice`: Recent Ao12가 있으면 그 값 이하의 다음 Ao12, 없으면 다음 Ao5 또는 첫 5 solves를 deterministic CTA로 제시
+
+Next Practice CTA는 coaching·prediction이 아니다. 새 metric을 만들지 않고 이미 계산한 current window를 다음 행동 문구로 연결한다.
+
+## 명시적 비범위
+
+- all-event combined Growth score
+- generic `averageTimeMs`를 V2.2 canonical metric으로 승격
+- Session, streak notification, Daily Challenge
+- Verified/Competition/WCA Official result 혼합
+- `occurred_at`, import/export, offline queue
+- user timezone setting
+- public activity timestamp·solve count·detailed trend
+- Growth용 Redis, snapshot table, materialized analytics platform

--- a/docs/02-requirements/features/growth.md
+++ b/docs/02-requirements/features/growth.md
@@ -1,0 +1,394 @@
+---
+doc_type: requirement
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/00-product/vision.md
+  - docs/00-product/roadmap.md
+  - docs/00-product/metrics.md
+  - docs/01-domain/growth-metrics.md
+  - docs/02-requirements/features/profile.md
+  - docs/03-architecture/growth-architecture.md
+  - docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+---
+# Growth
+
+## 문서 상태
+
+V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. application contract나 출시 약속이 아니다.
+
+```text
+Current
+- Timer의 recent Ao5/Ao12
+- private MyPage의 전체 요약, 최근 raw Record chart, history 관리
+- Ranking의 nickname과 event PB
+
+V2.2 proposal
+- private My Growth dashboard
+- event별 canonical Growth metric과 bounded aggregate API
+- next Practice로 돌아가는 명확한 action
+
+Future candidate
+- best Ao, Ao progression, opt-in public Profile
+
+Out of scope
+- Challenge, Verification, Competition, device/AI analytics
+```
+
+Metric 공식과 edge case는 [Growth Metrics](../../01-domain/growth-metrics.md), API·query·성능 제안은 [Growth Architecture](../../03-architecture/growth-architecture.md)가 기준이다.
+
+## 해결할 사용자 문제
+
+Primary User는 일상적으로 큐브를 반복 연습하며 기록 단축과 성장에 관심이 있다. V2.1은 solve를 신뢰할 수 있게 Record로 남기는 기반을 만들었지만, current MyPage의 전체 평균과 raw solve line만으로는 다음을 정확히 답하기 어렵다.
+
+- 최근에 빨라지고 있는가
+- current 반복 성과는 어느 정도인가
+- PB가 어떻게 발전했는가
+- 연습량과 안정성이 어떻게 달라졌는가
+- 다음 Practice에서 무엇을 목표로 할 것인가
+- Cubing Hub에 얼마나 오래 기록 활동을 남겼는가
+
+V2.2는 숫자가 많은 통계 화면이 아니라 `Record → Improve → Profile → Practice`를 연결하는 최소 read experience여야 한다.
+
+## 목표
+
+- 사용자가 3x3 Practice의 current performance, direction, consistency, activity를 한 화면에서 이해한다.
+- 모든 metric이 population, DNF/+2, time boundary, insufficient sample을 명시한다.
+- PB progression으로 장기 기록 서사를 제공한다.
+- 한 화면의 결과를 다음 Timer 행동으로 연결한다.
+- current Record Foundation과 event dimension을 재사용하고 schema·Redis를 불필요하게 확장하지 않는다.
+
+## 비목표
+
+- 모든 계산 가능한 통계 제공
+- current MyPage history 관리와 account 관리 제거
+- 신규 public Profile/visibility setting system
+- all-event combined score 또는 지원하지 않는 event의 empty dashboard
+- Session, streak reward·notification, Daily Challenge
+- `occurred_at`, import/export, multi-solve offline queue
+- Verified Record, Competition, Organizer
+- Stackmat, Smart Timer, Smart Cube telemetry
+- AI coaching 또는 자동 solve phase 분석
+- analytics infrastructure 구현
+
+## V2.2 MVP
+
+### 1. Current performance
+
+- 사용자 가치: PB 하나와 반복 가능한 최근 결과를 구분해 current skill을 이해한다.
+- metric contract: Current PB, Recent Ao5, Recent Ao12.
+- API: private Growth summary.
+- backend work: current `user_pbs` 조회와 latest 12 lightweight Record projection, canonical Ao calculator.
+- frontend work: 세 summary card, 부족/DNF status, Timer와 같은 시간 formatter.
+- data/migration impact: 없음.
+- tests: PB null/+2, Ao 부족/1 DNF/2 DNF, stable ordering, unsupported event.
+- risk: Ao를 official result 또는 session average로 오해할 수 있어 `최근 5회/12회`를 표시한다.
+
+### 2. Performance direction
+
+- 사용자 가치: 최근 완료 7일이 직전 7일보다 빨라졌는지와 30일 흐름을 함께 본다.
+- metric contract: 두 7-day median 비교와 30-day daily median.
+- API: Growth summary의 period comparison + Growth trend의 fixed 30-day points.
+- backend work: Asia/Seoul 경계를 UTC instant로 변환한 range query와 median aggregate.
+- frontend work: `빨라짐/느려짐/표본 부족` copy, daily median line chart.
+- data/migration impact: 없음.
+- tests: KST 자정, 빈 날, DNF-only day, 작은 표본, PLUS_TWO, partial today.
+- risk: descriptive comparison을 인과·통계적 유의성으로 표현하지 않는다.
+
+### 3. Recent consistency
+
+- 사용자 가치: 최근 가운데 기록 범위가 이전 12회보다 좁아졌는지 확인한다.
+- metric contract: latest 12와 previous 12의 IQR, DNF/+2 count.
+- API: private Growth summary.
+- backend work: latest 24 Record projection과 deterministic percentile calculator.
+- frontend work: `최근 12회 기록 범위` card와 previous comparison, recent Ao12 병치.
+- data/migration impact: 없음.
+- tests: percentile interpolation, rankable 8 미만, DNF/+2, 좁아짐/넓어짐/같음.
+- risk: 좁은 범위가 빠른 성과를 뜻하지 않으므로 별도 score/badge로 만들지 않는다.
+
+### 4. PB progression
+
+- 사용자 가치: 장기 성장 이력을 milestone으로 이해한다.
+- metric contract: current canonical Record의 strictly improving running minimum.
+- API: private PB progression endpoint.
+- backend work: MySQL 8 window query 또는 ordered projection scan으로 point만 반환.
+- frontend work: step chart와 접근 가능한 ordered timeline, current-state 안내.
+- data/migration impact: snapshot/event table 없이 재계산.
+- tests: tie, PLUS_TWO, DNF, penalty 변경·삭제 후 재구성, 동일 timestamp+ID ordering.
+- risk: immutable 과거로 오해할 수 있어 `현재 남아 있는 기록 기준`을 표시한다.
+
+### 5. Practice activity
+
+- 사용자 가치: 최근 Practice 기록량과 장기 활동 범위를 확인한다.
+- metric contract: event total, 오늘 포함 7/30-day count, previous 7-day count, 30-day active days/daily counts, first/latest recorded activity.
+- API: Growth summary + Growth trend daily point.
+- backend work: indexed count/min/max와 30-day date aggregate.
+- frontend work: activity cards와 daily bar chart, exact KST date/partial-today label.
+- data/migration impact: 없음.
+- tests: 0 records, DNF-only records, date boundary, deleted first/latest Record.
+- risk: 실제 모든 Practice가 아니라 Cubing Hub에 저장된 activity다.
+
+### 6. Next Practice action
+
+- 사용자 가치: 통계를 본 뒤 다음 행동을 선택한다.
+- metric contract: 새 예측 metric이 아니라 existing recent window를 사용하는 deterministic priority다.
+- API: 추가 field 불필요. summary data로 client가 표현한다.
+- backend work: 없음.
+- frontend work: Recent Ao12가 numeric이면 `다음 12회에서 {Ao12} 이하 만들기`; Ao12가 없고 Ao5가 있으면 `12회까지 기록 이어가기`; 5건 미만이면 `첫 Ao5 만들기`; Timer link 제공.
+- data/migration impact: 없음.
+- tests: 각 fallback과 `/timer` navigation.
+- risk: coaching으로 과장하지 않고 사용자가 무시할 수 있는 제안으로 둔다.
+
+## UX / Information Architecture 대안
+
+| 안 | Practice 직후 연결 | 복잡도 | 모바일/navigation | V2.3 확장 | 평가 |
+| --- | --- | --- | --- | --- | --- |
+| A. Timer 일부 + Profile Growth section | 즉시 보임 | Timer가 측정·저장·통계까지 과밀해짐 | 좁은 화면에서 solve flow를 방해 | Challenge와 Timer가 더 복잡해질 수 있음 | 비추천 |
+| B. 별도 Growth page + Profile summary | 명확한 전용 공간 | 새 route·top nav·mobile tab 위치 필요 | 현재 MyPage와 기능 중복 | 별도 activity hub 확장은 쉬움 | 장기 후보 |
+| C. My Page를 My Growth dashboard로 확장 | Timer CTA로 연결 가능 | 기존 summary/chart/history를 교체 | protected route와 account modal 재사용 | Challenge activity는 나중에 별도 aggregate로 연결 가능 | **추천** |
+
+### V2.2 proposal
+
+V2.2는 `/mypage` route를 유지하고 화면의 primary identity를 `My Growth`로 확장한다. Account 관리는 current modal을 유지하며, Record history/penalty/delete는 dashboard 아래에 둔다. Timer에는 Ao5/Ao12와 작은 `내 성장 보기` link만 두고 Growth chart를 복제하지 않는다.
+
+이 선택은 새 navigation item을 추가하지 않고 current MyPage와 Recharts를 재사용한다. V2.3 Daily Challenge는 Growth metric이나 `records`에 섞지 않고 나중에 별도 activity section으로 연결할 수 있다.
+
+## Text wireframe
+
+```text
+My Growth                                      [3x3x3]
+내 Practice 기록을 바탕으로 현재 성장 흐름을 확인합니다.
+
+[Current PB]        [Recent Ao5]       [Recent Ao12]
+[19.780]             [20.412]           [20.965]
+
+Next Practice
+----------------------------------------------------
+다음 12회에서 Ao12 20.965 이하를 만들어보세요. [Timer 시작]
+
+Performance Direction
+----------------------------------------------------
+최근 완료 7일 중앙 기록 20.100
+직전 7일 21.350보다 5.9% 빨라짐 · 표본 24 / 18
+[30-day daily median line chart]
+
+Recent Consistency
+----------------------------------------------------
+최근 12회 기록 범위 1.820초 · 이전 12회보다 0.430초 좁아짐
+DNF 1/12 · +2 1/12
+
+PB Progression
+----------------------------------------------------
+[PB step chart]
+23.410 → 21.820 → 20.150 → 19.780
+[접근 가능한 milestone list]
+
+Practice Activity
+----------------------------------------------------
+[7일 42회] [직전 7일 31회] [30일 126회] [활동일 12일]
+[30-day daily activity bar chart]
+전체 438회 · 첫 기록 2026-04-22 · 최근 기록 2026-08-11
+
+Record History
+----------------------------------------------------
+[기존 pagination / penalty / delete]
+```
+
+Empty state는 빈 card를 여러 개 만들지 않고 다음 단계 하나를 제시한다.
+
+- 0 records: 첫 Practice를 시작하는 Timer CTA
+- 1~4 records: PB와 activity만 표시하고 첫 Ao5까지 남은 수 안내
+- 5~11 records: Ao5와 Ao12까지 남은 수 안내
+- period sample 부족: chart raw point와 count는 보여 주되 improvement 문구는 숨김
+- DNF-only: count와 DNF 상태를 보여 주고 numeric trend를 만들지 않음
+
+## Chart 결정
+
+현재 frontend에 Recharts `3.8.1`이 설치돼 있고 MyPage에서 `ResponsiveContainer`, `LineChart`, `Tooltip`을 사용한다. V2.2에 새 chart dependency는 필요하지 않다.
+
+### 30-day daily median line
+
+- x-axis: Asia/Seoul `YYYY-MM-DD`, 모바일에서는 5~7개 tick만 표시
+- y-axis: effective millisecond를 formatted time으로 표시, `낮을수록 빠름` 안내
+- sample size: 최대 30 date point, tooltip에 record/rankable/DNF/+2 count
+- missing day: `medianTimeMs=null`, 선을 연결하지 않고 0으로 만들지 않음
+- DNF-only day: null point와 tooltip의 DNF count
+- timezone: response의 `Asia/Seoul`
+- responsive: fixed 240~280px height, horizontal scroll 없이 tick 수를 줄임
+
+### PB step chart
+
+- x-axis: progression point `createdAt`을 Asia/Seoul date로 표시
+- y-axis: effective millisecond
+- sample size: improvement point만 사용
+- missing day: 개념 없음. 다음 PB까지 step 유지
+- DNF: progression point가 될 수 없음
+- responsive: point가 적으면 timeline을 우선, 많으면 tick 축약
+- accessibility: chart만 제공하지 않고 chronological text list를 함께 제공
+
+### Daily activity bar
+
+- x-axis: daily median과 같은 30 date
+- y-axis: Record count, DNF 포함
+- missing day: 높이 0 bar
+- timezone: Asia/Seoul
+- responsive: day label 축약, tooltip에 exact date와 penalty count
+
+### 보류 chart
+
+- Sparkline: summary card에 의미·축·표본을 숨기므로 MVP에서는 사용하지 않는다.
+- Raw solve line: 현재 MyPage chart는 outlier와 irregular activity를 그대로 연결한다. 상세 drill-down 후보로 남기고 canonical Growth trend로 사용하지 않는다.
+- Rolling Ao chart: overlapping window와 DNF 표현이 복잡해 MVP 이후 검증한다.
+
+## My Growth와 Public Profile
+
+| 항목 | My Growth | Public Profile |
+| --- | --- | --- |
+| 접근 | authenticated owner only | V2.2 신규 route/API 없음 |
+| nickname | 표시·수정 | 기존 Ranking에서 이미 공개 |
+| Current PB | 표시 | 기존 Ranking PB만 유지 |
+| Recent Ao/trend/IQR | 표시 | 공개하지 않음 |
+| total/7/30-day solve count | 표시 | 공개하지 않음 |
+| first/latest activity | 표시 | 공개하지 않음 |
+| Record history·scramble·input method | owner 관리 | 공개하지 않음 |
+
+### Privacy proposal
+
+- Practice 횟수는 경쟁 실력과 다른 행동 정보이므로 default public으로 만들지 않는다.
+- 최근 활동 시각은 생활 패턴을 드러낼 수 있어 공개하지 않는다.
+- 상세 trend와 consistency는 공개 가치가 확인되지 않았고 비교 압박을 만들 수 있어 private로 둔다.
+- visibility setting system은 V2.2 문제 해결의 prerequisite가 아니다.
+- 신규 public Profile을 만들지 않으면 privacy setting 없이도 안전한 최소 범위를 유지할 수 있다.
+
+Future public Profile을 검토할 때는 stable user identifier, block/deleted-user behavior, opt-in 또는 visibility policy를 먼저 결정한다. nickname과 PB만 보여 주는 화면은 현재 Ranking 이상의 사용자 가치가 있는지도 검증해야 한다.
+
+## Event 정책
+
+- V2.2 public release는 `WCA_333` Growth만 지원한다.
+- UI selector는 supported Practice event만 보여 준다. current `mainEvent`가 미지원 legacy value이면 WCA_333을 fallback으로 사용하되 해당 event의 fake empty dashboard를 만들지 않는다.
+- API는 `eventType`을 유지해 future event 추가가 response/schema rewrite를 요구하지 않게 한다.
+- known but unsupported event는 기존 capability policy대로 400을 반환한다.
+- Result Kind와 capability 승인 없이 other EventType을 time metric에 넣지 않는다.
+
+## Acceptance와 release gate
+
+### Metric correctness
+
+- DNF, PLUS_TWO, tie, deletion, penalty PATCH와 stable ordering fixture가 domain contract와 일치한다.
+- 부족한 표본, DNF result, numeric result가 서로 다른 status로 표현된다.
+- chart와 summary가 동일한 `generatedAt`, `asOfDate`, timezone 의미를 사용한다.
+- PB progression이 current `user_pbs` PB와 같은 final point를 갖는다.
+
+### API/Data
+
+- Growth endpoint는 authenticated owner의 WCA_333 data만 반환한다.
+- unsupported/invalid event와 인증 실패 contract를 REST Docs로 검증한다.
+- summary/trend는 bounded payload이며 frontend에 전체 history를 보내지 않는다.
+- 10,000-record fixture에서 query plan과 row scope를 기록한다. 100,000-record case는 stress evidence이며 실제 blocker threshold는 baseline 측정 후 정한다.
+- V2.2 release note에는 migration이 없음을 기록한다. Production row count는 release criterion으로 사용하지 않는다.
+
+### Frontend
+
+- loading, error, empty, insufficient, numeric, DNF state를 구분한다.
+- desktop/mobile에서 chart, tooltip, text alternative, Timer CTA와 history 관리가 동작한다.
+- current Timer save/penalty/delete 뒤 Growth refresh가 canonical server result와 일치한다.
+- 새 chart dependency를 추가하지 않는다.
+
+### CI와 smoke
+
+- 각 implementation PR의 focused backend/frontend test와 generated REST Docs를 통과한다.
+- `dev` push와 `dev → main` PR Validate의 required job이 성공한다.
+- release candidate에서 keyboard/touch save → Growth, penalty/delete → PB progression 재계산, KST boundary, mobile layout을 targeted smoke한다.
+- build/CI 성공을 production request 성공으로 표현하지 않는다. main merge/deploy는 별도 승인과 release gate를 따른다.
+
+## Product validation
+
+### 출시 후 볼 행동 지표
+
+- `Growth page reach`: Record를 가진 주간 사용자 중 My Growth를 본 비율
+- `Growth revisit`: 첫 조회 뒤 7일 이내 다시 본 사용자 비율
+- `Timer → Growth`: Timer 저장 또는 Timer 화면에서 My Growth로 이동한 비율
+- `Growth → Timer`: Next Practice CTA를 통해 Timer로 돌아간 비율
+- `PB progression interaction`: progression tooltip/timeline을 확인한 비율
+- `Practice continuation`: Growth 조회 cohort와 미조회 cohort의 이후 7일 Record 저장 빈도. 인과로 단정하지 않고 표본·selection bias를 기록
+
+### 최소 analytics event 후보
+
+Analytics infrastructure는 V2.2에 포함하지 않는다. 향후에도 raw time, scramble, Record ID를 event payload에 넣지 않는다.
+
+| Event | 최소 property | 목적 |
+| --- | --- | --- |
+| `growth_viewed` | `eventType`, `entryPoint`, `sampleState` | reach와 entry path |
+| `growth_revisited` | `eventType`, `daysSinceFirstViewBucket` | revisit |
+| `growth_pb_progression_opened` | `eventType`, `pointCountBucket` | progression 가치 |
+| `growth_practice_cta_clicked` | `eventType`, `targetType` | Growth → Practice 연결 |
+| `practice_record_saved` | `eventType`, `origin` | 이후 Practice 행동과 연결. 실제 time은 수집하지 않음 |
+
+### 사용자 인터뷰 질문
+
+1. 지금은 기록이 빨라지고 있는지 어떤 방식으로 확인하는가?
+2. PB와 최근 Ao12 중 현재 실력을 더 잘 설명한다고 느끼는 것은 무엇이며 왜 그런가?
+3. 최근 7일 중앙 기록과 직전 7일 비교가 이해되는가? 어떤 표현이 더 자연스러운가?
+4. 기록이 없는 날을 chart의 빈칸으로 보는 것이 이해되는가?
+5. `최근 12회 기록 범위`가 안정성을 이해하는 데 도움이 되는가, 아니면 복잡한가?
+6. PB progression에서 가장 보고 싶은 정보는 time, 날짜, penalty 중 무엇인가?
+7. 연습량에서 solve count, active days, streak 중 실제 행동을 바꾸는 정보는 무엇인가?
+8. Growth 화면을 본 뒤 다음 Practice 목표로 어떤 안내가 가장 유용한가?
+9. 다른 사람에게 공개해도 괜찮은 Profile 정보와 공개하고 싶지 않은 정보는 무엇인가?
+10. 이 화면이 기존 timer/statistics 도구를 보완하는가, 중복하는가?
+
+## Decision matrix
+
+| Decision | Options | V2.2 proposal | Why | Confidence | Blocks implementation? |
+| --- | --- | --- | --- | --- | --- |
+| V2.2 MVP metrics | 많은 통계 / 6 value units | Current, direction, consistency, PB, activity, next action | 사용자 7개 질문을 작은 묶음으로 충족 | High | No, default 사용 가능 |
+| Growth page location | Timer+Profile / 별도 page / MyPage 확장 | MyPage를 My Growth로 확장 | current route·chart·history·account 구조 재사용 | High | No |
+| Calculation | frontend full history / backend aggregate | backend canonical calculation | O(N) client transfer와 client drift 방지 | High | No |
+| PB progression | snapshot table / current history scan | current canonical history 재구성 | 현재 data로 충분하고 correction과 일치 | High | No |
+| Trend | 7/30 mean / rolling mean / daily median+7-day median | daily median+완료 7-day 비교 | population과 missing day를 명확히 표현 | Medium | No, 사용자 검증 필요 |
+| DNF | mean 제외 / infinity / rate only | median/IQR에서 제외하고 count/rate 병기, Ao는 V2.1 rule | metric 목적을 섞지 않음 | High | No |
+| Activity timezone | UTC / Asia/Seoul / user timezone | Asia/Seoul service day, instant는 UTC | current UI/Home 정책 재사용, user timezone은 과도 | High | No |
+| Public Profile | 상세 공개 / 최소 공개 / 신규 없음 | 신규 public Profile 없음 | privacy setting 없이 안전한 최소 범위 | Medium | No, default 사용 가능 |
+| API shape | history client 계산 / one large response / summary+series split | summary + trend + PB progression | initial payload·query·evolution 분리 | High | No |
+| Migration/index | covering index·snapshot / 없음 | V2.2 migration 없음 | 기존 user/event/date index가 최소 query 지원 | Medium | No, benchmark gate 필요 |
+
+## Open Questions
+
+### 1. 신규 Public Profile을 V2.2에 포함할 것인가
+
+```text
+Question: V2.2에서 다른 사용자가 여는 신규 Profile route/API를 만들 것인가?
+Why it matters: Practice count·activity time·trend 공개는 privacy와 stable identifier 계약을 만든다.
+Option A: My Growth만 구현하고 기존 Ranking nickname/PB 공개만 유지한다.
+Option B: nickname과 event PB만 보여 주는 최소 public Profile을 추가한다.
+Proposal: Option A. current Growth 범위에 집중하고 public Profile 가치를 별도로 검증한다.
+Default without a separate decision: Option A.
+```
+
+### 2. Legacy 전체 평균을 어떻게 전환할 것인가
+
+```text
+Question: current profile/home `averageTimeMs`를 V2.2에서 즉시 제거할 것인가?
+Why it matters: event·population이 없는 all-time mean은 V2.2 metric 원칙과 충돌하지만 existing consumer compatibility가 있다.
+Option A: UI에서는 제거하고 API field는 한 release 동안 유지·deprecated 처리한 뒤 별도 제거한다.
+Option B: API와 UI에서 같은 PR에 제거한다.
+Proposal: Option A. Growth API를 additive하게 도입하고 consumer 전환을 분리한다.
+Default without a separate decision: Option A.
+```
+
+### 3. Consistency 표현을 노출할 것인가
+
+```text
+Question: latest-12 IQR을 `최근 12회 기록 범위`로 MVP에 보여 줄 것인가?
+Why it matters: 안정성 질문에는 답하지만 처음 보는 사용자에게 복잡할 수 있다.
+Option A: Ao12 옆에 기록 범위와 DNF/+2 count를 짧게 표시한다.
+Option B: raw/daily trend만 제공하고 consistency card는 사용자 연구 뒤 추가한다.
+Proposal: Option A. 수학 용어와 score를 숨기고 previous 12와의 millisecond 차이만 설명한다.
+Default without a separate decision: Option A.
+```
+
+세 항목은 기본안으로 구현 계획을 막지 않는다. 기본안이 바뀌면 API payload, UI acceptance와 PR 분할을 다시 확인한다.

--- a/docs/02-requirements/features/profile.md
+++ b/docs/02-requirements/features/profile.md
@@ -2,7 +2,7 @@
 doc_type: requirement
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -11,6 +11,8 @@ related:
   - docs/01-domain/solve-model.md
   - docs/02-requirements/features/authentication.md
   - docs/02-requirements/features/timer.md
+  - docs/02-requirements/features/growth.md
+  - docs/01-domain/growth-metrics.md
 ---
 # Profile
 
@@ -22,12 +24,12 @@ related:
 
 - profile, 주 종목, 요약 통계 조회
 - 전체 Record history와 pagination
-- client에서 선택 event의 최근 기록 추세와 PB 표시
+- all-event 첫 page를 받은 뒤 client에서 선택 event의 최근 raw 기록 추세와 PB 표시
 - nickname과 주 종목 변경
 - 현재 비밀번호 확인 후 비밀번호 변경
 - Record penalty 수정과 삭제
 
-현재 summary의 average 의미와 event별 성장 지표는 V2.2에서 별도 제품 결정을 거쳐야 한다.
+현재 summary의 `averageTimeMs`는 all-event, all-time arithmetic mean이고 DNF를 제외한다. UI의 `전체 평균`은 population과 event가 충분히 드러나지 않으므로 V2.2 canonical Growth metric으로 재사용하지 않는다.
 
 ## 요구사항
 
@@ -54,3 +56,23 @@ related:
 - `occurred_at` 기반 chronology
 
 Growth, trend와 장기 activity history의 제품 범위는 [Roadmap](../../00-product/roadmap.md)의 V2.2에서 검증한다.
+
+## V2.2 Profile Proposal
+
+[Growth 요구사항](growth.md)의 `draft`를 따른다. 아래 범위는 current 구현이 아니다.
+
+### My Growth
+
+- authenticated owner만 current performance, trend, PB progression, activity와 Record history를 본다.
+- `/mypage`를 새 top-level route 없이 My Growth dashboard로 확장한다.
+- Account 관리와 Record penalty/delete는 current 기능을 유지한다.
+- Full Record history를 client metric 계산용으로 전송하지 않고 private Growth aggregate API를 사용한다.
+
+### Public Profile
+
+- V2.2 MVP에서 신규 public Profile route/API를 만들지 않는다.
+- Existing Ranking의 nickname과 event PB 공개 범위만 유지한다.
+- Practice count, first/latest activity, detailed trend, DNF/+2와 consistency를 공개하지 않는다.
+- 따라서 V2.2 문제 해결을 위해 full visibility setting system을 선구현하지 않는다.
+
+Public Profile이 future scope로 승인되면 stable user identifier, opt-in/visibility, deleted/blocked user와 activity privacy를 먼저 결정한다.

--- a/docs/03-architecture/growth-architecture.md
+++ b/docs/03-architecture/growth-architecture.md
@@ -1,0 +1,663 @@
+---
+doc_type: architecture
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/01-domain/growth-metrics.md
+  - docs/02-requirements/features/growth.md
+  - docs/02-requirements/features/profile.md
+  - docs/03-architecture/backend-architecture.md
+  - docs/03-architecture/frontend-architecture.md
+  - docs/04-data/data-dictionary.md
+  - docs/04-data/erd.md
+  - docs/04-data/migration-policy.md
+  - docs/05-api/conventions.md
+  - docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+---
+# Growth Architecture
+
+## 문서 상태와 경계
+
+V2.2 Growth & Profile architecture는 `draft`다. endpoint, Java type, SQL, schema가 current 구현이라는 뜻이 아니다. 구현 시 exact request·response는 Spring REST Docs test가 Source of Truth가 된다.
+
+```text
+Current
+- private profile summary와 paginated Record history
+- MySQL records·user_pbs Source of Truth
+- WCA_333 event-filtered history와 stable ordering
+- Timer client의 recent Ao5/Ao12
+- Redis ranking read model
+
+V2.2 proposal
+- private server-side Growth read API
+- bounded summary와 30-day series
+- current Record 기반 paginated PB progression
+- MySQL request-time aggregate, no migration, no Growth Redis
+
+Future candidate
+- observed cost에 근거한 PB progression cache/projection
+- additional supported event와 user timezone
+- opt-in public Profile read contract
+
+Out of scope
+- application implementation, Flyway, Redis key, analytics platform
+- Challenge, Verification, Competition lifecycle 통합
+```
+
+## Current implementation
+
+### Record와 PB
+
+현재 `records`는 completed Practice solve를 저장한다.
+
+| 값 | Current source | Growth 의미 |
+| --- | --- | --- |
+| id | `records.id` | 같은 timestamp의 stable tie-break와 progression point identity |
+| user | `records.user_id` | authenticated owner scope |
+| event | `records.event_type` | 모든 metric의 dimension. public capability는 WCA_333만 지원 |
+| raw time | `records.time_ms` | penalty 전 canonical integer millisecond |
+| penalty | `NONE`, `PLUS_TWO`, `DNF` | current effective result 계산 |
+| scramble | `records.scramble` | history detail에는 필요하지만 Growth aggregate에는 불필요 |
+| input method | `records.input_method` | provenance이며 Growth performance dimension이 아님 |
+| recorded time | `records.created_at` | UTC instant 의미의 server persistence timestamp |
+
+Effective result는 persistent column이 아니다.
+
+```text
+NONE     -> time_ms
+PLUS_TWO -> time_ms + 2000
+DNF      -> numeric result 없음
+```
+
+`user_pbs`는 사용자·event별 current PB와 source Record를 보유하는 MySQL projection이다. Record create, penalty PATCH와 delete 뒤 재계산된다. Redis `ranking:v2:*`는 전체 Ranking 조회를 위한 rebuild 가능한 Read Model이며 Growth 통계의 Source of Truth가 아니다.
+
+### Current read API와 client calculation
+
+- `GET /api/users/me/records`는 optional `eventType`, 1-based page, `created_at DESC, id DESC` ordering을 제공한다.
+- page size 상한은 100이다.
+- `GET /api/users/me/profile`의 `totalRecords`와 `averageTimeMs`는 모든 event를 섞는다. average는 DNF를 제외한 all-time arithmetic mean이며 population이 UI label에 드러나지 않는다.
+- Timer는 WCA_333 recent 12 Record를 받아 Ao5/Ao12를 frontend에서 계산한다.
+- MyPage는 all-event 첫 100 Record를 받은 뒤 client에서 event filter하고 최근 30 raw result line을 그린다. 이는 bounded transfer이지만 mixed event나 100개 밖의 target event가 있으면 Growth population으로 정확하지 않다.
+- public user Profile route/API는 없다. Ranking은 nickname, event와 PB를 보여 주지만 stable public user profile contract를 제공하지 않는다.
+
+따라서 current history API를 canonical Growth 계산에 그대로 사용하는 것은 client별 metric drift와 불필요한 Record payload를 만든다. 기존 endpoint는 Record 관리와 detail pagination에 유지하고 Growth는 별도 read contract로 둔다.
+
+## Current data 계산 가능성
+
+| 질문 | 현재 data로 가능한가 | 조건과 한계 |
+| --- | --- | --- |
+| PB progression 재구성 | 가능 | current penalty와 retained Record 기준이다. 삭제·수정 전 immutable 과거는 복원할 수 없음 |
+| 최근 7/30/90일 Practice trend | 가능 | `created_at` UTC range를 사용할 수 있음. V2.2 UI/API는 7-day comparison과 30-day series만 채택하고 90일은 future 후보 |
+| `created_at`을 activity timestamp로 사용 | 조건부 가능 | actual solve occurrence가 아니라 Cubing Hub에 기록된 Practice activity라고 명시. `occurred_at`은 prerequisite가 아님 |
+| historical Ao5/Ao12 progression | 계산 가능 | 모든 chronological contiguous window가 필요해 O(N). Recent Ao만 MVP, best/Ao progression은 SHOULD |
+| solve count·daily count·mean/median·trend | 가능 | entity 전체 load 대신 indexed range와 SQL aggregate/projection 사용. Generic mean은 제품 이유로 채택하지 않음 |
+| best Ao5/Ao12 | 계산 가능 | ordered history O(N) 또는 future projection 필요. Current data 부족 문제가 아니라 MVP 가치·비용 우선순위 문제 |
+| recent Ao5/Ao12·IQR | 가능 | latest 24 lightweight row면 충분 |
+| current PB | 가능 | `user_pbs` unique projection 재사용 |
+
+`scramble`, `input_method`와 submission identity는 Growth aggregate 계산에 필요하지 않다. Detail history가 이미 제공하므로 summary payload에 복제하지 않는다.
+
+## API 접근 대안
+
+| 안 | 장점 | 비용·위험 | 판단 |
+| --- | --- | --- | --- |
+| A. history API에서 frontend 계산 | backend endpoint 추가가 적음 | 최대 100 page 제한, O(N) transfer, client별 DNF/timezone drift, scramble 등 불필요 payload | 채택하지 않음 |
+| B. 하나의 Growth aggregate endpoint | client 단순, 한 번의 request | 30-day series와 full PB history가 initial payload/query lifecycle을 결합 | 채택하지 않음 |
+| C. summary + trend + PB progression 분리 | initial payload bounded, query 성격·refresh·evolution 분리 | endpoint 3개와 server calculator 필요 | **V2.2 proposal** |
+
+## API proposal
+
+모든 endpoint는 authenticated owner 전용이다. query의 `eventType`은 required로 두고 현재 `WCA_333`만 허용한다. known but unsupported EventType은 current Practice capability 정책과 같은 400 error를 반환한다.
+
+| Endpoint | 역할 | Payload boundary | Refresh trigger |
+| --- | --- | --- | --- |
+| `GET /api/users/me/growth?eventType=WCA_333` | current performance, comparison, consistency, activity summary | fixed-size object | Record create/PATCH/delete 후 |
+| `GET /api/users/me/growth/trend?eventType=WCA_333&period=30D` | daily performance와 activity series | 항상 30 date point | Record create/PATCH/delete 후 |
+| `GET /api/users/me/growth/pb-progression?eventType=WCA_333&page=1&size=50` | PB milestone list | page size 기본 50, 최대 100 | Record create/PATCH/delete 후 |
+
+V2.2에서 `period`는 `30D`만 지원한다. future 90-day 조회 가능성을 위해 dimension을 유지하되, 지원하지 않는 값에 빈 배열을 반환하지 않고 400으로 거절한다.
+
+### Summary response proposal
+
+JSON은 V2.2 proposal이며 generated REST Docs가 아니다.
+
+```json
+{
+  "status": 200,
+  "message": "성장 요약 조회 성공",
+  "data": {
+    "eventType": "WCA_333",
+    "timeZone": "Asia/Seoul",
+    "generatedAt": "2026-08-11T03:15:20.123Z",
+    "asOfDate": "2026-08-11",
+    "currentPb": {
+      "status": "AVAILABLE",
+      "recordId": 438,
+      "timeMs": 17780,
+      "penalty": "PLUS_TWO",
+      "effectiveTimeMs": 19780,
+      "createdAt": "2026-08-09T11:02:14.000Z"
+    },
+    "recentAo5": {
+      "status": "AVAILABLE",
+      "windowSize": 5,
+      "recordCount": 5,
+      "valueMs": 20412
+    },
+    "recentAo12": {
+      "status": "AVAILABLE",
+      "windowSize": 12,
+      "recordCount": 12,
+      "valueMs": 20965
+    },
+    "performanceComparison": {
+      "status": "AVAILABLE",
+      "recentPeriod": {
+        "fromDate": "2026-08-04",
+        "toDateExclusive": "2026-08-11",
+        "medianTimeMs": 20100,
+        "recordCount": 25,
+        "rankableCount": 24,
+        "activeDays": 4,
+        "dnfCount": 1,
+        "plusTwoCount": 1
+      },
+      "previousPeriod": {
+        "fromDate": "2026-07-28",
+        "toDateExclusive": "2026-08-04",
+        "medianTimeMs": 21350,
+        "recordCount": 18,
+        "rankableCount": 18,
+        "activeDays": 3,
+        "dnfCount": 0,
+        "plusTwoCount": 2
+      },
+      "direction": "FASTER",
+      "improvementPercent": 5.9
+    },
+    "consistency": {
+      "status": "AVAILABLE",
+      "current": {
+        "windowSize": 12,
+        "recordCount": 12,
+        "rankableCount": 11,
+        "iqrMs": 1820,
+        "dnfCount": 1,
+        "dnfRatePercent": 8.3,
+        "plusTwoCount": 1,
+        "plusTwoRatePercent": 8.3
+      },
+      "previous": {
+        "windowSize": 12,
+        "recordCount": 12,
+        "rankableCount": 12,
+        "iqrMs": 2250,
+        "dnfCount": 0,
+        "dnfRatePercent": 0.0,
+        "plusTwoCount": 1,
+        "plusTwoRatePercent": 8.3
+      },
+      "direction": "NARROWER",
+      "differenceMs": 430
+    },
+    "activity": {
+      "totalSolveCount": 438,
+      "last7DaysSolveCount": 42,
+      "previous7DaysSolveCount": 31,
+      "last30DaysSolveCount": 126,
+      "activeDaysLast30Days": 12,
+      "firstRecordedAt": "2026-04-22T09:12:00.000Z",
+      "latestRecordedAt": "2026-08-11T03:10:00.000Z"
+    }
+  }
+}
+```
+
+`AVAILABLE`, `DNF`, `NO_DATA`, `INSUFFICIENT_DATA`, `INSUFFICIENT_SAMPLE`을 명시적으로 구분한다. 적용되지 않는 numeric field는 `null`이 될 수 있지만 status 없이 `null`만 해석하게 만들지 않는다.
+
+`currentPb.timeMs`는 raw value, `effectiveTimeMs`는 penalty 반영 value다. Current PB가 없으면 `status=NO_DATA`이고 Record 관련 field는 null이다.
+
+### Trend response proposal
+
+```json
+{
+  "status": 200,
+  "message": "성장 추세 조회 성공",
+  "data": {
+    "eventType": "WCA_333",
+    "period": "30D",
+    "timeZone": "Asia/Seoul",
+    "generatedAt": "2026-08-11T03:15:20.123Z",
+    "fromDate": "2026-07-13",
+    "toDate": "2026-08-11",
+    "todayPartial": true,
+    "points": [
+      {
+        "date": "2026-07-13",
+        "recordCount": 0,
+        "rankableCount": 0,
+        "medianTimeMs": null,
+        "dnfCount": 0,
+        "plusTwoCount": 0
+      },
+      {
+        "date": "2026-07-14",
+        "recordCount": 7,
+        "rankableCount": 6,
+        "medianTimeMs": 22345,
+        "dnfCount": 1,
+        "plusTwoCount": 1
+      }
+    ]
+  }
+}
+```
+
+DB query가 반환하지 않은 date는 application이 요청 `asOfDate` 기준으로 채운다. missing day는 `recordCount=0`, `medianTimeMs=null`이다. DNF-only day는 `recordCount>0`, `rankableCount=0`, `medianTimeMs=null`로 구분한다.
+
+### PB progression response proposal
+
+```json
+{
+  "status": 200,
+  "message": "PB progression 조회 성공",
+  "data": {
+    "eventType": "WCA_333",
+    "basis": "CURRENT_RECORD_STATE",
+    "timeZone": "Asia/Seoul",
+    "content": [
+      {
+        "recordId": 438,
+        "timeMs": 17780,
+        "penalty": "PLUS_TWO",
+        "effectiveTimeMs": 19780,
+        "createdAt": "2026-08-09T11:02:14.000Z"
+      },
+      {
+        "recordId": 301,
+        "timeMs": 20150,
+        "penalty": "NONE",
+        "effectiveTimeMs": 20150,
+        "createdAt": "2026-06-18T02:20:10.000Z"
+      }
+    ],
+    "page": 1,
+    "size": 50,
+    "totalElements": 4,
+    "totalPages": 1,
+    "hasNext": false,
+    "hasPrevious": false
+  }
+}
+```
+
+Progression content는 current PB부터 과거로 가는 `created_at DESC, id DESC` milestone order다. UI는 받은 page를 chronological order로 바꿔 step chart를 그리며, 다음 page를 명시적으로 더 불러올 수 있다. Page boundary는 pathological하게 모든 solve가 PB인 경우에도 O(N) client transfer를 막는다. DB는 current canonical progression을 판별하기 위해 여전히 전체 user/event history를 볼 수 있으므로 100,000-record gate에서 별도 측정한다.
+
+### Error와 cache boundary
+
+- unauthenticated request: current auth contract의 401
+- invalid enum/query format: 400 generic validation error
+- known unsupported Practice event: 400 `지원하지 않는 Practice 종목입니다.`
+- empty WCA_333 history: 200과 explicit empty/status response
+- 다른 사용자의 identifier를 받는 parameter나 public variant는 V2.2에 추가하지 않음
+- browser/shared cache를 canonical store로 사용하지 않음
+- shared Redis cache를 추가하지 않음
+- private response의 HTTP caching/ETag는 observed traffic과 mutation invalidation 필요가 확인된 뒤 검토
+
+## Server component 책임
+
+```text
+GrowthController
+  -> authentication + query validation + response envelope
+
+GrowthService (@Transactional(readOnly = true))
+  -> one asOf clock/date 결정
+  -> capability 검증
+  -> repository projection 조합
+  -> pure metric calculator 호출
+
+GrowthMetricCalculator
+  -> effective result, Ao5/Ao12, median, percentile, improvement status
+
+RecordRepository / UserPBRepository
+  -> bounded recent rows, counts/ranges, daily aggregate, progression projection
+```
+
+- 기존 Timer frontend utility의 Ao fixture를 backend calculator test로 이식해 두 계산이 같은 규칙을 사용하게 한다.
+- Response DTO는 persistence entity를 노출하지 않는다.
+- Summary는 MySQL `records`와 `user_pbs`만 읽는다. Redis fallback/ready 상태를 Growth에 전파하지 않는다.
+- 같은 summary request의 시간 경계는 한 번 정한 `generatedAt`과 `asOfDate`를 모든 query에 사용한다.
+- 여러 query를 하나의 read-only transaction에 두어 Record와 current PB가 서로 다른 mutation 시점을 보지 않게 한다.
+
+## Query 설계
+
+### Current index
+
+V3의 핵심 index는 다음 순서다.
+
+```text
+(user_id, event_type, created_at, id)
+```
+
+이 index는 leftmost equality인 `user_id`, `event_type` 뒤에서 `created_at` range와 chronological/recent ordering을 지원한다. 따라서 다음 query의 candidate row scope를 user/event로 좁힌다.
+
+- latest 5/12/24 Record
+- 7/14/30-day date range
+- total count와 first/latest created_at
+- full chronological PB progression scan
+
+한계도 명확하다.
+
+- `penalty`, `time_ms`가 index에 없어 effective metric은 table row를 읽는다.
+- `DATE(created_at + 9 hours)` group과 median은 index만으로 끝나지 않는다.
+- effective result는 persistent/indexed column이 아니므로 DB가 계산한다.
+- all-time progression은 해당 user/event의 전체 index range를 순회한다.
+
+WHERE 절에는 `created_at` function을 두지 않는다. Application이 KST calendar boundary를 UTC instant로 변환해 raw `created_at >= :fromUtc AND created_at < :toUtc`로 전달한다. 선택된 30-day row를 group할 때만 UTC semantics의 DATETIME에 명시적으로 9시간을 더해 KST date를 만든다.
+
+### Query별 전략
+
+| Result | Query | 계산 위치 | 이유 |
+| --- | --- | --- | --- |
+| Current PB | `user_pbs` unique lookup + source Record join | DB projection | current ranking/PB contract 재사용 |
+| Recent Ao/IQR | user/event recent order `LIMIT 24` | application pure calculator | DNF trim·percentile status를 test하기 쉽고 bounded |
+| total/first/latest | user/event count, min, max | SQL aggregate 또는 index endpoint query | entity 전체 load 불필요 |
+| 7/14/30-day counts | raw UTC range conditional aggregate | SQL | bounded range, payload 없음 |
+| period median | 두 7-day range의 rankable row/window median | MySQL 8 native projection | unbounded entity list보다 명확한 DB aggregate |
+| daily median/count | 30-day range daily aggregate + rankable median | MySQL 8 native projection | 최대 30 row response |
+| PB progression | running previous minimum window query | MySQL 8 native projection | 전체 Record를 application/client로 전달하지 않고 point만 반환 |
+
+### Effective result expression
+
+Native aggregate에서 canonical expression은 다음과 같다.
+
+```sql
+CASE penalty
+  WHEN 'NONE' THEN time_ms
+  WHEN 'PLUS_TWO' THEN time_ms + 2000
+  WHEN 'DNF' THEN NULL
+END
+```
+
+이 expression은 schema column을 새로 만들지 않는다. Java calculator도 같은 enum mapping을 가져야 하며 fixture parity test로 drift를 막는다.
+
+### Daily aggregate outline
+
+다음은 query shape 설명용 outline이다. 실제 repository query와 REST Docs 구현이 아니다.
+
+```sql
+WITH ranged AS (
+  SELECT
+    DATE(DATE_ADD(created_at, INTERVAL 9 HOUR)) AS practice_date,
+    penalty,
+    CASE penalty
+      WHEN 'NONE' THEN time_ms
+      WHEN 'PLUS_TWO' THEN time_ms + 2000
+      WHEN 'DNF' THEN NULL
+    END AS effective_time_ms
+  FROM records
+  WHERE user_id = :userId
+    AND event_type = :eventType
+    AND created_at >= :fromUtc
+    AND created_at < :toUtc
+),
+rankable AS (
+  SELECT
+    practice_date,
+    effective_time_ms,
+    ROW_NUMBER() OVER (
+      PARTITION BY practice_date
+      ORDER BY effective_time_ms
+    ) AS position_in_day,
+    COUNT(*) OVER (PARTITION BY practice_date) AS rankable_count
+  FROM ranged
+  WHERE effective_time_ms IS NOT NULL
+)
+SELECT
+  practice_date,
+  ROUND(AVG(effective_time_ms)) AS median_time_ms
+FROM rankable
+WHERE position_in_day IN (
+  FLOOR((rankable_count + 1) / 2),
+  FLOOR((rankable_count + 2) / 2)
+)
+GROUP BY practice_date;
+```
+
+Record/DNF/+2 count는 같은 `ranged` population의 daily conditional aggregate로 구한다. 두 result를 date로 조합하고 30-date skeleton의 missing day를 application에서 채운다. SQL session timezone에 암묵적으로 의존하지 않는다.
+
+### PB progression outline
+
+```sql
+WITH canonical AS (
+  SELECT
+    id,
+    time_ms,
+    penalty,
+    created_at,
+    CASE penalty
+      WHEN 'NONE' THEN time_ms
+      WHEN 'PLUS_TWO' THEN time_ms + 2000
+    END AS effective_time_ms
+  FROM records
+  WHERE user_id = :userId
+    AND event_type = :eventType
+    AND penalty <> 'DNF'
+),
+scanned AS (
+  SELECT
+    canonical.*,
+    MIN(effective_time_ms) OVER (
+      ORDER BY created_at, id
+      ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+    ) AS previous_best_time_ms
+  FROM canonical
+)
+SELECT id, time_ms, penalty, effective_time_ms, created_at
+FROM scanned
+WHERE previous_best_time_ms IS NULL
+   OR effective_time_ms < previous_best_time_ms
+ORDER BY created_at DESC, id DESC;
+```
+
+Penalty PATCH 또는 delete 뒤 이 query를 다시 실행하면 current canonical state 기준으로 progression이 바뀐다. 마지막 progression point의 effective time과 `user_pbs.best_time_ms`가 일치해야 한다.
+
+### Repository 기술 선택
+
+현재 repository의 단순 동적 조건은 Querydsl custom repository가 담당하고, Ranking의 `ROW_NUMBER()`처럼 DB window 기능이 필요한 부분은 native query를 사용한다. V2.2도 같은 스타일을 따른다.
+
+- recent 24: Spring Data/Querydsl lightweight projection + page limit
+- count/min/max와 simple range count: Querydsl aggregate projection
+- daily/period median과 PB progression: MySQL 8 native query + interface/record projection
+- metric policy: repository SQL에 흩뿌리지 않고 pure Java calculator와 domain fixture로 검증
+- entity list 전체 반환 또는 frontend raw history aggregate: 사용하지 않음
+
+## Migration과 index 결정
+
+**V2.2에서는 Flyway migration과 새 index를 추가하지 않는다.**
+
+| 후보 | 필요한 query | 기존 index가 부족한 이유 | write/storage cost | 판단 |
+| --- | --- | --- | --- | --- |
+| `(user_id,event_type,created_at,id,penalty,time_ms)` covering index | recent/range metric을 table lookup 없이 처리 | current index에 value column이 없음 | 모든 Record mutation의 더 큰 index write, raw time·penalty 중복 storage | 실제 latency evidence 전에는 과도 |
+| effective generated column + index | effective min/median | current effective result가 계산값 | schema 의미와 penalty mutation write 확대, V2.1 non-persistent 결정 변경 | 채택하지 않음 |
+| PB event/snapshot table | progression read | current history scan은 O(N) | create/PATCH/delete correction과 audit 의미, migration·backfill·정합성 비용 | V2.2 불필요 |
+| Growth Redis keys | repeated summary | 현재 Redis는 Ranking read model | invalidation·rebuild·운영 책임 추가 | 책임 경계와 맞지 않음 |
+
+Current composite index가 필요한 최소 row scope와 ordering을 제공한다. MySQL의 composite index는 leftmost prefix를 이용하며, index가 많거나 넓어지면 write와 storage 비용이 증가한다. 구현 PR에서는 10,000-record fixture의 `EXPLAIN ANALYZE`를 보존하고 관찰 결과가 기준을 넘을 때만 별도 index proposal을 연다.
+
+## 규모별 비용과 최소 gate
+
+| user/event Record 수 | Summary/recent | 30-day trend | PB progression | V2.2 판단 |
+| ---: | --- | --- | --- | --- |
+| 100 | constant recent + 작은 aggregate | 작은 range | 작은 full scan | request-time 계산 |
+| 1,000 | bounded/reasonable | 최근 row만 | user/event 1K scan | request-time 계산 |
+| 10,000 | entity load 없이 projection이면 적정 | activity density에 따라 range | 10K window scan | query plan·latency evidence를 release gate로 기록 |
+| 100,000 | current PB/recent는 index로 제한 | 30-day density에 좌우 | 매 view 100K scan 가능 | stress 측정, 문제가 확인되면 progression cache/projection 후보 |
+
+Production row count와 request frequency는 V2.2 architecture의 전제가 아니다. 100,000-record case는 current 요구사항이 아니라 future stress evidence로 다룬다.
+
+Pre-aggregation이 필요해지는 신호는 다음과 같다.
+
+- PB progression query가 실제 p95 budget을 반복적으로 초과
+- 한 user/event의 progression view가 자주 반복되고 Record mutation은 상대적으로 적음
+- 30-day density가 커져 range aggregate가 measured bottleneck이 됨
+
+그때에도 local request cache, progression projection과 invalidation-on-mutation을 비교한 뒤 선택한다. Ranking Redis namespace에 통계를 넣는 것을 기본값으로 하지 않는다.
+
+## Time과 timezone
+
+- JPA persistence와 API `createdAt`/`generatedAt`은 UTC instant 의미를 유지한다.
+- current frontend formatter와 Home daily boundary가 사용하는 `Asia/Seoul`을 V2.2 service day로 사용한다.
+- Application Clock으로 한 request의 KST `asOfDate`와 UTC bounds를 만든다.
+- `created_at`은 recorded time이며 delayed retry가 실제 solve보다 늦게 저장될 수 있다.
+- 30-day activity는 오늘 포함, performance comparison은 partial today 제외다.
+- user timezone preference와 V2.3 Daily Challenge day identity를 V2.2 schema/API prerequisite로 만들지 않는다.
+
+User timezone이 도입되면 historical day regrouping, profile setting, cache key와 comparison consistency를 새 계약으로 검토해야 한다. `timeZone` response field를 유지하므로 API 전체 rewrite 없이 진화할 수 있다.
+
+## Event evolution
+
+- 모든 endpoint와 query는 `eventType` predicate를 유지한다.
+- current public Growth capability는 WCA_333만 제공한다.
+- frontend는 supported Practice event만 선택지로 보여 준다.
+- enum에 존재하지만 capability가 없는 event에 empty metric을 만들지 않는다.
+- future event는 Result Kind, Timer, Record와 Growth capability를 함께 승인한다.
+- WCA_333FM, WCA_333MBF 같은 non-time result를 millisecond metric에 자동 편입하지 않는다.
+
+## Frontend integration
+
+- `/mypage`를 유지하고 current summary/raw chart 영역을 My Growth section으로 대체한다.
+- Record history와 account modal은 유지한다.
+- Timer는 current recent Ao5/Ao12를 계속 즉시 보여 주되 `내 성장 보기` link만 추가한다.
+- Recharts 3.8.1의 existing components를 사용한다. dependency 추가는 필요하지 않다.
+- Summary와 trend는 parallel fetch가 가능하지만 independent loading/error state를 둔다.
+- progression은 summary 뒤 lazy load한다. page 1을 먼저 표시하고 사용자가 전체 이력을 열 때 다음 page를 읽는다.
+- chart에는 text summary/timeline을 함께 제공하고 mobile tick 수를 줄인다.
+- Record create/PATCH/delete 성공 후 관련 Growth query를 invalidate/refetch한다.
+
+## Test 전략
+
+### Domain unit
+
+- NONE, PLUS_TWO, DNF effective result
+- Ao5/Ao12 부족, numeric, 1 DNF trim, 2 DNF result
+- median odd/even과 integer rounding
+- period sample status와 improvement direction/rounding
+- type-7 Q1/Q3 interpolation, rankable 8 gate, IQR direction
+- next Practice CTA fallback
+
+### Repository integration on MySQL 8
+
+- same `created_at` + id ordering
+- KST 전후 UTC instant와 half-open range
+- missing day, DNF-only day, PLUS_TWO median
+- PB tie, mutable penalty, delete 후 progression
+- final progression point와 `user_pbs` parity
+- unsupported event는 repository call 전 차단
+- 10,000-record fixture `EXPLAIN ANALYZE`와 returned row/payload count
+
+H2로 MySQL window/date behavior를 대신 증명하지 않는다. Current MySQL 8.0 runtime과 같은 major의 integration evidence를 사용한다.
+
+### REST Docs / API
+
+- authenticated success, unauthenticated, invalid/unsupported event
+- empty, insufficient, DNF와 available response field
+- fixed 30 point와 progression pagination metadata
+- UTC instant, KST date와 enum documentation
+- owner scope 외 identifier가 contract에 없는지 확인
+
+### Frontend
+
+- loading/error/empty/partial/available/DNF state
+- mobile chart tick, tooltip, text alternative
+- 30-day missing line point와 zero activity bar 구분
+- progression page merge/order와 current-state notice
+- Timer CTA와 Record create/PATCH/delete refresh
+- current ambiguous all-time average를 Growth label로 재사용하지 않음
+
+### Manual release smoke
+
+1. keyboard와 touch에서 WCA_333 save
+2. Timer recent Ao와 Growth recent Ao parity 확인
+3. penalty NONE → PLUS_TWO → DNF 변경과 PB/progression/trend refresh
+4. Record delete 후 current PB와 progression final point parity
+5. empty/insufficient user와 30-day gap 표시
+6. iPhone-width My Growth → Timer → My Growth flow
+
+Build와 CI success는 production request 성공을 뜻하지 않는다. main merge, deploy와 public URL smoke는 별도 release 승인과 운영 gate를 따른다.
+
+## 구현 PR 순서
+
+### PR A — Growth contract와 calculator
+
+- scope: accepted metric/ADR 반영, backend pure calculator와 fixture, no endpoint
+- dependency: ADR-0010과 MUST metric proposal acceptance
+- acceptance: DNF/+2/Ao/median/IQR/time-window contract가 executable test와 일치
+- tests: focused domain unit tests
+- rollback risk: production behavior 없음, 새 internal code 제거 가능
+
+### PR B — Growth read API와 query
+
+- scope: summary/trend/progression controller, service, projection, native query, REST Docs
+- dependency: PR A
+- acceptance: private WCA_333 contract, bounded payload, progression parity, no migration/Redis
+- tests: service/repository MySQL integration, REST Docs, query-plan evidence
+- rollback risk: additive GET endpoint 제거. DB rollback 없음
+
+### PR C — My Growth dashboard
+
+- scope: `/mypage` information architecture, summary/trend/activity/progression, Timer CTA
+- dependency: PR B
+- acceptance: state matrix, mobile/accessibility, existing history/account 유지
+- tests: utility/component test, focused frontend build, manual responsive flow
+- rollback risk: prior MyPage presentation으로 되돌릴 수 있고 API/data 영향 없음
+
+### PR D — Legacy Profile consumer 전환
+
+- scope: Home/MyPage의 ambiguous all-event average 제거, additive API field deprecation 문서, duplicate calculation 정리
+- dependency: PR C가 Growth replacement 제공
+- acceptance: existing account/history/PB consumer 회귀 없음, breaking API removal 없음
+- tests: profile service/REST Docs regression, frontend routes
+- rollback risk: legacy UI label 복원 가능. API field 제거는 별도 compatibility 결정 전 금지
+
+### PR E — Release evidence
+
+- scope: acceptance/quality 문서, targeted smoke checklist와 query evidence 갱신
+- dependency: PR A~D integrated on dev
+- acceptance: required Validate, no blocker, metric parity와 mobile smoke evidence
+- tests: docs link/diff validation, integrated CI 결과 기록
+- rollback risk: documentation-only. merge/deploy 권한을 포함하지 않음
+
+각 PR은 commit, push, PR, merge와 deploy 승인을 별도로 받는다. V2.2 implementation이 끝나도 Daily Challenge 구현으로 자동 진행하지 않는다.
+
+## Release gate와 rollback
+
+V2.2 release candidate는 다음을 모두 만족해야 한다.
+
+- canonical metric fixture와 API/generated docs 일치
+- authenticated owner/event boundary와 secret/scramble 비노출
+- full Record entity/history가 Growth payload로 전송되지 않음
+- 10,000-record query plan과 observed latency 기록
+- frontend empty/insufficient/DNF/mobile/accessibility state 확인
+- Record mutation 뒤 PB, progression, summary가 일치
+- required CI 성공과 unresolved blocker 0건
+- main merge와 release/deploy 승인 경계를 다시 확인
+
+Rollback은 additive endpoint와 frontend consumer를 이전 revision으로 되돌리는 application rollback이다. V2.2가 migration을 만들지 않으므로 DB reverse migration은 없다. 다만 release 뒤 생성·수정된 Record는 기존 V2.1 schema와 호환돼야 하며 삭제하지 않는다.
+
+## 근거와 검증할 항목
+
+- MySQL 8은 window function을 지원하므로 running minimum과 median rank query가 가능하다.
+- Composite index의 leftmost prefix가 현재 user/event/date query shape에 맞는다.
+- Index 추가는 read speed뿐 아니라 write와 storage cost를 함께 검토해야 한다.
+- 정확한 execution plan과 latency는 구현 branch의 MySQL 8 fixture에서 검증한다. 설계 문서의 query outline만으로 성능을 완료 판정하지 않는다.
+
+참고:
+
+- [MySQL 8.0 Window Function Descriptions](https://dev.mysql.com/doc/refman/8.0/en/window-functions.html)
+- [MySQL Multiple-Column Indexes](https://dev.mysql.com/doc/refman/8.0/en/multiple-column-indexes.html)
+- [How MySQL Uses Indexes](https://dev.mysql.com/doc/refman/8.0/en/mysql-indexes.html)

--- a/docs/08-decisions/README.md
+++ b/docs/08-decisions/README.md
@@ -2,7 +2,7 @@
 doc_type: index
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -23,6 +23,7 @@ ADR은 구현과 운영에 영향을 주는 중요한 기술 결정과 trade-off
 | [ADR-0007](adr-0007-canonical-timer-time-input-provenance.md) | accepted | Practice Timer canonical time과 Input Method provenance 분리 |
 | [ADR-0008](adr-0008-record-submission-idempotency.md) | accepted | client submission identity 기반 Record 저장 idempotency |
 | [ADR-0009](adr-0009-practice-event-capability.md) | accepted | EventType identity와 WCA_333 Practice capability 분리 |
+| [ADR-0010](adr-0010-current-record-growth-read-contract.md) | proposed | Current Record 기반 private Growth read contract |
 
 과거 최초 결정일을 신뢰성 있게 특정하지 못해, 기존 구현을 ADR로 공식 기록한 2026-08-10을 created로 사용한다.
 

--- a/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+++ b/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
@@ -1,0 +1,113 @@
+---
+doc_type: adr
+status: proposed
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/00-product/roadmap.md
+  - docs/01-domain/growth-metrics.md
+  - docs/01-domain/solve-model.md
+  - docs/02-requirements/features/growth.md
+  - docs/02-requirements/features/profile.md
+  - docs/03-architecture/growth-architecture.md
+  - docs/04-data/data-dictionary.md
+  - docs/05-api/conventions.md
+---
+# ADR-0010 Current Record 기반 Growth read contract
+
+## Context
+
+V2.1은 `Record = completed Practice solve` 경계, WCA_333 capability, raw time·penalty, stable event history, current PB와 Redis Ranking 책임을 확정했다. V2.2는 이 Record를 사용자가 이해할 수 있는 성장 정보와 장기 활동 이력으로 연결해야 한다.
+
+다음 결정은 metric, API, query, UX와 correction behavior에 동시에 영향을 주므로 개별 구현 세부보다 오래 유지될 가능성이 높다.
+
+- PB progression이 immutable event history인지 current Record의 derived view인지
+- `created_at`을 어떤 activity timestamp로 해석하는지
+- DNF/+2와 timezone을 어느 layer가 canonical하게 계산하는지
+- private My Growth와 future public Profile을 같은 read contract로 취급하는지
+- current history API를 client가 aggregate할지 dedicated read API를 만들지
+- request-time query로 시작할지 snapshot/cache schema를 선구현할지
+
+현재 `records`에는 `occurred_at`과 immutable correction audit가 없다. Penalty는 PATCH 가능하고 Record는 delete할 수 있다. `user_pbs`는 current PB projection이며 history table이 아니다. Redis는 Ranking을 위한 rebuild 가능한 Read Model이다.
+
+## Options
+
+### Option A — 기존 history API와 frontend 계산
+
+Frontend가 paginated Record history를 내려받아 PB, trend와 activity를 계산한다.
+
+- 장점: backend endpoint와 SQL 추가가 적다.
+- 단점: page size 밖의 history, mixed event, DNF/timezone drift와 O(N) transfer가 생긴다.
+- 단점: Web 외 consumer가 metric contract를 다시 구현해야 한다.
+
+### Option B — immutable Growth snapshot/event model 선구현
+
+PB event, daily aggregate 또는 Growth snapshot table을 추가해 historical view를 고정한다.
+
+- 장점: read cost와 immutable historical display를 제어하기 쉽다.
+- 단점: correction·delete 의미, backfill, rebuild, audit·retention 정책을 먼저 확정해야 한다.
+- 단점: 현재 사용자 가치와 규모가 검증되기 전에 schema와 운영 책임이 생긴다.
+
+### Option C — current Record 기반 dedicated server read model
+
+Current canonical Record를 요청 시 계산하고, summary·trend·PB progression endpoint를 분리한다. Existing index와 MySQL projection/window query를 사용하며 schema와 Redis를 추가하지 않는다.
+
+- 장점: V2.1 correction/PB semantics를 재사용하고 client drift와 raw history transfer를 막는다.
+- 장점: current index로 MVP query를 시작하고 observed cost 뒤에만 최적화할 수 있다.
+- 단점: PB progression은 user/event 전체 history O(N) scan일 수 있다.
+- 단점: 과거에 보았던 PB snapshot을 복원하지 않는다.
+
+## Decision proposal
+
+Option C를 V2.2 proposal로 둔다. ADR-0010은 `proposed`이며 accepted contract가 아니다.
+
+1. Growth의 canonical population은 요청 event의 current retained completed Practice Record다.
+2. `NONE`은 raw time, `PLUS_TWO`는 raw + 2,000ms, `DNF`는 non-numeric result다. DNF는 일반 median/percentile에서 제외하고 count/rate로 보존한다. Ao5/Ao12는 V2.1의 별도 trim rule을 유지한다.
+3. PB progression은 `created_at ASC, id ASC`에서 strictly improving running minimum을 재구성한다. Penalty PATCH와 delete 뒤 current canonical state로 다시 계산한다.
+4. `created_at`은 actual occurrence가 아니라 recorded Practice activity instant다. API instant는 UTC, V2.2 calendar day는 `Asia/Seoul`을 사용한다.
+5. Growth calculation은 authenticated owner용 dedicated server read API가 담당한다. Fixed summary, 30-day trend와 paginated PB progression을 분리한다.
+6. My Growth 상세 통계는 private다. V2.2에서 신규 public Profile route/API와 visibility setting을 만들지 않는다. Existing Ranking nickname/PB 공개 범위만 유지한다.
+7. V2.2는 Flyway, generated effective column, PB snapshot table, Growth Redis와 pre-aggregation을 추가하지 않는다. 10,000-record query evidence를 release gate로 남기고 100,000-record stress에서 문제가 확인되면 후속 결정을 연다.
+8. Event dimension은 유지하되 current public Growth capability는 WCA_333만 허용한다. Unsupported known event에 fake empty Growth를 제공하지 않는다.
+
+세부 metric formula는 [Growth Metrics](../01-domain/growth-metrics.md), endpoint와 query proposal은 [Growth Architecture](../03-architecture/growth-architecture.md)가 관리한다.
+
+## Consequences
+
+### Positive
+
+- V2.1 Record, PB와 correction behavior를 schema 재설계 없이 재사용한다.
+- 같은 metric이 backend contract 하나에서 계산돼 client와 future consumer 사이 drift를 줄인다.
+- Frontend는 full history, scramble과 provenance를 Growth 화면 때문에 전송받지 않는다.
+- Public/private boundary가 명시돼 activity timestamp와 Practice volume을 실수로 공개하지 않는다.
+- Redis Ranking 책임이 Growth analytics로 확장되지 않는다.
+- Future event와 user timezone을 response dimension으로 확장할 여지를 남긴다.
+
+### Negative
+
+- PB progression은 immutable 당시 snapshot이 아니며 Record correction 뒤 이전 point가 달라질 수 있다.
+- `created_at` 기반 daily metric은 delayed retry가 실제 Practice date와 다를 수 있다.
+- Summary가 여러 query를 조합하므로 read-only transaction, one-clock boundary와 query-plan 검증이 필요하다.
+- 100,000 Record user의 progression view는 전체 index range를 스캔할 수 있다.
+- Asia/Seoul 밖 사용자의 local day와 service day가 다를 수 있다.
+
+### Required follow-up
+
+- 구현 전에 ADR-0010과 MUST metric proposal을 accepted contract로 확정한다.
+- Backend calculator fixture에서 DNF/+2/Ao/median/IQR/time boundary를 고정한다.
+- MySQL 8 integration test와 10,000-record `EXPLAIN ANALYZE` evidence를 남긴다.
+- UI에 `현재 남아 있는 기록 기준`, `기록된 활동`, `Asia/Seoul`, sample count를 필요한 위치에 표시한다.
+- Public Profile, immutable audit, user timezone 또는 measured pre-aggregation 필요가 생기면 각각 별도 product/architecture decision을 연다.
+
+## Rejected as part of this proposal
+
+- current `averageTimeMs`를 이름만 바꿔 canonical Growth metric으로 재사용
+- DNF를 arbitrary worst millisecond나 infinity로 바꿔 일반 mean에 포함
+- `occurred_at`을 V2.2 prerequisite로 추가
+- 모든 Profile view마다 entire Record entity/history를 client로 전송
+- `user_pbs` row를 PB history로 해석
+- Ranking Redis namespace에 Growth summary/progression을 저장
+- 다른 EventType enum에 misleading empty Growth response 제공

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 doc_type: index
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -44,6 +44,7 @@ related:
 ### 01 Domain
 
 - [Glossary](01-domain/glossary.md) · [Solve Model](01-domain/solve-model.md)
+- [Growth Metrics](01-domain/growth-metrics.md) (V2.2 draft)
 - [Record Verification](01-domain/record-verification.md)
 - [Ranking Rules](01-domain/ranking-rules.md) · [Scramble Rules](01-domain/scramble-rules.md)
 - [Competition Rules](01-domain/competition-rules.md)
@@ -53,12 +54,14 @@ related:
 - [User Flows](02-requirements/user-flows.md)
 - [Non-functional Requirements](02-requirements/non-functional-requirements.md)
 - Current: [Authentication](02-requirements/features/authentication.md), [Timer](02-requirements/features/timer.md), [Profile](02-requirements/features/profile.md), [Ranking](02-requirements/features/ranking.md), [Learning](02-requirements/features/learning.md), [Community](02-requirements/features/community.md), [Feedback and Administration](02-requirements/features/feedback-and-administration.md)
+- Draft: [Growth](02-requirements/features/growth.md)
 - Candidates: [Daily Challenge](02-requirements/features/daily-challenge.md), [Verified Record](02-requirements/features/verified-record.md), [Competition](02-requirements/features/competition.md), [Organizer](02-requirements/features/organizer.md)
 
 ### 03 Architecture
 
 - [System Context](03-architecture/system-context.md) · [Application](03-architecture/application-architecture.md)
 - [Backend](03-architecture/backend-architecture.md) · [Frontend](03-architecture/frontend-architecture.md)
+- [Growth](03-architecture/growth-architecture.md) (V2.2 draft)
 - [Auth and Security](03-architecture/auth-security.md)
 - [Ranking](03-architecture/ranking-architecture.md) · [Storage](03-architecture/storage-architecture.md)
 - [Deployment](03-architecture/deployment-architecture.md)
@@ -143,7 +146,7 @@ ADR은 proposed, accepted, rejected, superseded만 사용한다.
 ## 내용 상태 표기
 
 - 확인된 사실: code, test, configuration, official source로 검증
-- 결정: accepted ADR 또는 사용자 승인으로 확정
+- 결정: accepted ADR 또는 명시적으로 확정한 기준
 - 추론·가설: 근거에서 해석한 내용이며 검증 필요
 - TODO·Open Questions: 미정이며 일정이나 설계를 확정하지 않음
 


### PR DESCRIPTION
## V2.2 Growth & Profile

- V2.2 MVP 범위와 canonical Growth metric을 정리합니다.
- My Growth IA, Public Profile 경계, API/Data 방향을 정의합니다.
- ADR-0010과 구현 PR 순서, release validation gate를 추가합니다.

## Scope

- 문서만 변경합니다.
- application code, Flyway, API endpoint, runtime configuration은 변경하지 않습니다.