### PR TITLE
docs: clean up active documentation style

### DIFF
--- a/docs/00-product/market-validation.md
+++ b/docs/00-product/market-validation.md
@@ -2,7 +2,7 @@
 doc_type: product
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -20,7 +20,7 @@ related:
 
 ## 문서 상태와 목적
 
-공개 서비스 조사에서 확인한 사실, 사용자가 선택한 제품 방향, 앞으로 검증할 가설을 분리한다. 제품 방향이 결정됐다는 사실을 시장 수요 검증 완료로 표현하지 않는다.
+공개 서비스 조사에서 확인한 사실, 제품 방향, 앞으로 검증할 가설을 분리한다. 제품 방향이 정해졌다고 시장 수요 검증이 완료된 것은 아니다.
 
 ## Research에서 확인한 패턴
 
@@ -32,7 +32,7 @@ related:
 
 세부 조사 근거는 [research 문서](research/)에서 관리한다. 위 사실만으로 Cubing Hub의 기능 우선순위나 시장 수요가 자동 확정되지는 않는다.
 
-## 사용자 결정
+## 제품 방향
 
 - Cubing Hub는 Cuber-first 큐빙 활동 플랫폼으로 간다.
 - Primary User는 일상적으로 반복 연습하며 기록 단축과 성장에 관심 있는 큐버다.
@@ -42,7 +42,7 @@ related:
 - Daily Challenge는 Participation 가치를 확인할 미래 검증 후보로 둔다.
 - V2.1 Timer / Record Foundation을 Growth, Daily Challenge, Verified Record보다 먼저 정비한다.
 
-이 결정의 제품 표현은 [Vision](vision.md), 구현 범위와 선행 gate는 [PRD](prd.md), 단계 순서는 [Roadmap](roadmap.md)이 기준이다.
+제품 표현은 [Vision](vision.md), 구현 범위와 선행 gate는 [PRD](prd.md), 단계 순서는 [Roadmap](roadmap.md)이 기준이다.
 
 ## 아직 검증할 가설
 

--- a/docs/00-product/prd.md
+++ b/docs/00-product/prd.md
@@ -204,7 +204,7 @@ V2.1은 다음 기능을 구현하지 않고, 나중에 추가할 때 현재 Rec
 
 ## Implementation / Release Gate 상태
 
-1. 사용자 확인 기준 현재 `records`, `user_pbs` data가 없으므로 event distribution audit blocker를 제거했다.
+1. 기존 `records`와 `user_pbs` data가 없다는 전제에서 event distribution audit blocker를 제거했다.
 2. V2.1 Practice Timer·Scramble·Record·Ranking event를 WCA_333으로 확정했다.
 3. Input Method, idempotency, canonical create response와 pending recovery의 API·data·architecture 계약을 문서화했다.
 4. forward-only additive migration, old application compatibility와 실제 MySQL upgrade test 방식을 확정했다.

--- a/docs/00-product/vision.md
+++ b/docs/00-product/vision.md
@@ -2,7 +2,7 @@
 doc_type: product
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -15,7 +15,7 @@ related:
 
 ## 문서 상태
 
-제품 positioning, Primary User, 핵심 문제와 Core Loop는 2026-08-10 사용자 결정으로 확정됐다. 이 문서는 현재 제품 방향의 기준으로 사용한다. 미래 기능의 상세 범위·정책은 각 draft 문서와 [PRD](prd.md)의 gate를 따른다.
+제품 positioning, Primary User, 핵심 문제와 Core Loop는 현재 제품 방향의 기준이다. 미래 기능의 상세 범위·정책은 각 draft 문서와 [PRD](prd.md)의 gate를 따른다.
 
 ## Product Positioning
 

--- a/docs/01-domain/competition-rules.md
+++ b/docs/01-domain/competition-rules.md
@@ -2,7 +2,7 @@
 doc_type: domain
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -14,7 +14,7 @@ related:
 
 ## 현재 상태
 
-Cubing Hub에는 competition과 organizer domain이 구현돼 있지 않다. 이 문서는 향후 논의를 위한 권위와 용어 경계만 정의한다.
+Cubing Hub에는 competition과 organizer domain이 구현돼 있지 않다. 향후 논의를 위한 권위와 용어 경계만 정의한다.
 
 ## 권위 경계
 
@@ -39,4 +39,4 @@ WCA 규정은 현재 버전의 공식 페이지를 링크해 참고하되 내용
 
 ## 비목표
 
-대회 출시 일정, bracket, registration schema, payment, API는 이 문서에서 선설계하지 않는다.
+대회 출시 일정, bracket, registration schema, payment, API는 선설계하지 않는다.

--- a/docs/01-domain/record-verification.md
+++ b/docs/01-domain/record-verification.md
@@ -2,7 +2,7 @@
 doc_type: domain
 status: draft
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -97,4 +97,4 @@ Smart Cube telemetry를 evidence로 사용하려면 Practice data, improvement d
 
 ## 비목표
 
-이 문서에서는 DB table, endpoint, moderation architecture, device protocol, 출시 일정을 확정하지 않는다.
+DB table, endpoint, moderation architecture, device protocol, 출시 일정을 확정하지 않는다.

--- a/docs/05-api/README.md
+++ b/docs/05-api/README.md
@@ -2,7 +2,7 @@
 doc_type: index
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -32,7 +32,7 @@ related:
 
 - 게시글 수정 preload snippet post/detail-edit는 test에 존재하며 index에 연결했다.
 - DELETE /api/admin/memos/{memoId}는 controller와 integration test에 존재하지만 REST Docs test·snippet이 없다.
-- 이번 문서 rebaseline은 application test 변경을 포함하지 않으므로 admin memo delete 항목을 Known Gap으로 명시한다.
+- admin memo delete 항목은 REST Docs contract가 없으므로 Known Gap으로 관리한다.
 
 ## 변경 규칙
 

--- a/docs/07-operations/ci-cd.md
+++ b/docs/07-operations/ci-cd.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -51,7 +51,7 @@ main push는 deploy workflow의 release validation을 시작한다. deployment f
 - main merge는 release workflow 시작
 - production variable이 enable된 경우 merge가 실제 deploy로 이어질 수 있음
 
-따라서 commit, push, PR, merge, deploy는 별도 승인이다. 이 문서 작업은 local commit까지만 포함한다.
+따라서 commit, push, PR, merge, deploy는 별도 승인이다.
 
 ## Source of Truth
 

--- a/docs/07-operations/environments.md
+++ b/docs/07-operations/environments.md
@@ -34,7 +34,7 @@ repository Compose에는 MySQL 8.0.46, Redis 7.2.14, API, Web이 정의돼 있�
 
 ## Tracked legacy configuration
 
-infra/docker/docker-compose.prod.yml은 latest tag, S3 환경변수, host 80·443 port를 전제로 한 2026-04 시점 파일이며 현재 workflow·homeserver script에서 참조되지 않는다. 현재 production Source of Truth로 사용하거나 이 파일로 배포하지 않는다. 설정 파일의 이동·삭제는 이번 문서-only 범위 밖의 별도 정리 작업이다.
+infra/docker/docker-compose.prod.yml은 latest tag, S3 환경변수, host 80·443 port를 전제로 한 2026-04 시점 파일이며 현재 workflow·homeserver script에서 참조되지 않는다. 현재 production Source of Truth로 사용하거나 이 파일로 배포하지 않는다. 설정 파일의 이동·삭제는 별도 정리 작업으로 관리한다.
 
 ## Observed runtime fact
 

--- a/docs/07-operations/local-development.md
+++ b/docs/07-operations/local-development.md
@@ -27,7 +27,7 @@ version과 task는 repository configuration이 Source of Truth다.
 
 Mac mini host에는 Java나 Node.js를 새로 설치하거나 version을 바꾸지 않는다. 현재 repository에는 backend·frontend 전체 검증용 개발 container wrapper가 없으므로 이 host에서는 CI 결과를 전체 검증 기준으로 사용한다.
 
-root docker-compose.yml은 기존 local helper이며 fixed container name과 host port를 사용한다. 실행 전 다른 project·production resource와 겹치지 않는지 확인하고, 운영 .env·network·volume을 참조하지 않는다. 이 문서 작업에서는 실행하지 않았다.
+root docker-compose.yml은 기존 local helper이며 fixed container name과 host port를 사용한다. 실행 전 다른 project·production resource와 겹치지 않는지 확인하고, 운영 .env·network·volume을 참조하지 않는다.
 
 ## Release smoke와 구분
 

--- a/docs/08-decisions/README.md
+++ b/docs/08-decisions/README.md
@@ -10,7 +10,7 @@ related: []
 ---
 # Architecture Decision Records
 
-ADR은 구현과 운영에 영향을 주는 중요한 기술 결정과 trade-off를 보존한다. status는 proposed, accepted, rejected, superseded 중 하나를 사용한다. `accepted`는 사용자가 결정을 승인했다는 뜻이며 구현 완료를 의미하지 않는다.
+ADR은 구현과 운영에 영향을 주는 중요한 기술 결정과 trade-off를 보존한다. status는 proposed, accepted, rejected, superseded 중 하나를 사용한다. `accepted`는 승인된 결정을 뜻하며 구현 완료를 의미하지 않는다.
 
 | ADR | 상태 | 결정 |
 | --- | --- | --- |

--- a/docs/08-decisions/adr-0009-practice-event-capability.md
+++ b/docs/08-decisions/adr-0009-practice-event-capability.md
@@ -2,7 +2,7 @@
 doc_type: adr
 status: accepted
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-11
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -20,7 +20,7 @@ related:
 
 현재 `EventType`에는 여러 WCA event code가 있고 Record와 Ranking API가 그 enum 전체를 받을 수 있다. 반면 public Timer와 Scramble은 WCA_333만 실제 지원한다. WCA_333FM과 WCA_333MBF처럼 일반 `time_ms` lower-is-better 결과와 맞지 않는 event까지 enum 존재만으로 Practice Record·Ranking에 허용하면 잘못된 제품 의미를 만든다.
 
-사용자는 2026-08-10 현재 DB에 `records`와 `user_pbs` data가 없다고 확인했다. 이 세션은 production query를 실행하지 않았지만, 사용자 확인을 근거로 기존 event data migration blocker 없이 V2.1 public Practice 범위를 닫을 수 있다.
+V2.1 public Practice 범위는 기존 `records`와 `user_pbs` data가 없다는 전제로 정했다. Production query는 실행하지 않았으며, 기존 event data migration blocker를 두지 않는다.
 
 ## Decision
 


### PR DESCRIPTION
## 변경

- active documentation 문체와 문장 구조 정리
- AI·meta·report-style 표현과 불필요한 provenance 제거
- 제품·기술 contract와 문서 status 유지

## 범위

- `docs/99-archive/v1/**`와 generated documentation 제외
- application code, Flyway, workflow, runtime configuration 변경 없음

## 검증

- `git diff --check`
- 변경 Markdown frontmatter, local link, code fence 확인
- 문체 lint와 변경 범위 확인