### PR TITLE
docs: design UI UX redesign foundation

### DIFF
--- a/docs/00-product/ui-visual-direction.md
+++ b/docs/00-product/ui-visual-direction.md
@@ -22,7 +22,7 @@ related:
 
 ## Status
 
-이 문서는 Cubing Hub UI/UX redesign의 Design Gate proposal이다. 제품 기능, Timer·Record 계약과 V2.2 Growth metric을 변경하지 않는다. visual direction과 screen hierarchy가 승인되기 전에는 구현 계약으로 사용하지 않는다.
+이 문서는 Cubing Hub UI/UX redesign의 Design Gate proposal이다. 제품 기능, Timer·Record 계약과 V2.2 Growth metric을 변경하지 않는다. visual direction, Target Mockup과 screen hierarchy가 승인되기 전에는 구현 계약으로 사용하지 않는다.
 
 Cubing Hub는 generic dashboard가 아니라 다음 경험을 연결하는 큐빙 활동 제품이다.
 
@@ -113,7 +113,7 @@ Timer는 집중 도구, Growth는 해석 도구, Ranking은 비교 도구, Commu
 | Timer | 중심 장비처럼 가장 강함 | 집중 stage와 옆 performance rail | dark scoreboard와 competition 긴장감 |
 | Growth | dense analysis table에 가까움 | 지금→방향→안정성→장기→활동 narrative | delta와 PB를 크게 강조 |
 | Mobile | compact tool tray | core action 순서 중심의 bottom navigation | full-screen focus와 bold status |
-| AI-generated visual | 거의 사용하지 않음 | optional key visual·empty-state에 제한 | campaign/achievement visual에 비교적 적극적 |
+| Runtime AI Asset | 거의 사용하지 않음 | optional key visual·empty-state에 제한 | campaign/achievement visual에 비교적 적극적 |
 | 장점 | Timer 신뢰와 정보 밀도가 높다. | Core Loop 전체, Growth와 content 화면을 한 system으로 연결하기 쉽다. | Timer와 Ranking의 존재감이 강하다. |
 | 위험 | 차갑고 developer tool처럼 보일 수 있다. Community·Learning 확장이 약하다. | 구현이 평범해지면 sports identity가 희미해질 수 있다. | competition이 아직 중심이 아닌 제품을 gamer app처럼 보이게 할 수 있다. Dark QA 비용도 크다. |
 | Cubing Hub 적합도 | 4/5 | 5/5 | 3/5 |
@@ -129,6 +129,8 @@ Timer는 집중 도구, Growth는 해석 도구, Ranking은 비교 도구, Commu
 - 성장은 chart 수가 아니라 방향과 근거로 이해된다.
 - cube identity는 3×3 geometry, scramble notation과 제한된 signal color에서 드러난다.
 - content와 support 화면도 같은 제품 안에 있지만 Practice보다 앞에 나오지 않는다.
+
+Measured Momentum은 semantic visual direction이다. exact spacing, component proportion과 surface 빈도는 Approved Target Mockup을 선택한 뒤 implementation-ready detail로 확정한다.
 
 ### Light / Dark proposal
 
@@ -173,20 +175,17 @@ Home | Timer | My Page/Growth | Rankings | More
 
 Timer는 ordinary page card가 아니라 viewport의 중심 practice stage다.
 
-### Desktop hierarchy
+### Content hierarchy
 
 ```text
 Event · connection/context
-Scramble notation                         Scramble visual
-────────────────────────────────────────────────────────
-                     Timer stage          Ao5 / Ao12
-                     00.000               Recent solves
-                     State                Current PB*
-────────────────────────────────────────────────────────
-Penalty · save/recovery action
+Scramble notation · scramble visual
+Timer stage · time · state
+Stopped result · penalty · save/recovery action
+Ao5 · Ao12 · recent solves · Current PB
 ```
 
-`Current PB`는 Growth read contract를 사용할 수 있을 때만 추가한다. Timer redesign PR은 V2.1의 Ao5/Ao12와 recent solves를 먼저 보존한다.
+Desktop target은 이 정보 순서를 유지한다. 실제 placement는 Center Stage, Instrument Bench, Focus Canvas 중 선택된 Variant에서 확정한다. `Current PB`는 Growth read contract를 사용할 수 있을 때만 추가한다. Timer redesign PR은 V2.1의 Ao5/Ao12와 recent solves를 먼저 보존한다.
 
 ### State contract
 
@@ -207,7 +206,7 @@ Timer state machine, `KEYBOARD`/`TOUCH` provenance, canonical integer millisecon
 
 - iPhone portrait: scramble은 stage 상단에서 2~3줄까지 허용하고 VisualCube는 접을 수 있는 보조 정보로 둔다. 숫자는 `clamp()` 기반으로 viewport width에 맞추고 recent solves는 stage 아래 compact list 또는 drawer로 이동한다.
 - Timer landscape: top/footer navigation을 축소하고 scramble을 한 줄 context bar로 둔다. 숫자를 중앙, recent/Ao rail을 오른쪽 또는 하단 얇은 rail로 배치한다. full-screen API는 사용하지 않는다.
-- Desktop: main stage와 performance rail을 divider로 분리하고 outer card는 두지 않는다.
+- Desktop: selected target이 performance data를 rail, compact strip 또는 collapsible edge region에 배치한다. outer card는 두지 않는다.
 - holding, ready와 running 동안 nonessential content의 contrast를 낮추지만 DOM에서 제거하거나 focus 순서를 바꾸지 않는다.
 
 별도 distraction-free fullscreen toggle은 V2.2 기본 범위에 넣지 않는다. state-based focus만 제공하고 실제 수요와 mobile browser behavior를 확인한 뒤 검토한다.
@@ -314,13 +313,207 @@ My Growth | Records
 
 Feedback은 같은 form primitive를 사용한다. Admin은 public primary navigation에서 분리하고 compact filter, table/list와 operational status를 우선한다. redesign은 permission, route와 workflow를 바꾸지 않는다.
 
-## AI-generated asset strategy
+## AI UI Screen Mockup workflow
 
-AI-generated image는 product structure를 설명하거나 functional control을 대신하지 않는다.
+V2.2 UI redesign proposal은 repository의 functional contract를 먼저 유지하고 AI UI Screen Mockup으로 visual decision을 진행한다.
+
+~~~text
+Product / UX contract
+→ Visual Direction
+→ AI UI Screen Mockup 생성
+→ 여러 시안 비교
+→ 선택 및 수정
+→ Desktop / Mobile Target Mockup 승인
+→ approved mockup에서 visual rule 추출
+→ Design System implementation detail 확정
+→ React/CSS 구현
+→ 구현 screenshot
+→ Target Mockup 비교
+→ visual gap 수정
+~~~
+
+### AI UI Screen Mockup
+
+AI UI Screen Mockup은 디자인 결정을 위한 visual reference다. 실제 application bundle에 삽입하지 않는다.
+
+- layout과 composition
+- visual hierarchy와 information density
+- spacing proportion, surface와 color balance
+- typography hierarchy
+- navigation appearance와 major component proportion
+- desktop, mobile portrait와 Timer landscape의 responsive visual intent
+
+### Runtime AI Asset
+
+Runtime AI Asset은 실제 제품이 선택적으로 로드할 수 있는 이미지다. Guest Home key visual, OG/social image, optional illustration과 optional empty state가 여기에 속한다. Runtime AI Asset은 redesign workflow의 핵심 산출물이 아니며 UI 구현을 막지 않는다.
+
+### Functional source of truth
+
+Approved Target Mockup은 visual reference이며 기능 Source of Truth가 아니다. 실제 text/copy, Timer state machine, canonical timing, keyboard/touch 처리, Record lifecycle, API, auth, permissions, routing, accessibility, focus order, loading과 error contract는 repository의 requirement, code와 test를 따른다.
+
+생성 이미지에 잘못된 text, fake number 또는 존재하지 않는 control이 있어도 구현하지 않는다. accessibility 또는 usability requirement와 mockup이 충돌하면 requirement가 우선한다.
+
+### Approval gates
+
+다음 단계는 서로 별도 승인이다.
+
+1. mockup 생성
+2. mockup 선택
+3. mockup 수정
+4. Target Mockup 승인
+5. React/CSS code implementation
+
+Target approved 상태가 되어도 code implementation은 자동으로 시작하지 않는다.
+
+### Screen rollout and target approval
+
+각 화면은 해당 target mockup이 승인되기 전 production UI 구현을 시작하지 않는다.
+
+~~~text
+Phase A — Timer
+Desktop Variant A
+Desktop Variant B
+Desktop Variant C
+→ 하나 선택
+→ 수정
+→ Desktop Target 승인
+→ Mobile Portrait Target
+→ Mobile Landscape Target
+→ 승인
+
+Phase B — Core
+Home Desktop/Mobile
+Rankings Desktop/Mobile
+MyPage Records Desktop/Mobile
+
+Phase C — My Growth
+My Growth Desktop/Mobile
+
+Phase D
+Community
+Learning
+Auth
+Q&A
+Feedback
+Admin
+~~~
+
+### Timer desktop exploration
+
+Timer Desktop 시안은 같은 Measured Momentum language 안에서 실제 layout을 다르게 비교한다. 색상만 바꾼 변형은 만들지 않는다.
+
+| Variant | Layout | 확인할 판단 |
+| --- | --- | --- |
+| A. Center Stage | scramble을 상단 context로 두고 큰 중앙 Timer stage를 배치한다. 오른쪽 performance rail에 Ao, PB와 compact recent solves를 둔다. | Timer와 secondary performance data의 균형 |
+| B. Instrument Bench | scramble → timer → stopped result를 강한 수직축으로 배치한다. Ao와 recent solves는 하단 compact strip으로 모은다. | solve flow가 가장 직접적으로 읽히는지 |
+| C. Focus Canvas | Timer가 viewport 대부분을 차지한다. scramble은 얇은 상단 context로 두고 secondary data는 edge rail 또는 접히는 영역으로 보낸다. | running 상태에서 distraction을 얼마나 줄일 수 있는지 |
+
+### Screenshot evidence and target storage
+
+Current Baseline Screenshot은 기존 실제 UI를, Approved Target Mockup은 AI image generation으로 선택·수정해 승인한 목표 UI를, Actual Implementation Screenshot은 React/CSS 구현 결과를 뜻한다.
+
+구현 PR은 가능한 경우 세 이미지를 함께 비교한다. pixel-perfect 복제보다 primary focus, layout hierarchy, relative spacing, palette, surface hierarchy, typography hierarchy, density, major proportion과 navigation structure의 일치를 확인한다.
+
+exploration mockup은 repository에 저장하지 않는다. implementation reference가 필요한 최종 approved target만 versioned 보관한다.
+
+~~~text
+docs/assets/ui-targets/
+├─ timer/
+├─ home/
+├─ rankings/
+├─ mypage/
+└─ growth/
+~~~
+
+## UI Screen Mockup Prompt Pack
+
+각 prompt는 단독으로 image generation model에 전달할 수 있다. 생성된 text, number와 control은 visual placeholder이며 implementation contract가 아니다.
+
+### Timer Desktop Variant A — Center Stage
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop Timer screen with a compact top navigation, scramble notation and a small cube reference across the top, a large centered dark Timer focus stage, stable oversized timer digits, a visible idle or stopped state message, and a right performance rail for Ao5, Ao12, current PB when available, and a compact recent solves list. Keep penalty, save, Retry, and Discard actions close to the stopped-result area without inventing new behavior. Use a warm neutral canvas, deep green primary, restrained amber PB accent, a dark Timer focus stage, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Timer Desktop Variant B — Instrument Bench
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop Timer screen organized as an instrument bench: scramble at the top, a single strong vertical axis through the dark timer stage, then the stopped result and its penalty or recovery controls. Put Ao5, Ao12, current PB when available, and recent solves in one compact horizontal strip along the bottom instead of a side rail. The timer, result, and next-solve context must read as one deliberate sequence. Use a warm neutral canvas, deep green primary, restrained amber PB accent, a dark Timer focus stage, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Timer Desktop Variant C — Focus Canvas
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop Timer screen where the dark Timer focus stage fills most of the viewport. Keep scramble notation in a narrow top context bar. Put Ao5, Ao12, current PB when available, recent solves, and secondary controls in a thin edge rail or a clearly collapsible secondary region so running timing remains visually dominant. Show a focused, calm precision tool rather than a dashboard. Use a warm neutral canvas, deep green primary, restrained amber PB accent, a dark Timer focus stage, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Timer Mobile Portrait
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 390 by 844 iPhone portrait Timer screen that adapts the approved desktop Timer direction. Keep compact scramble notation above a large dark Timer focus stage, make the timer digits dominant, keep the state message clear, and move Ao5, Ao12, recent solves, and recovery detail into a compact lower region or drawer without hiding the primary practice action. Include a compact context bar and mobile bottom navigation with safe-area spacing. Use a warm neutral canvas, deep green primary, restrained amber PB accent, a dark Timer focus stage, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Timer Mobile Landscape
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show an 844 by 390 iPhone landscape Timer screen that adapts the approved desktop Timer direction. Minimize the shell, keep scramble as a compact single-line context, size the dark Timer focus stage by viewport height, and place recent solves plus Ao5 and Ao12 in a thin right or lower rail. Preserve a calm direct practice surface with visible state feedback and safe-area spacing; do not use a browser fullscreen treatment. Use a warm neutral canvas, deep green primary, restrained amber PB accent, a dark Timer focus stage, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Home Desktop
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 authenticated Home screen whose primary action is Continue Practice. Place the action, current scramble context, and a concise recent performance summary above compact activity and secondary Community content. Do not repeat a full Record table or a full Growth dashboard. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Home Mobile
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 390 by 844 authenticated Home screen with Continue Practice as the immediate primary action, a compact recent performance summary, a small activity preview, and secondary Community content below. Preserve a deliberate mobile reading order instead of stacking desktop cards. Include compact top context and bottom navigation with safe-area spacing. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Rankings Desktop
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop Rankings screen with an event selector and nickname search in one compact toolbar, a restrained top-three treatment, and a dense leaderboard table for rank, nickname, and PB. Highlight the current member with a label and structural contrast rather than color alone. Favor fast comparison over podium spectacle. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### Rankings Mobile
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 390 by 844 mobile Rankings screen with compact event selection and nickname search, then scan-friendly one-line leaderboard rows for rank, nickname, and PB. Use a small top-three summary only when it does not push the comparison list below the fold. Include mobile bottom navigation and safe-area spacing. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### MyPage Records Desktop
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop MyPage Records screen with clear internal navigation between My Growth, Records, and account utility. Make Records management the active section: dense solve rows, penalty and delete actions, pagination, and compact profile context. Keep account settings out of the main data surface. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### MyPage Records Mobile
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 390 by 844 mobile MyPage Records screen with compact section navigation, an active Records section, readable solve rows, accessible penalty and delete actions, and pagination or progressive loading without horizontal overflow. Keep account utility separate from the record list and include bottom navigation with safe-area spacing. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### My Growth Desktop
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 1440 by 900 desktop private My Growth screen in this order: current level with PB, recent Ao5 and recent Ao12; recent direction with a 30-day daily median chart; consistency with IQR, DNF and plus-two context; PB progression; practice activity; and a clear next Practice action. Group information with typography, dividers, and measured surfaces instead of giving every metric its own rounded card. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+### My Growth Mobile
+
+~~~text
+Create a realistic production-ready web application screenshot for Cubing Hub, a Measured Momentum precision cubing practice and performance web application. Show a 390 by 844 mobile private My Growth screen with the same question order as desktop: current PB, recent Ao5 and Ao12; recent direction; consistency; PB progression; practice activity; then next Practice. Use one readable chart at a time with sparse labels and supporting text summaries. Avoid a generic analytics dashboard and preserve a direct route back to Timer. Include compact section navigation, bottom navigation, and safe-area spacing. Use a warm neutral canvas, deep green primary, restrained amber PB accent, medium-high information density, minimal shadow, controlled radius, divider and typography driven hierarchy, and subtle 3x3 cubing identity. Make the layout feasible in React/CSS with consistent spacing and component geometry. No purple SaaS gradient, no blue SaaS gradient, no glassmorphism, no excessive rounded cards, no giant marketing hero, no generic analytics dashboard, no decorative icon boxes, no emoji, no gamer UI, no neon glow, no rainbow six-color palette, no excessive shadows, no Dribbble fantasy UI. This is a UI screen reference, not concept art, a poster, or a marketing landing page. Approximate generated copy and fake numbers are visual placeholders, not product requirements.
+~~~
+
+## Runtime AI Asset Strategy
+
+Runtime AI Asset은 product structure를 설명하거나 functional control을 대신하지 않는다. UI Screen Mockup과 달리 실제 application에서 optional image로 사용될 수 있다.
 
 | Asset | 필요성 | Purpose·screen | Format·crop | Theme·cost | Decision proposal |
 | --- | --- | --- | --- | --- | --- |
-| Cubing Hub key visual | Optional | Guest Home 또는 OG/social에서 precision practice identity 전달 | 16:9 master, 4:5 center-safe crop | light-first, AVIF/WebP fallback과 size budget 필요 | UI foundation 뒤 별도 승인 시 생성 |
+| Cubing Hub key visual | Optional | Guest Home 또는 OG/social에서 precision practice identity 전달 | 16:9 master, 4:5 center-safe crop | light-first, AVIF/WebP fallback과 size budget 필요 | core UI 구조 안정 뒤 별도 승인 시 생성 |
 | Auth visual | Low | wide AuthShell의 비어 있는 보조 영역 | 4:5, mobile에서는 숨김 | light surface 전용, lazy load | V2.2에서는 만들지 않음 |
 | Empty Practice | Low | 저장된 solve가 없는 recent area | transparent 3:2, action을 침범하지 않음 | 작은 asset만 허용 | CSS/SVG geometry 우선 |
 | Empty Growth | Optional | metric sample이 없는 My Growth | transparent 3:2, mobile center crop | lazy load, text alternative 불필요한 decorative 처리 가능 | foundation 뒤 검토 |
@@ -329,9 +522,9 @@ AI-generated image는 product structure를 설명하거나 functional control을
 
 Button, navigation, form, chart, timer digit, table, metric과 UI text는 이미지로 만들지 않는다. Cube geometry를 code-native SVG/CSS로 충분히 표현할 수 있으면 raster asset을 추가하지 않는다.
 
-## Image prompt pack
+## Runtime Asset Prompt Candidates
 
-실제 생성은 별도 승인 뒤 수행한다. 모든 prompt는 `Measured Momentum` palette와 safe crop을 기준으로 하며 특정 작가나 브랜드의 visual style을 복제하지 않는다.
+Runtime AI Asset 생성은 별도 승인 뒤 수행한다. 모든 prompt는 Measured Momentum palette와 safe crop을 기준으로 하며 특정 작가나 브랜드의 visual style을 복제하지 않는다.
 
 ### 1. Cubing Hub key visual
 
@@ -397,9 +590,11 @@ Design Gate 승인 대상만 정리한다. `Default`는 별도 선호가 없을 
 | Light/Dark | Light-first / Dark-first / both first-class | Light-first, theme-ready token | current light UI에서 migration 범위와 chart QA를 통제한다. | dark 사용 수요를 바로 충족하지 못한다. | Light-first | Yes |
 | Navigation | top / sidebar / desktop top + mobile bottom | desktop top + mobile bottom | current route를 보존하면서 mobile core action 순서를 개선한다. | More 안으로 이동한 content destination 발견성이 낮아질 수 있다. | Hybrid | Yes |
 | MyPage/Growth IA | 한 화면 / 별도 Growth route / `/mypage` internal sections | `/mypage`: My Growth + Records, Account utility | private Growth proposal과 current route를 함께 보존한다. | section state와 deep link 기준이 필요하다. | Internal sections | Yes |
-| AI visual 사용량 | 없음 / 제한 / 적극 사용 | 제한, UI foundation 뒤 optional | functional UI와 brand asset의 책임을 분리한다. | 생성 품질과 bundle cost가 불확실하다. | 생성하지 않음 | No |
+| UI design workflow | contract-first / mockup-first / code-first | AI visual mockup-first + repository functional contract | functional contract를 보존하면서 screen hierarchy와 visual detail을 먼저 비교한다. | mockup을 기능 명세로 오해할 수 있다. | Mockup-first | Yes |
+| Design System timing | 모든 visual value 선확정 / semantic foundation 후 target 확정 | semantic foundation 먼저, visual detail은 Approved Target Mockup 뒤 확정 | token 의미는 일관되게 유지하고 실제 layout에 맞는 value만 고정한다. | target approval 전 implementation이 지연된다. | Semantic first | Yes |
+| Runtime AI Asset | 없음 / optional / 적극 사용 | optional | visual reference와 runtime bundle을 분리한다. | 생성 품질과 bundle cost가 불확실하다. | 생성하지 않음 | No |
 | Timer distraction-free | 없음 / state-based focus / fullscreen toggle | state-based focus | 기존 interaction과 browser lifecycle을 바꾸지 않고 집중도를 높인다. | 일부 사용자는 explicit fullscreen을 원할 수 있다. | State-based focus | No |
-| Screenshot strategy | manual / Playwright / Storybook+Chromatic | fixed viewport manual before/after, automation은 구조 안정 뒤 재평가 | current visual infra가 없고 초기 churn이 크다. | pixel regression을 자동 차단하지 못한다. | Manual baseline | Yes, before first screen migration |
+| Screenshot strategy | manual / Playwright / Storybook+Chromatic | fixed viewport baseline / target / implementation 비교, automation은 구조 안정 뒤 재평가 | current visual infra가 없고 초기 churn이 크다. | pixel regression을 자동 차단하지 못한다. | Manual evidence | Yes, before first screen migration |
 
 ## Current, Proposal and Out of Scope
 
@@ -415,7 +610,8 @@ Design Gate 승인 대상만 정리한다. `Default`는 별도 선호가 없을 
 - `Measured Momentum`, light-first semantic token
 - Core Loop 중심 App Shell
 - Timer focus stage와 private My Growth hierarchy
-- 제한된 AI asset과 manual visual baseline
+- AI UI Screen Mockup exploration, Target Mockup approval과 manual visual evidence
+- optional Runtime AI Asset
 
 ### Future candidate
 

--- a/docs/00-product/ui-visual-direction.md
+++ b/docs/00-product/ui-visual-direction.md
@@ -1,0 +1,434 @@
+---
+doc_type: product
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/00-product/vision.md
+  - docs/00-product/prd.md
+  - docs/00-product/roadmap.md
+  - docs/01-domain/growth-metrics.md
+  - docs/02-requirements/features/timer.md
+  - docs/02-requirements/features/growth.md
+  - docs/02-requirements/features/profile.md
+  - docs/03-architecture/frontend-architecture.md
+  - docs/03-architecture/frontend-design-system.md
+  - docs/03-architecture/growth-architecture.md
+---
+# UI Visual Direction
+
+## Status
+
+이 문서는 Cubing Hub UI/UX redesign의 Design Gate proposal이다. 제품 기능, Timer·Record 계약과 V2.2 Growth metric을 변경하지 않는다. visual direction과 screen hierarchy가 승인되기 전에는 구현 계약으로 사용하지 않는다.
+
+Cubing Hub는 generic dashboard가 아니라 다음 경험을 연결하는 큐빙 활동 제품이다.
+
+```text
+Practice
+→ Record
+→ Improve
+→ Participate
+→ Profile
+→ Practice
+```
+
+UI는 precision timing tool, sports performance product, personal growth tracker의 성격을 먼저 보여 준다. Participation은 현재 기능과 future gate를 구분하고, 아직 제공하지 않는 기능을 navigation에 노출하지 않는다.
+
+## Current UI audit
+
+Current source와 repository의 V1 historical screenshot을 함께 살폈다. screenshot은 과거 visual evidence이며 current 화면으로 간주하지 않는다. Current 판단은 `frontend/src`의 route, component와 CSS를 기준으로 한다.
+
+### 공통 문제
+
+1. 큰 panel, rounded card, pale tint, shadow가 page와 data unit에 반복돼 hierarchy가 border에 의존한다.
+2. blue tint와 background gradient가 모든 화면의 기본 인상이어서 precision sports identity가 약하다.
+3. icon box, badge와 metric card가 의미보다 장식 단위로 반복된다.
+4. Home, MyPage와 Timer recent area가 비슷한 summary를 각자 보여 줘 화면 역할이 겹친다.
+5. mobile 대응은 desktop grid를 한 열로 접거나 table row를 card로 바꾸는 방식이 많다. 핵심 행동 순서는 그대로 재설계되지 않는다.
+6. Timer 숫자와 통계 숫자가 일반 UI typography를 공유해 빠른 판독과 숫자 폭 안정성을 별도로 보장하지 않는다.
+7. loading, empty, error, confirmation과 form feedback이 page별 pattern으로 흩어져 있다.
+8. page별 CSS와 one-off class가 많아 같은 interaction도 화면마다 밀도, radius, shadow와 상태 표현이 달라진다.
+
+### 화면별 역할과 우선순위
+
+| 화면 | 역할 | Primary action | Secondary action | 현재 UX·visual 문제 | Mobile 문제 | Redesign priority |
+| --- | --- | --- | --- | --- | --- | --- |
+| Home | 다음 행동 결정 | Practice 계속하기 | Growth·content로 이동 | scramble, 통계, community와 records가 같은 무게로 이어져 MyPage와 중복된다. | 긴 dashboard stack으로 변한다. | High |
+| Timer | Practice와 Record 저장 | solve 측정 | penalty·recent solve 관리 | Timer stage가 scramble·recent card와 같은 panel hierarchy에 놓인다. | portrait scroll이 길고 landscape 전용 구성이 없다. | Critical |
+| Rankings | 현재 PB 비교 | 순위 탐색 | event 선택·nickname 검색 | podium이 비교보다 장식에 가까워질 수 있고 table과 밀도 차이가 크다. | top 3가 긴 card stack이 된다. | High |
+| MyPage | private history·account | 기록 확인·관리 | profile·password 관리 | profile, legacy summary, raw trend, records와 account modal이 한 화면에 섞인다. | 핵심 정보까지 긴 scroll이 필요하다. | Critical |
+| Learning | 학습 콘텐츠 탐색 | case 학습 | curriculum tab 전환 | 실제 content card와 page panel의 구분이 약하다. | tab과 case 비교가 단순 1열로 축소된다. | Medium |
+| Community | 게시글 탐색·참여 | 글 읽기·작성 | category·검색 | filter, search, list와 metadata가 one-off pattern으로 구성된다. | desktop table과 별도 card hierarchy가 생긴다. | Medium |
+| Post detail/write/edit | 읽기·댓글·작성 | 콘텐츠 소비·입력 | edit·delete·comment | reading width, metadata, form과 action hierarchy가 통일되지 않았다. | action이 full-width 또는 horizontal overflow로만 대응한다. | Medium |
+| Login | 인증 | 로그인 | Signup·password reset 이동 | functional form보다 decorative shell 비중이 크다. | desktop column을 접는 수준이다. | Medium |
+| Signup·verification | 계정 생성 | 단계 완료 | resend·Login 이동 | form 단계는 있으나 Login과 shell·feedback을 중복한다. | mobile keyboard와 submit visibility 기준이 없다. | Medium |
+| Password reset | 계정 복구 | 비밀번호 변경 | Login 이동 | Auth 상태·오류 pattern을 별도로 반복한다. | form focus와 오류 이동 기준이 없다. | Medium |
+| Feedback·Q&A | 지원 접점 | 질문·의견 전달 | 상태·답변 확인 | Community와 유사한 list/form/status를 별도 style로 만든다. | action이 한 열로만 변한다. | Low |
+| Admin | 운영 관리 | feedback·memo 처리 | filter·detail 탐색 | public visual과 같은 card·badge 문법이 operational density를 낮춘다. | 긴 card stack이 된다. | Low |
+
+Current source 경로와 세부 component 분류는 [Frontend Design System](../03-architecture/frontend-design-system.md)에서 관리한다.
+
+## Design principles
+
+### Practice first
+
+Timer 진입과 다음 Practice가 가장 빠르게 보여야 한다. Home은 기능 directory가 아니라 다음 행동을 고르는 시작점이다.
+
+### Data before decoration
+
+시간, trend, sample과 상태를 먼저 읽을 수 있어야 한다. section은 spacing, typography, divider와 surface 차이로 구분하고 모든 metric을 card로 만들지 않는다.
+
+### Calm precision
+
+정확성과 속도는 과도한 glow나 animation이 아니라 안정된 숫자, 일관된 alignment, 분명한 state와 짧은 feedback으로 표현한다.
+
+### Subtle cubing identity
+
+Cube 6색 전체를 main palette로 사용하지 않는다. 단일 primary accent, PB signal, 3×3 geometry와 scramble notation을 필요한 지점에만 사용한다.
+
+### One system, different focus
+
+Timer는 집중 도구, Growth는 해석 도구, Ranking은 비교 도구, Community와 Learning은 content 도구다. 같은 token과 primitive를 사용하되 모든 화면을 같은 dashboard layout으로 만들지 않는다.
+
+## Visual Direction 3안
+
+| 항목 | A. Precision Bench | B. Measured Momentum | C. Arena Signal |
+| --- | --- | --- | --- |
+| 한 줄 concept | 교정된 timing 장비처럼 정확하고 절제된 작업면 | 연습의 흐름과 성장 방향을 빠르게 읽는 performance journal | 경쟁 직전의 집중과 순위를 강조하는 high-contrast sports interface |
+| 제품 분위기 | technical, quiet, exact | focused, progressive, grounded | intense, competitive, immediate |
+| Reference category | professional timing equipment, developer-grade precision tool | sports performance application, editorial/data product | competitive sports interface, event timing display |
+| Color philosophy | cold neutral과 cyan signal 하나 | warm neutral, deep green primary, amber PB | charcoal 기반, bright cyan과 amber signal |
+| Typography | condensed UI와 monospace 숫자 비중이 큼 | 자연스러운 sans UI와 안정된 monospace 숫자 분리 | 굵은 condensed heading과 큰 scoreboard 숫자 |
+| Surface | flat white/gray workbench | warm background 위 flat section과 필요한 raised surface | dark layered surface와 강한 contrast plane |
+| Border | 1px hairline 중심 | subtle border와 divider 중심 | strong border와 state strip 중심 |
+| Radius | 0~6px | 4~12px | 4~8px |
+| Shadow | overlay 외 사용하지 않음 | shell·overlay에만 제한 | raised competition module에 제한 |
+| Spacing·density | compact | medium-dense | compact, large focal number |
+| Iconography | 작은 technical outline | 의미 있는 action·status에만 outline | 높은 contrast의 minimal outline/filled signal |
+| Motion | 즉각적인 100~160ms state change | 120~240ms selection·panel transition | 짧은 score/state reveal |
+| Chart | grid와 label이 정밀한 analytical chart | 설명 문장과 함께 읽는 quiet chart | current point와 delta가 강한 chart |
+| Timer | 중심 장비처럼 가장 강함 | 집중 stage와 옆 performance rail | dark scoreboard와 competition 긴장감 |
+| Growth | dense analysis table에 가까움 | 지금→방향→안정성→장기→활동 narrative | delta와 PB를 크게 강조 |
+| Mobile | compact tool tray | core action 순서 중심의 bottom navigation | full-screen focus와 bold status |
+| AI-generated visual | 거의 사용하지 않음 | optional key visual·empty-state에 제한 | campaign/achievement visual에 비교적 적극적 |
+| 장점 | Timer 신뢰와 정보 밀도가 높다. | Core Loop 전체, Growth와 content 화면을 한 system으로 연결하기 쉽다. | Timer와 Ranking의 존재감이 강하다. |
+| 위험 | 차갑고 developer tool처럼 보일 수 있다. Community·Learning 확장이 약하다. | 구현이 평범해지면 sports identity가 희미해질 수 있다. | competition이 아직 중심이 아닌 제품을 gamer app처럼 보이게 할 수 있다. Dark QA 비용도 크다. |
+| Cubing Hub 적합도 | 4/5 | 5/5 | 3/5 |
+
+## Recommended direction: Measured Momentum
+
+`Measured Momentum`을 Design Gate 기본안으로 둔다. Practice의 집중, Growth의 해석, Ranking의 비교와 Community·Learning의 읽기 경험을 한 방향에서 다룰 수 있다. Timer에는 `Precision Bench`의 numeric discipline과 집중 stage를 가져오되 별도 theme처럼 보이지 않게 같은 color, type와 spacing token을 사용한다.
+
+이 방향은 다음 인상을 목표로 한다.
+
+- 시간과 상태가 정확해 보인다.
+- 연습 직후 다음 정보를 빠르게 찾을 수 있다.
+- 성장은 chart 수가 아니라 방향과 근거로 이해된다.
+- cube identity는 3×3 geometry, scramble notation과 제한된 signal color에서 드러난다.
+- content와 support 화면도 같은 제품 안에 있지만 Practice보다 앞에 나오지 않는다.
+
+### Light / Dark proposal
+
+V2.2까지는 light-first로 구현한다. semantic token은 future theme mapping이 가능하게 설계하지만 dark theme toggle과 dark visual regression matrix는 만들지 않는다. 야간 사용 선호를 뒷받침하는 현재 근거가 없고, 두 theme을 동시에 first-class로 만들면 component와 chart QA 범위가 두 배로 늘어난다.
+
+Timer의 dark `focus stage`는 full dark theme이 아니다. 같은 light shell 안에서 timing 영역만 주변 정보와 분리하는 surface다. 실제 dark theme은 Timer 사용 환경과 사용자 반응을 확인한 뒤 별도 gate로 연다.
+
+## App Shell and navigation
+
+Generic sidebar는 사용하지 않는다. Current top navigation과 mobile bottom navigation의 장점을 유지하면서 Core Loop 순서에 맞게 destination을 재배치한다.
+
+### Desktop
+
+```text
+[Cubing Hub]
+Home  Timer  My Page/Growth  Rankings  Explore ▾
+                                      Learning
+                                      Community
+                                      Q&A
+                           [Account ▾]
+```
+
+- Home, Timer, My Page/Growth와 Rankings가 primary destination이다.
+- V2.2 My Growth 출시 전에는 `/mypage`를 `My Page`로 표시한다. Growth가 구현된 뒤 같은 route를 `My Growth`로 승격한다.
+- Learning, Community와 Q&A는 `Explore`에 모으되 direct route와 deep link를 유지한다.
+- Feedback, account settings와 logout은 account menu에 둔다.
+- Admin은 ADMIN account menu에만 노출한다.
+- Daily Challenge는 승인 전 빈 slot이나 disabled item으로 노출하지 않는다. 출시가 확정되면 primary navigation 또는 Explore에 추가할 수 있는 data-driven nav model을 사용한다.
+
+### Mobile
+
+```text
+Home | Timer | My Page/Growth | Rankings | More
+```
+
+- Timer는 중앙 destination이지만 floating action처럼 shell을 깨지 않는다. active indicator와 label weight로 우선순위를 높인다.
+- More에는 Learning, Community, Q&A, Feedback와 account utility를 둔다.
+- top bar는 brand/context와 account action만 남긴다.
+- bottom navigation은 safe area를 포함하고 44×44px 이상의 touch target을 유지한다.
+
+## Timer UX
+
+Timer는 ordinary page card가 아니라 viewport의 중심 practice stage다.
+
+### Desktop hierarchy
+
+```text
+Event · connection/context
+Scramble notation                         Scramble visual
+────────────────────────────────────────────────────────
+                     Timer stage          Ao5 / Ao12
+                     00.000               Recent solves
+                     State                Current PB*
+────────────────────────────────────────────────────────
+Penalty · save/recovery action
+```
+
+`Current PB`는 Growth read contract를 사용할 수 있을 때만 추가한다. Timer redesign PR은 V2.1의 Ao5/Ao12와 recent solves를 먼저 보존한다.
+
+### State contract
+
+| State | Primary presentation | Required action·message |
+| --- | --- | --- |
+| idle | neutral stage, stable `00.000`, concise keyboard/touch hint | press and hold affordance |
+| holding | amber outline와 `계속 누르세요` text | release 전에는 시작하지 않음 |
+| ready | green outline와 `놓으면 시작` text | color 없이 label로도 구분 |
+| running | 숫자 외 decoration과 lower rail을 visually recede | continuous animation 없음 |
+| stopped | canonical integer millisecond를 가장 강하게 표시 | penalty와 save status를 숫자 가까이에 배치 |
+| pending recovery | stage 안의 persistent recovery notice | Retry를 primary, Discard를 explicit destructive action으로 제공 |
+| error | 원인과 recovery action을 같은 영역에 표시 | retry 가능 여부를 구분 |
+| next scramble loading | 이전 solve와 새 scramble 사이 lock를 표시 | fresh response가 pending state를 덮어쓰지 않음 |
+
+Timer state machine, `KEYBOARD`/`TOUCH` provenance, canonical integer millisecond, pending snapshot, account isolation, Retry/Discard, scramble consistency, next-solve lock, Record save, penalty와 Ao5/Ao12 계산은 바꾸지 않는다.
+
+### Responsive behavior
+
+- iPhone portrait: scramble은 stage 상단에서 2~3줄까지 허용하고 VisualCube는 접을 수 있는 보조 정보로 둔다. 숫자는 `clamp()` 기반으로 viewport width에 맞추고 recent solves는 stage 아래 compact list 또는 drawer로 이동한다.
+- Timer landscape: top/footer navigation을 축소하고 scramble을 한 줄 context bar로 둔다. 숫자를 중앙, recent/Ao rail을 오른쪽 또는 하단 얇은 rail로 배치한다. full-screen API는 사용하지 않는다.
+- Desktop: main stage와 performance rail을 divider로 분리하고 outer card는 두지 않는다.
+- holding, ready와 running 동안 nonessential content의 contrast를 낮추지만 DOM에서 제거하거나 focus 순서를 바꾸지 않는다.
+
+별도 distraction-free fullscreen toggle은 V2.2 기본 범위에 넣지 않는다. state-based focus만 제공하고 실제 수요와 mobile browser behavior를 확인한 뒤 검토한다.
+
+## Growth UX
+
+`/mypage`의 기본 section을 private My Growth로 확장하는 proposal을 유지한다. 정보는 metric card 모음이 아니라 다음 질문 순서로 배치한다.
+
+```text
+지금 어느 정도인가
+Current PB · Recent Ao5 · Recent Ao12
+
+최근 방향이 어떤가
+최근 완료 7일 vs 직전 7일 median · 30-day daily median
+
+안정성이 어떤가
+Latest-12 IQR · DNF · +2 · sample count
+
+장기적으로 어떻게 성장했나
+PB progression
+
+얼마나 연습했나
+7/30-day count · total · daily activity
+
+다음 Practice
+Timer CTA
+```
+
+- PB, Ao5와 Ao12는 하나의 performance strip으로 묶는다.
+- 기간 비교는 숫자와 `빨라짐/느려짐/비교 불가` 문장을 함께 보여 준다.
+- IQR, DNF와 +2는 하나의 consistency section에서 sample 수와 함께 읽는다.
+- chart는 title, concise interpretation, chart, text alternative 순으로 둔다.
+- `현재 남아 있는 기록 기준`, `기록된 활동`, `Asia/Seoul` 같은 canonical 의미는 필요한 위치에서 짧게 설명한다.
+- insufficient sample은 0이나 flat chart로 대체하지 않는다. 필요한 solve 수와 다음 Practice CTA를 보여 준다.
+
+### Chart contract
+
+| Chart | Axis·label | Tooltip | Missing·DNF | Mobile | Text alternative |
+| --- | --- | --- | --- | --- | --- |
+| 30-day daily median | x: Asia/Seoul calendar date, y: completed solve seconds | date, median, completed sample, DNF, +2 | missing day는 gap, DNF-only day는 numeric point 없이 상태 표시 | x label은 주 단위 4~5개, horizontal scroll 없음 | 최근/이전 방향, best/worst median day와 sample summary |
+| PB progression | x: `createdAt`, y: effective seconds, lower is better | date, effective time, penalty, Record id link candidate | current retained Record 기준으로 point 재계산, DNF point 없음 | 최근 milestone 우선, older pagination | milestone을 시간순 list로 제공 |
+| Daily activity | x: Asia/Seoul date, y: solve count integer | date, total count, completed/DNF count | 기록 없는 날은 0, DNF도 activity count에는 포함 | 30 bars 유지, 날짜 label은 주 단위 | 7/30-day count, active days와 daily count list |
+
+Recharts 3.8.1로 세 chart를 구현할 수 있다. Design Gate에서는 새 chart library를 추가하지 않는다.
+
+## Home, Rankings and MyPage
+
+### Home
+
+Home은 `다음에 무엇을 할지`를 결정하는 화면이다.
+
+1. Continue Practice와 current scramble을 primary action으로 둔다.
+2. 최근 performance는 PB/Ao와 한 줄 변화 요약만 보여 주고 상세 내용은 My Growth로 연결한다.
+3. 최근 activity는 compact preview로 제한하고 full Record table을 반복하지 않는다.
+4. Community는 secondary feed로 두고 Learning/Community directory card를 만들지 않는다.
+5. Guest는 Timer 체험과 제품 loop를 설명하되 빈 개인 통계 placeholder를 보여 주지 않는다.
+
+### Rankings
+
+- event selector와 nickname search를 한 toolbar로 묶는다.
+- top 3는 compact leading row로 유지하되 큰 podium illustration은 사용하지 않는다.
+- 내 순위는 list 안 highlight와 상단 jump link를 함께 제공한다.
+- current user는 `내 순위` label, left rule와 text weight로 구분하고 color만 사용하지 않는다.
+- mobile row는 rank, nickname, PB를 한 줄에서 비교한다. 선택 event는 toolbar에 있으므로 각 row에서 반복하지 않는다.
+- loading은 row skeleton, empty는 search/event 조건과 recovery action을 보여 준다.
+
+### MyPage
+
+```text
+My Growth | Records
+                      Account menu
+```
+
+- 기본 section은 My Growth다.
+- Records는 history, pagination, penalty와 delete를 소유한다.
+- Account는 profile과 password를 account menu의 dialog 또는 drawer에서 다룬다.
+- 신규 Public Profile route/API와 visibility setting은 V2.2에 포함하지 않는다.
+- legacy `averageTimeMs` card는 V2.2 UI에서 제거하고 API field deprecation 계약은 Growth 문서를 따른다.
+
+## Community, Learning and Auth consistency
+
+### Community and Q&A
+
+- Content list, filter toolbar, metadata row, author, pagination과 empty/loading/error를 공통화한다.
+- post detail은 약 70ch reading width를 사용하고 이미지, 본문, metadata와 comment hierarchy를 분리한다.
+- write/edit은 같은 form primitive와 validation placement를 사용한다.
+- category와 status에만 Badge를 쓰고 모든 metadata를 pill로 만들지 않는다.
+
+### Learning
+
+- notation, beginner와 CFOP navigation은 Tabs를 사용한다.
+- Learning case는 실제 반복 content unit이므로 card를 유지할 수 있다. page와 section까지 중첩 card로 감싸지 않는다.
+- cube image, case name과 algorithm을 같은 scan order로 정렬한다.
+- mobile에서는 한 case 안의 image와 algorithm을 유지하고 case 사이 divider로 density를 확보한다.
+
+### Auth
+
+- Login, Signup/verification과 Password Reset은 같은 AuthShell, Field, InlineError와 submit feedback을 사용한다.
+- form이 화면의 primary content다. wide layout에서도 illustration은 필수가 아니다.
+- mobile keyboard가 열려도 current field error와 submit action에 도달할 수 있어야 한다.
+- 인증 실패 뒤 첫 오류로 focus를 이동하고 label, helper와 error를 programmatically 연결한다.
+
+### Feedback and Admin
+
+Feedback은 같은 form primitive를 사용한다. Admin은 public primary navigation에서 분리하고 compact filter, table/list와 operational status를 우선한다. redesign은 permission, route와 workflow를 바꾸지 않는다.
+
+## AI-generated asset strategy
+
+AI-generated image는 product structure를 설명하거나 functional control을 대신하지 않는다.
+
+| Asset | 필요성 | Purpose·screen | Format·crop | Theme·cost | Decision proposal |
+| --- | --- | --- | --- | --- | --- |
+| Cubing Hub key visual | Optional | Guest Home 또는 OG/social에서 precision practice identity 전달 | 16:9 master, 4:5 center-safe crop | light-first, AVIF/WebP fallback과 size budget 필요 | UI foundation 뒤 별도 승인 시 생성 |
+| Auth visual | Low | wide AuthShell의 비어 있는 보조 영역 | 4:5, mobile에서는 숨김 | light surface 전용, lazy load | V2.2에서는 만들지 않음 |
+| Empty Practice | Low | 저장된 solve가 없는 recent area | transparent 3:2, action을 침범하지 않음 | 작은 asset만 허용 | CSS/SVG geometry 우선 |
+| Empty Growth | Optional | metric sample이 없는 My Growth | transparent 3:2, mobile center crop | lazy load, text alternative 불필요한 decorative 처리 가능 | foundation 뒤 검토 |
+| PB achievement | Low | PB 저장 직후 짧은 feedback | transparent 1:1 | reduced motion 대응, 작은 용량 | token·geometry motion 우선, raster 미사용 |
+| Subtle background pattern | Optional | Guest Home/OG background | seamless tile 또는 wide 16:9 | light/dark 별도 생성보다 CSS/SVG 유리 | CSS/SVG 우선 |
+
+Button, navigation, form, chart, timer digit, table, metric과 UI text는 이미지로 만들지 않는다. Cube geometry를 code-native SVG/CSS로 충분히 표현할 수 있으면 raster asset을 추가하지 않는다.
+
+## Image prompt pack
+
+실제 생성은 별도 승인 뒤 수행한다. 모든 prompt는 `Measured Momentum` palette와 safe crop을 기준으로 하며 특정 작가나 브랜드의 visual style을 복제하지 않는다.
+
+### 1. Cubing Hub key visual
+
+- Purpose: Guest Home과 OG/social에서 precision practice와 measured growth를 한 장면에 표현
+- Aspect ratio intent: 16:9 master, 중앙 60%는 4:5 mobile crop에서도 유지
+
+```text
+Create a refined editorial key visual for a precision cubing practice and performance product. Compose an abstract 3x3 cubie geometry slightly off center, built from matte graphite, warm off-white, deep performance green, and one restrained amber milestone accent. Show a subtle sequence from calibrated pieces to an aligned form, suggesting repeated practice and measurable improvement without depicting a dashboard. Use precise edges, tactile polymer and anodized metal materials, soft directional studio lighting, fine paper-like background texture, generous but purposeful negative space, and a clear focal hierarchy around the central cube geometry. Keep important geometry inside the central 60 percent for a 4:5 mobile crop. No people, no childish toy treatment, no rainbow six-color palette, no neon glow, no glassmorphism, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Wide 16:9 composition.
+```
+
+### 2. Auth visual
+
+- Purpose: wide AuthShell의 보조 영역에서 차분한 brand cue 제공
+- Aspect ratio intent: 4:5, mobile에서는 asset 없이 form만 표시
+
+```text
+Create a quiet vertical brand illustration for an authentication screen of a serious cubing practice product. Arrange a small set of precise 3x3 cubie modules along a measured vertical rhythm, with matte warm-white surfaces, graphite seams, deep green accents, and a single amber checkpoint. Use soft side lighting, subtle technical paper texture, restrained shadows, and ample empty space so the functional form remains visually dominant beside the image. The cube representation should feel like calibrated sports equipment, not a toy. No people, no gradients, no rainbow palette, no decorative icons, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Vertical 4:5 composition with a center-safe crop.
+```
+
+### 3. Empty Practice
+
+- Purpose: 아직 저장된 solve가 없는 recent Practice 영역의 보조 visual
+- Aspect ratio intent: transparent 3:2, 320px mobile에서도 식별 가능
+
+```text
+Create a small transparent-background empty-state illustration for a cubing practice timer before the first saved solve. Show one precise unsolved 3x3 cubie outline and a subtle starting marker, using graphite lines, warm-white faces, and one deep green signal. Keep the composition compact, calm, and readable at small size, with minimal material detail and no scenery. Leave clear space below for real product copy and a real action button. No person, no confetti, no rainbow cube, no childish expression, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Transparent 3:2 asset with center-safe mobile crop.
+```
+
+### 4. Empty Growth
+
+- Purpose: Growth sample이 부족할 때 반복 Practice가 data로 이어진다는 의미 보조
+- Aspect ratio intent: transparent 3:2, central composition
+
+```text
+Create a subtle transparent-background empty-state illustration for a personal cubing growth view with insufficient practice data. Use three small calibrated cubie forms progressing from scattered to aligned, connected only by understated spatial rhythm rather than a literal chart. Materials are matte graphite, warm off-white, deep green, and one restrained amber detail. Keep the image secondary to surrounding explanation and the next-practice action. No graph axes, no fake metrics, no trophies, no confetti, no rainbow palette, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Transparent 3:2 composition, centered for narrow mobile crop.
+```
+
+### 5. PB achievement
+
+- Purpose: PB 순간에 사용할 수 있는 작은 celebratory asset 후보
+- Aspect ratio intent: transparent 1:1, short-lived overlay 또는 inline placement
+
+```text
+Create a restrained personal-best achievement symbol for a precision cubing performance product. Center a compact 3x3 geometric mark with one amber milestone face emerging from matte graphite and deep green layers. Use crisp construction, subtle radial separation, controlled studio highlights, and a premium sports-equipment feel. Celebration should feel earned and quiet, without confetti or spectacle. The symbol must remain clear at 96 pixels and work on a warm light background. No medal text, no trophy, no rainbow cube, no glow burst, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Transparent square 1:1 composition.
+```
+
+### 6. Subtle background pattern
+
+- Purpose: Guest Home 또는 brand collateral의 low-contrast background
+- Aspect ratio intent: seamless tile과 16:9 crop 모두 가능한 반복 구조
+
+```text
+Create a seamless low-contrast geometric background pattern inspired by the grid and turning layers of a 3x3 cube. Use thin graphite-gray lines on a warm off-white field with very sparse deep green intersections and an extremely rare amber point. Keep contrast low, spacing generous, geometry precise, and texture lightly tactile so foreground content remains dominant. Avoid literal full cubes and avoid visual noise near the center-safe content area. No gradients, no glow, no rainbow palette, no text, no logo text, no UI screenshot, no fake button, no fake dashboard. Seamless wide 16:9 pattern with mobile-safe central quiet zone.
+```
+
+## Decision Matrix
+
+Design Gate 승인 대상만 정리한다. `Default`는 별도 선호가 없을 때 proposal이 따르는 값이다.
+
+| Decision | Options | Recommendation | Reason | Risk | Default | Blocks implementation? |
+| --- | --- | --- | --- | --- | --- | --- |
+| Visual direction | Precision Bench / Measured Momentum / Arena Signal | Measured Momentum | Core Loop 전체와 Growth·content를 같은 system으로 연결한다. | 평범한 wellness UI로 흐르지 않도록 numeric discipline이 필요하다. | Measured Momentum | Yes |
+| Light/Dark | Light-first / Dark-first / both first-class | Light-first, theme-ready token | current light UI에서 migration 범위와 chart QA를 통제한다. | dark 사용 수요를 바로 충족하지 못한다. | Light-first | Yes |
+| Navigation | top / sidebar / desktop top + mobile bottom | desktop top + mobile bottom | current route를 보존하면서 mobile core action 순서를 개선한다. | More 안으로 이동한 content destination 발견성이 낮아질 수 있다. | Hybrid | Yes |
+| MyPage/Growth IA | 한 화면 / 별도 Growth route / `/mypage` internal sections | `/mypage`: My Growth + Records, Account utility | private Growth proposal과 current route를 함께 보존한다. | section state와 deep link 기준이 필요하다. | Internal sections | Yes |
+| AI visual 사용량 | 없음 / 제한 / 적극 사용 | 제한, UI foundation 뒤 optional | functional UI와 brand asset의 책임을 분리한다. | 생성 품질과 bundle cost가 불확실하다. | 생성하지 않음 | No |
+| Timer distraction-free | 없음 / state-based focus / fullscreen toggle | state-based focus | 기존 interaction과 browser lifecycle을 바꾸지 않고 집중도를 높인다. | 일부 사용자는 explicit fullscreen을 원할 수 있다. | State-based focus | No |
+| Screenshot strategy | manual / Playwright / Storybook+Chromatic | fixed viewport manual before/after, automation은 구조 안정 뒤 재평가 | current visual infra가 없고 초기 churn이 크다. | pixel regression을 자동 차단하지 못한다. | Manual baseline | Yes, before first screen migration |
+
+## Current, Proposal and Out of Scope
+
+### Current
+
+- React SPA, desktop top navigation, mobile bottom navigation
+- Recharts 3.8.1, Lucide, React Toastify
+- V2.1 Timer/Record behavior와 current routes
+- light-only CSS token과 page-specific styles
+
+### Design Gate proposal
+
+- `Measured Momentum`, light-first semantic token
+- Core Loop 중심 App Shell
+- Timer focus stage와 private My Growth hierarchy
+- 제한된 AI asset과 manual visual baseline
+
+### Future candidate
+
+- first-class dark theme
+- Playwright screenshot gate
+- user-validated fullscreen Timer mode
+- optional key visual과 empty-state asset
+
+### Out of scope
+
+- production frontend implementation와 dependency 설치
+- V2.2 backend/API 구현
+- new Public Profile
+- Daily Challenge, Verified Record, Competition과 future event UI
+- AI image generation
+- product requirement, Growth metric와 Roadmap 변경

--- a/docs/03-architecture/frontend-design-system.md
+++ b/docs/03-architecture/frontend-design-system.md
@@ -24,9 +24,22 @@ related:
 
 ## Status and responsibility
 
-이 문서는 [UI Visual Direction](../00-product/ui-visual-direction.md)을 React frontend에 적용하기 위한 architecture proposal이다. token, primitive, layout, App Shell, responsive, accessibility, visual validation과 구현 순서를 다룬다.
+이 문서는 [UI Visual Direction](../00-product/ui-visual-direction.md)을 React frontend에 적용하기 위한 architecture proposal이다. semantic token, primitive, layout, App Shell, responsive, accessibility, visual validation과 구현 순서를 다룬다.
 
 Current implementation 설명은 [Frontend Architecture](frontend-architecture.md), Timer 요구사항은 [Timer](../02-requirements/features/timer.md), V2.2 Growth metric과 API proposal은 [Growth Metrics](../01-domain/growth-metrics.md)와 [Growth Architecture](growth-architecture.md)가 Source of Truth다. 이 문서가 기능·API 계약을 다시 정의하지 않는다.
+
+## Design System decision timing
+
+현재 Design Gate는 semantic foundation을 정한다. Measured Momentum, warm neutral canvas, deep green primary, amber PB accent, light-first, Timer dark focus stage, accessibility invariant와 semantic token은 이 단계에서 유지한다.
+
+Approved Target Mockup 뒤에는 implementation-ready visual detail을 확정한다. mockup은 visual reference일 뿐이며 functional contract나 accessibility contract를 바꾸지 않는다.
+
+| Decision layer | 확정 범위 |
+| --- | --- |
+| Semantic foundation | color의 domain 의미, typography 역할, light-first boundary, Timer focus surface, accessibility invariant, component의 semantic 책임 |
+| Target-dependent visual detail | exact spacing, radius frequency, border frequency, navigation height, content width, typography scale, component proportion, Timer stage proportion, chart density, surface treatment |
+
+Target-dependent detail은 selected target의 hierarchy와 responsive intent를 읽어 token value와 component geometry로 옮긴다. target approval 전에는 visual value를 production implementation 계약으로 고정하지 않는다.
 
 ## Current frontend inventory
 
@@ -47,7 +60,7 @@ Current source에는 4,309줄의 CSS와 881줄 `TimerPage.jsx`, 927줄 `MyPage.j
 
 ## Foundation tokens
 
-Token name은 semantic purpose를 나타낸다. component가 hex, arbitrary spacing, radius 또는 shadow를 직접 선택하지 않는다. 아래 값은 `Measured Momentum` proposal의 light-first starting point이며 implementation visual QA에서 contrast를 확인한 뒤 같은 semantic 의미 안에서 조정할 수 있다.
+Token name은 semantic purpose를 나타낸다. component가 hex, arbitrary spacing, radius 또는 shadow를 직접 선택하지 않는다. 아래 값은 Measured Momentum proposal의 light-first starting point다. semantic 의미는 유지하고 exact value와 component geometry는 Approved Target Mockup 뒤에 확정한다. contrast는 implementation gate에서 다시 확인한다.
 
 ### Color
 
@@ -325,10 +338,12 @@ TimerPage orchestration
 │  ├─ TimerStateMessage
 │  ├─ TimerResultActions
 │  └─ PendingSolveRecovery
-└─ PracticeRail
+└─ PracticeSecondaryData
    ├─ AverageMetric Ao5/Ao12
    └─ SolveList
 ```
+
+PracticeSecondaryData의 desktop placement는 selected Timer target에 따라 rail, compact strip 또는 collapsible edge region으로 결정한다.
 
 ### Presentation priority
 
@@ -423,7 +438,9 @@ Lucide outline icon을 유지한다.
 - decorative header icon box와 모든 card의 leading icon은 제거 후보로 둔다.
 - functional cube diagram은 VisualCube를 사용한다. AI image로 대체하지 않는다.
 
-AI asset의 허용 범위와 prompt는 [UI Visual Direction](../00-product/ui-visual-direction.md)이 관리한다. Asset은 explicit width/height, lazy loading, responsive source와 format/size budget을 implementation acceptance에 포함한다.
+AI UI Screen Mockup은 visual reference이며 runtime asset이 아니다. mockup의 layout과 proportion은 Approved Target Mockup 뒤 implementation detail로 옮기고, functional cube diagram이나 control은 image로 대체하지 않는다.
+
+Runtime AI Asset의 허용 범위와 prompt는 [UI Visual Direction](../00-product/ui-visual-direction.md)이 관리한다. Runtime asset을 실제로 추가하는 PR은 explicit width/height, lazy loading, responsive source와 format/size budget을 implementation acceptance에 포함한다.
 
 ## Loading, empty, error and feedback
 
@@ -441,9 +458,9 @@ AI asset의 허용 범위와 prompt는 [UI Visual Direction](../00-product/ui-vi
 
 Current repository에는 executable visual regression infrastructure가 없다. Storybook, Chromatic과 Playwright를 Design Gate prerequisite로 추가하지 않는다.
 
-### Initial baseline
+### Baseline, target and implementation evidence
 
-첫 UI implementation PR을 시작하기 전에 exact `origin/dev` commit에서 다음 화면을 fixed state로 캡처한다.
+Target Mockup approval과 Design System implementation value 확정 뒤, 첫 UI implementation PR을 시작하기 전에 implementation base commit의 Current Baseline Screenshot을 캡처한다.
 
 | Screen | State | Viewport |
 | --- | --- | --- |
@@ -455,14 +472,18 @@ Current repository에는 executable visual regression infrastructure가 없다. 
 
 - production data를 사용하지 않고 isolated development/test fixture를 사용한다.
 - screenshot에는 base commit, route, viewport와 state를 기록한다.
-- before/after pair는 implementation PR evidence에 첨부하고 binary를 repository에 무조건 commit하지 않는다.
+- Approved Target Mockup은 같은 route와 viewport의 visual reference로 둔다. Actual Implementation Screenshot은 같은 fixture로 캡처한다.
+- implementation PR evidence는 Current Baseline Screenshot, Approved Target Mockup과 Actual Implementation Screenshot을 가능한 경우 함께 비교한다.
+- primary focus, layout hierarchy, relative spacing, palette, surface hierarchy, typography hierarchy, density, major proportion과 navigation structure를 확인한다. pixel-perfect 복제는 요구하지 않는다.
+- functional requirement, accessibility와 usability는 Target Mockup보다 우선한다.
+- binary를 repository에 무조건 commit하지 않는다. implementation reference가 필요한 최종 target만 UI Visual Direction의 target storage policy를 따른다.
 - dynamic date, nickname와 network state를 고정할 수 없으면 pixel comparison 근거로 사용하지 않는다.
 
 ### Tool comparison
 
 | Option | Cost | Value | Proposal |
 | --- | --- | --- | --- |
-| Manual before/after | dependency 없음, 사람이 state를 준비 | 초기 방향과 responsive review에 충분 | 지금 사용 |
+| Manual baseline/target/implementation | dependency 없음, 사람이 state를 준비 | 초기 방향과 responsive review에 충분 | 지금 사용 |
 | Playwright screenshot | browser/config/mock API와 baseline 관리 필요 | stable screen의 repeatable regression | shell과 2개 핵심 화면이 안정된 뒤 재평가 |
 | Storybook | component story와 state fixture 작성 필요 | primitive catalog와 isolated QA | component 수요가 늘 때 검토 |
 | Chromatic | external service와 snapshot lifecycle 필요 | hosted review·diff | 현재 규모에서는 사용하지 않음 |
@@ -493,27 +514,35 @@ Manual matrix가 반복 누락되거나 cross-page shell regression이 두 번 �
 - Timer keyboard, touch, pending Retry/Discard, penalty, delete와 scramble lifecycle
 - mobile landscape Timer
 - contrast와 200% zoom, reduced motion
-- fixed viewport before/after screenshot pair
+- fixed viewport baseline/target/implementation screenshot evidence
 
 ## Implementation sequence
 
-V2.2 Growth frontend를 current UI로 먼저 만들지 않는다. Growth backend는 ADR-0010 acceptance 뒤 UI foundation과 병렬로 진행할 수 있고, Growth frontend는 App Shell과 MyPage migration 뒤에 연결한다.
+V2.2 Growth frontend를 current UI로 먼저 만들지 않는다. Growth backend는 별도 승인 뒤 core UI mockup과 병렬로 진행할 수 있다. My Growth frontend는 Growth API contract와 My Growth target approval 뒤에 연결한다.
 
-```text
+~~~text
 Design Gate
-→ UI Foundation
-→ App Shell
-→ Timer / Home / Ranking / MyPage migration
-                    ↘ Growth backend/API
-→ My Growth frontend
-→ Content / Auth / Utility consistency
-```
+→ Timer mockup exploration
+→ Timer desktop/mobile approval
+→ Core screen mockups
+→ Visual language approval
+→ Design System implementation values 확정
+→ Current baseline capture
+→ PR 1 Tokens + primitives
+→ PR 2 App Shell
+→ PR 3 Timer
+→ PR 4 Home
+→ PR 5 Ranking
+→ PR 6 MyPage
+~~~
+
+Mockup 생성, 선택, 수정, target 승인과 code implementation은 별도 gate다. 각 screen migration PR은 해당 Desktop/Mobile Target Mockup이 승인된 뒤에만 시작한다.
 
 ### PR 1 — Design tokens and core primitives
 
 - Goal/scope: semantic color/type/spacing/radius/shadow/motion token과 Button, Field, Select, InlineAlert, Skeleton, EmptyState의 first consumers
 - Main files: `frontend/src/styles` foundation, new shared primitives와 focused tests
-- Dependency: Design Gate 승인
+- Dependency: Design Gate 승인, visual language approval, Design System implementation value 확정, Current Baseline Screenshot capture
 - Functional boundary: page behavior와 route 변경 없음
 - Visual acceptance: arbitrary gradient/shadow를 새 primitive에 넣지 않고 focus, touch target과 state가 token으로 표현됨
 - Tests/manual: primitive interaction/accessibility, lint/test/build, sample states desktop/mobile
@@ -533,7 +562,7 @@ Design Gate
 
 - Goal/scope: focus stage, scramble/context, result/recovery action과 recent performance rail
 - Main files: `TimerPage.jsx`, presentation components, `timer.css`, existing Timer tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, Timer Desktop Target approved, Timer Mobile Portrait Target approved, Timer Mobile Landscape Target approved, Current Baseline Screenshot capture
 - Functional boundary: Timer Core, canonical time, provenance, pending solve, Retry/Discard, scramble, Record/PB/Ao 계약 변경 없음
 - Visual acceptance: digits 안정성, 상태를 text+accent로 구분, portrait/landscape/desktop hierarchy와 running distraction 제거
 - Tests/manual: current Timer focused tests 전체, keyboard/touch/device viewport, pending/error/next-scramble screenshot
@@ -543,7 +572,7 @@ Design Gate
 
 - Goal/scope: Continue Practice 중심 Home, compact performance/activity preview와 secondary Community feed
 - Main files: `HomePage.jsx`, `home.css`, shared summary/list component와 tests
-- Dependency: PR 1~2, Timer route 유지
+- Dependency: PR 1~2, Timer route 유지, Home Desktop Target approved, Home Mobile Target approved
 - Functional boundary: current API call과 guest/auth 분기 유지
 - Visual acceptance: 하나의 primary action, MyPage full summary/history 중복 제거, guest empty metric 미노출
 - Tests/manual: guest/member/loading/error, CTA route, portrait/desktop screenshot
@@ -553,7 +582,7 @@ Design Gate
 
 - Goal/scope: compact top 3, my-rank highlight, dense desktop table와 mobile row
 - Main files: `RankingsPage.jsx`, `rankings.css`, data list/table primitives와 tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, Rankings Desktop Target approved, Rankings Mobile Target approved
 - Functional boundary: search, pagination, event capability, Redis/MySQL response 의미 변경 없음
 - Visual acceptance: mobile에서 rank/nickname/PB 한 줄 비교, current user를 color 외 label로 식별
 - Tests/manual: search, page, empty/loading/error, long nickname, 390px screenshot
@@ -563,7 +592,7 @@ Design Gate
 
 - Goal/scope: `/mypage` section navigation, Records 관리와 Account dialog/drawer 분리. Growth placeholder를 구현하지 않음
 - Main files: `MyPage.jsx`, MyPage layout/components, `mypage.css`, tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, MyPage Records Desktop Target approved, MyPage Records Mobile Target approved
 - Functional boundary: profile/password, logout, penalty/delete, history pagination 유지
 - Visual acceptance: Records와 Account 책임 분리, 미구현 Growth metric을 fake empty로 노출하지 않음
 - Tests/manual: account modal/drawer focus, penalty/delete/logout, mobile keyboard와 record list
@@ -573,7 +602,7 @@ Design Gate
 
 - Goal/scope: approved metric calculator, dedicated summary/trend/progression API와 query
 - Main files: backend domain/repository/service/controller, REST Docs와 tests
-- Dependency: ADR-0010와 MUST metric 승인. UI PR 1~6과 병렬 가능
+- Dependency: ADR-0010와 MUST metric 승인, 별도 implementation 승인. Core UI mockup 과정과 병렬 가능
 - Functional boundary: current Record correction/delete, WCA_333, Asia/Seoul와 no-migration proposal 유지
 - Visual acceptance: 해당 없음. frontend fixture에 필요한 canonical response 제공
 - Tests/manual: DNF/+2/median/IQR/Ao/PB/time boundary fixture, MySQL integration, REST Docs, query release gate
@@ -583,7 +612,7 @@ Design Gate
 
 - Goal/scope: Growth summary, period comparison, charts, consistency, PB progression, activity와 Next Practice
 - Main files: `/mypage` Growth components, API client, Recharts composition와 tests
-- Dependency: PR 1~2, PR 6~7
+- Dependency: PR 1~2, PR 6~7, Growth API contract available, My Growth Desktop Target approved, My Growth Mobile Target approved
 - Functional boundary: backend metric을 표시하며 frontend 재계산과 신규 Public Profile을 추가하지 않음
 - Visual acceptance: question-order hierarchy, metric card 남용 없음, insufficient/DNF/missing-day와 text alternative
 - Tests/manual: empty/insufficient/populated/API error, chart summary, iPhone/desktop screenshot
@@ -593,7 +622,7 @@ Design Gate
 
 - Goal/scope: content list, filter, metadata, reading column, comment/form과 pagination primitive 적용
 - Main files: Community/Q&A pages, `community.css`, shared content components와 tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, Community and Q&A Desktop/Mobile Target Mockup 승인
 - Functional boundary: authorization, image, post/comment CRUD와 Q&A workflow 유지
 - Visual acceptance: desktop/mobile information hierarchy 일치, badge는 category/status에만 사용
 - Tests/manual: list/detail/write/edit/comment, empty/error, long content와 mobile actions
@@ -603,7 +632,7 @@ Design Gate
 
 - Goal/scope: Learning tabs, case list/grid와 notation/algorithm hierarchy
 - Main files: `LearningPage.jsx`, `learning.css`, static data consumers와 tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, Learning Desktop/Mobile Target Mockup 승인
 - Functional boundary: case data, algorithm과 VisualCube mapping 유지
 - Visual acceptance: content card만 유지하고 page/card nesting 제거, mobile에서 image와 algorithm scan order 보존
 - Tests/manual: tab keyboard, case rendering, image fallback, portrait/desktop screenshot
@@ -613,7 +642,7 @@ Design Gate
 
 - Goal/scope: Login, Signup/verification, Password Reset의 AuthShell, Field와 feedback 통합
 - Main files: auth pages, `auth.css`, shared form components와 tests
-- Dependency: PR 1~2
+- Dependency: PR 1~2, Auth Desktop/Mobile Target Mockup 승인
 - Functional boundary: token, redirect, email verification와 password reset API 흐름 유지
 - Visual acceptance: form-first, wide visual optional, mobile keyboard에서 error/submit 접근 가능
 - Tests/manual: normal/error/loading/redirect, keyboard-only, 390px viewport
@@ -623,26 +652,27 @@ Design Gate
 
 - Goal/scope: Feedback/Admin/NotFound/route loading을 common form, data list, status와 overlay pattern으로 migration하고 전체 accessibility audit 수행
 - Main files: Feedback/Admin/NotFound pages, admin/feedback CSS, shared feedback components와 tests
-- Dependency: PR 1~2, 앞선 primitive 안정화
+- Dependency: PR 1~2, 앞선 primitive 안정화, Feedback/Admin Desktop/Mobile Target Mockup 승인
 - Functional boundary: ADMIN authorization, feedback/memo behavior와 route loading 유지
 - Visual acceptance: operational density, consistent loading/empty/error, no decorative hover lift
 - Tests/manual: role guard, filter, memo/feedback action, focus/contrast/reduced-motion audit
 - Risk/rollback: lower-use route regression이 늦게 발견될 수 있다. public/core PR과 분리해 revert한다.
 
-### Optional PR — Approved visual assets
+### Optional PR — Approved Runtime AI Assets
 
-Key visual 또는 empty-state asset이 별도 승인되고 UI 구조가 안정된 경우에만 연다. generated source, crop, license/usage record, format, width/height, size budget, lazy loading과 light surface QA를 포함한다. Asset이 없더라도 core redesign은 완료할 수 있다.
+Key visual 또는 empty-state Runtime AI Asset이 별도 승인되고 UI 구조가 안정된 경우에만 연다. generated source, crop, license/usage record, format, width/height, size budget, lazy loading과 light surface QA를 포함한다. Runtime asset이 없더라도 core redesign은 완료할 수 있다.
 
 ## Release gates
 
 각 screen migration PR은 다음을 통과해야 한다.
 
+- 해당 Desktop/Mobile Target Mockup approval과 implementation dependency 충족
 - 관련 current behavior test와 newly introduced primitive test
 - frontend lint, Vitest와 Vite build
 - application route/API/schema 변경 범위 확인
-- 390×844와 1440×900 before/after screenshot review
+- 390×844와 1440×900 baseline/target/implementation screenshot review
 - Timer PR의 844×390 landscape와 keyboard/touch manual regression
 - visible focus, 200% zoom, contrast와 reduced-motion focused check
 - unresolved functional change는 UI PR에서 분리
 
-Growth frontend release는 ADR-0010 acceptance, Growth backend contract와 query release gate를 추가로 요구한다. Design Gate 승인만으로 production implementation이나 release를 시작하지 않는다.
+Growth frontend release는 ADR-0010 acceptance, Growth backend contract, query release gate와 My Growth Desktop/Mobile Target Mockup approval을 추가로 요구한다. Design Gate 승인이나 mockup 생성만으로 production implementation 또는 release를 시작하지 않는다.

--- a/docs/03-architecture/frontend-design-system.md
+++ b/docs/03-architecture/frontend-design-system.md
@@ -1,0 +1,648 @@
+---
+doc_type: architecture
+status: draft
+created: 2026-08-11
+updated: 2026-08-11
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/00-product/ui-visual-direction.md
+  - docs/01-domain/growth-metrics.md
+  - docs/02-requirements/features/timer.md
+  - docs/02-requirements/features/growth.md
+  - docs/02-requirements/features/profile.md
+  - docs/03-architecture/frontend-architecture.md
+  - docs/03-architecture/growth-architecture.md
+  - docs/06-quality/test-strategy.md
+  - docs/06-quality/quality-gates.md
+  - docs/08-decisions/adr-0007-canonical-timer-time-input-provenance.md
+  - docs/08-decisions/adr-0008-record-submission-idempotency.md
+  - docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+---
+# Frontend Design System
+
+## Status and responsibility
+
+이 문서는 [UI Visual Direction](../00-product/ui-visual-direction.md)을 React frontend에 적용하기 위한 architecture proposal이다. token, primitive, layout, App Shell, responsive, accessibility, visual validation과 구현 순서를 다룬다.
+
+Current implementation 설명은 [Frontend Architecture](frontend-architecture.md), Timer 요구사항은 [Timer](../02-requirements/features/timer.md), V2.2 Growth metric과 API proposal은 [Growth Metrics](../01-domain/growth-metrics.md)와 [Growth Architecture](growth-architecture.md)가 Source of Truth다. 이 문서가 기능·API 계약을 다시 정의하지 않는다.
+
+## Current frontend inventory
+
+| Area | Current | Design implication |
+| --- | --- | --- |
+| Route and shell | `frontend/src/App.jsx`가 lazy route, auth guard, top navigation, mobile tab과 footer를 소유 | route/guard를 보존하고 nav model과 shell presentation을 분리한다. |
+| Global style | `frontend/src/styles/base.css`, `responsive.css`와 9개 page CSS를 전역 import | semantic token과 primitive style을 먼저 만들고 page를 하나씩 migration한다. |
+| Shared component | `frontend/src/components/GroupedPagination.jsx` | behavior는 재사용하고 visual primitive로 정리한다. |
+| Timer | `TimerPage.jsx`, `useCubeTimer`, `timerMachine`, input adapter와 인접 test | state machine과 browser orchestration은 유지하고 presentation component만 분리한다. |
+| MyPage | `MyPage.jsx`가 profile, summary, chart, Record 관리와 account modal을 소유 | `/mypage` section layout과 domain component를 분리한다. |
+| Chart | Recharts 3.8.1 | Growth chart에 재사용한다. 새 chart dependency는 추가하지 않는다. |
+| Icon | Lucide React | outline icon을 유지하고 size/stroke/semantic usage를 제한한다. |
+| Feedback | React Toastify, inline message, native confirm | Toast, InlineAlert, ConfirmDialog의 역할을 구분한다. |
+| Test | Vitest, Testing Library, page/component test | interaction regression은 유지한다. screenshot test infrastructure는 없다. |
+| Asset | `CUBINGHUB.png`, VisualCube URLs | functional cube diagram은 VisualCube를 유지하고 brand asset은 별도 gate를 거친다. |
+
+Current source에는 4,309줄의 CSS와 881줄 `TimerPage.jsx`, 927줄 `MyPage.jsx`가 있다. 숫자는 redesign 필요성을 증명하는 품질 지표가 아니라 migration risk를 설명하는 inventory다.
+
+## Foundation tokens
+
+Token name은 semantic purpose를 나타낸다. component가 hex, arbitrary spacing, radius 또는 shadow를 직접 선택하지 않는다. 아래 값은 `Measured Momentum` proposal의 light-first starting point이며 implementation visual QA에서 contrast를 확인한 뒤 같은 semantic 의미 안에서 조정할 수 있다.
+
+### Color
+
+```css
+--color-background: #f3f5f2;
+--color-surface: #fafbf9;
+--color-surface-raised: #ffffff;
+--color-surface-subtle: #e9eeea;
+
+--color-text-primary: #111a1f;
+--color-text-secondary: #3a474d;
+--color-text-muted: #667277;
+
+--color-border: #d5ddd8;
+--color-border-strong: #a8b4ad;
+
+--color-primary: #136b57;
+--color-primary-hover: #0f5a49;
+--color-primary-active: #0b493c;
+
+--color-success: #18744b;
+--color-warning: #a55f05;
+--color-danger: #b42318;
+
+--color-pb: #c27100;
+--color-plus-two: #a55f05;
+--color-dnf: #b42318;
+
+--color-timer-idle: #66736d;
+--color-timer-holding: #a86100;
+--color-timer-ready: #0f7a5b;
+--color-timer-running: #155e75;
+--color-timer-stopped: #1b252b;
+
+--color-timer-stage: #10191f;
+--color-timer-stage-text: #f7faf8;
+```
+
+| Token group | Semantic purpose |
+| --- | --- |
+| background | application canvas. content surface와 분리하되 gradient를 사용하지 않는다. |
+| surface | ordinary section과 content region |
+| surface-raised | modal, popover, sticky control처럼 elevation이 필요한 요소 |
+| surface-subtle | grouped data, selected row와 quiet control background |
+| text-primary/secondary/muted | heading/data, explanatory copy, metadata 순서. muted도 contrast gate를 통과해야 한다. |
+| border/border-strong | ordinary separation과 selected/focus-independent emphasis |
+| primary states | primary action과 selected navigation. decoration에는 사용하지 않는다. |
+| success/warning/danger | outcome과 actionable status. color와 label/icon을 함께 사용한다. |
+| pb/plus-two/dnf | 큐빙 결과의 domain signal. success/warning/danger와 목적을 섞지 않는다. |
+| timer state | Timer 상태의 accent. 전체 화면을 색으로 채우지 않고 label, outline와 indicator에 적용한다. |
+| timer stage | light shell 안의 집중 surface. full dark theme token이 아니다. |
+
+Chart는 primary, PB, activity와 neutral grid token을 위 semantic color에서 파생한다. six-face cube color를 chart series palette로 사용하지 않는다.
+
+V2.2는 WCA_333만 지원하므로 event별 accent를 만들지 않는다. `eventType` dimension은 data와 component API에 유지하고, 실제 event가 늘어날 때 의미와 contrast를 검증한 뒤 accent mapping을 추가한다.
+
+### Light / Dark boundary
+
+- V2.2 implementation은 light token map 하나를 제공한다.
+- component는 semantic token만 사용해 future dark map을 막지 않는다.
+- `prefers-color-scheme`만으로 검증되지 않은 dark theme을 자동 활성화하지 않는다.
+- Timer focus stage는 독립 surface이며 global theme switch가 아니다.
+
+### Typography
+
+새 webfont를 먼저 설치하지 않는다. 초기 foundation은 current system font를 정리해 loading, license와 Korean fallback 비용을 만들지 않는다.
+
+```css
+--font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+--font-numeric: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+```
+
+| Role | Size proposal | Weight | Rules |
+| --- | --- | --- | --- |
+| Timer display digits | `clamp(4.5rem, 18vw, 10rem)` | 700 | `tabular-nums`, `lining-nums`, stable decimal alignment, no slashed zero |
+| Large statistic | `clamp(2rem, 5vw, 3rem)` | 700 | numeric font, tabular digits |
+| Page heading | 1.75rem desktop / 1.5rem mobile | 700 | 한 화면에 하나 |
+| Section heading | 1.125~1.25rem | 700 | icon box 없이 text hierarchy 우선 |
+| Body | 1rem | 450~500 | 1.55~1.65 line height |
+| Label | 0.875rem | 650 | control과 metric 의미 |
+| Metadata | 0.75~0.8125rem | 500~600 | muted, uppercase 남발 금지 |
+| Table/list numeric | 0.875~1rem | 600 | right alignment, tabular digits |
+
+System monospace의 platform 차이는 desktop Safari, iPhone Safari와 CI browser screenshot에서 확인한다. 숫자 폭이나 Korean UI 조화가 불충분하면 self-hosted font를 별도 dependency decision으로 검토한다.
+
+### Spacing and density
+
+```text
+space-1  4px
+space-2  8px
+space-3  12px
+space-4  16px
+space-6  24px
+space-8  32px
+space-12 48px
+space-16 64px
+```
+
+- control 내부는 8/12/16px, data row는 12/16px, section 사이는 32/48px를 기본으로 한다.
+- touch target은 density와 무관하게 최소 44×44px를 유지한다.
+- page hierarchy는 `Page → Section → data grouping`이다. grouping마다 surface와 border를 모두 추가하지 않는다.
+
+### Layout
+
+| Token | Proposal | Purpose |
+| --- | --- | --- |
+| app max width | 1,280px | Home, Growth, Ranking과 content shell |
+| reading measure | 70ch~74ch | post, Q&A, help와 long-form content |
+| Timer max width | 1,440px 또는 viewport | practice stage와 side rail |
+| mobile gutter | 16px | safe-area 별도 포함 |
+| tablet gutter | 24px | 600~899px |
+| desktop gutter | 32px | 900px 이상 |
+| grid | 4 / 8 / 12 columns | mobile / tablet / desktop |
+| section rhythm | 32px mobile / 48px desktop | card padding이 아닌 page rhythm |
+
+Breakpoints는 content-driven `600px`, `900px`, `1200px` 세 구간과 Timer landscape media query를 기준으로 한다. Current 520/720/900/1080 media query는 screen migration마다 옮기며 한 번에 formatting하지 않는다.
+
+### Radius, border and shadow
+
+```text
+radius-0    0
+radius-sm   4px
+radius-md   8px
+radius-lg   12px
+radius-full 999px
+
+border-default 1px
+border-strong  2px
+```
+
+- control은 8px, top-level raised surface는 최대 12px를 사용한다.
+- data row와 chart container는 radius 0~4px 또는 divider만 사용할 수 있다.
+- `radius-full`은 status, avatar와 compact segmented selection에만 사용한다.
+- shadow는 sticky shell, popover, modal, drawer와 toast에만 둔다.
+- card hover lift와 arbitrary colored shadow는 사용하지 않는다.
+
+### Motion and z-index
+
+| Motion token | Value | Use |
+| --- | --- | --- |
+| fast | 100ms | pressed, state indicator |
+| base | 160ms | selected navigation, tooltip |
+| slow | 240ms | drawer, modal, short PB reveal |
+| easing | `cubic-bezier(0.2, 0, 0, 1)` | enter/selection |
+
+Running Timer, background, gradient와 ordinary card에는 animation을 적용하지 않는다. `prefers-reduced-motion: reduce`에서는 nonessential transition과 chart animation을 제거한다.
+
+```text
+base 0
+sticky shell 100
+mobile navigation 200
+popover/drawer overlay 400
+modal 500
+toast 600
+```
+
+새 stacking context를 page CSS에 임의로 추가하지 않는다.
+
+## App Shell architecture
+
+`App.jsx`의 route와 guard behavior는 유지하고 다음 책임을 분리한다.
+
+```text
+App
+├─ RouteStateBoundary
+├─ AppShell
+│  ├─ DesktopTopNav
+│  ├─ MobileContextBar
+│  ├─ MobileBottomNav
+│  └─ AccountMenu
+└─ Routes
+```
+
+Navigation item은 label, path, icon, visibility와 placement를 가진 data model로 관리한다. 인증 상태, ADMIN role과 Growth capability에 따라 item을 만들되 미구현 route를 placeholder로 노출하지 않는다.
+
+### Destination rollout
+
+| Phase | Desktop primary | Mobile bottom | Utility |
+| --- | --- | --- | --- |
+| existing screen migration | Home, Timer, My Page, Rankings, Explore | Home, Timer, My Page, Rankings, More | Account, Feedback, Admin |
+| V2.2 My Growth release | Home, Timer, My Growth, Rankings, Explore | Home, Timer, Growth, Rankings, More | Account, Feedback, Admin |
+
+Explore/More는 Learning, Community와 Q&A를 소유한다. Future Daily Challenge는 별도 제품 승인이 있기 전 data model에도 노출 item을 추가하지 않는다.
+
+`/mypage`는 route를 유지하고 internal section을 query로 deep-link할 수 있게 한다. Existing-screen migration에서는 `/mypage?section=records`를 제공하되 `/mypage`의 current behavior를 유지한다. My Growth 출시 뒤 `/mypage`와 `?section=growth`를 Growth 기본 진입으로 사용한다. 미구현 또는 알 수 없는 section 값은 fake Growth 화면을 만들지 않고 해당 release의 기본 section으로 돌아간다. Account dialog/drawer는 section이 아니며 account menu에서 연다.
+
+## Component architecture
+
+Component는 CSS 표현을 감추는 목적이 아니라 반복되는 semantic behavior와 accessibility를 한곳에서 보장할 때 만든다. Primitive는 첫 실제 consumer와 함께 추가하며 목록 전체를 선구현하지 않는다.
+
+### Foundation primitives
+
+| Group | Components | Contract |
+| --- | --- | --- |
+| Action | `Button`, `IconButton` | primary/secondary/quiet/danger, loading, disabled, 44px touch target |
+| Field | `Field`, `Input`, `Textarea`, `Select`, `Checkbox`, `Radio` | label, helper, error id, required와 focus 연결 |
+| Selection | `Tabs`, `SegmentedControl` | keyboard selection과 route/section state 구분 |
+| Status | `Badge`, `InlineAlert`, `Toast` | Badge는 category/status, Alert는 persistent state, Toast는 transient confirmation |
+| Overlay | `Tooltip`, `Popover`, `Modal`, `Drawer`, `ConfirmDialog` | focus trap, escape, return focus, mobile presentation |
+| Data | `Table`, `DataList`, `MetricValue`, `Skeleton`, `EmptyState` | numeric alignment, responsive column priority, text alternative |
+| Navigation | `Pagination` | current `GroupedPagination` behavior 보존 |
+
+`Tooltip`, `Popover`, `Checkbox`, `Radio`와 `SegmentedControl`은 consumer가 생길 때 추가한다. primitive catalog 완성이 목표가 아니다.
+
+### Layout components
+
+```text
+AppShell
+Page
+PageHeader
+Section
+Stack
+Cluster
+ResponsiveGrid
+ReadingColumn
+DataGroup
+```
+
+- `Page`는 width와 gutter를, `Section`은 heading/description/action 관계를 관리한다.
+- `DataGroup`은 divider와 density를 제공하며 rounded card를 강제하지 않는다.
+- `ResponsiveGrid`는 column count만 바꾸지 않고 slot priority와 named area를 지원한다.
+
+### Domain components
+
+```text
+TimerDisplay
+ScramblePanel
+TimerStateMessage
+PendingSolveRecovery
+SolveRow
+AverageMetric
+PBIndicator
+LeaderboardRow
+GrowthSummary
+PeriodComparison
+TrendChart
+ConsistencySummary
+PBProgression
+PracticeActivity
+NextPracticeCTA
+```
+
+Domain component는 formatter나 API shape를 새로 정의하지 않는다. domain utility와 server response를 받아 presentation과 accessible label을 제공한다.
+
+### Reuse, refactor, replace and delete candidates
+
+| Action | Current target | Direction |
+| --- | --- | --- |
+| Reuse | `timerMachine`, `useCubeTimer`, input adapters | state와 canonical time 계약을 그대로 사용 |
+| Reuse | AuthContext, route guards, API modules | shell 분리 뒤에도 authorization과 redirect behavior 유지 |
+| Reuse | Recharts 3.8.1 | Growth 세 chart와 current chart migration에 사용 |
+| Reuse | Lucide React | outline icon, 16/20/24px, stroke 1.75~2 범위 |
+| Reuse | VisualCube | scramble과 Learning functional image 유지 |
+| Refactor | `App.jsx` | route와 App Shell/navigation model 분리 |
+| Refactor | `GroupedPagination` | behavior 유지, `Pagination` primitive로 style 통합 |
+| Refactor | `TimerPage.jsx` | orchestration을 남기고 stage, state, result와 recent rail presentation 분리 |
+| Refactor | `MyPage.jsx` | Growth, Records와 Account section 책임 분리 |
+| Refactor | record/ranking/community table | `Table`과 mobile-priority `DataList`로 같은 information hierarchy 유지 |
+| Replace | `.panel`, `.dashboard-card`, page header icon box | `Page`, `Section`, `DataGroup`, typography/divider hierarchy |
+| Replace | page별 button, field, tab, badge, toast markup | semantic primitive |
+| Replace | native destructive `window.confirm` | accessible `ConfirmDialog`, destructive behavior 자체는 유지 |
+| Delete candidate | duplicated `*-header-icon`, `*-input-shell`, `*-status-chip`, hover-lift style | 마지막 consumer migration 뒤 제거 |
+| Delete candidate | MyPage legacy average card와 raw recent trend | V2.2 Growth UI와 deprecation contract 적용 뒤 제거 |
+
+Delete candidate는 사용처와 test가 모두 migration된 뒤 삭제한다. current functionality를 CSS cleanup과 함께 제거하지 않는다.
+
+## Timer composition and regression boundary
+
+```text
+TimerPage orchestration
+├─ PracticeContextBar
+├─ ScramblePanel
+├─ TimerStage
+│  ├─ TimerDisplay
+│  ├─ TimerStateMessage
+│  ├─ TimerResultActions
+│  └─ PendingSolveRecovery
+└─ PracticeRail
+   ├─ AverageMetric Ao5/Ao12
+   └─ SolveList
+```
+
+### Presentation priority
+
+1. pending recovery/error가 있으면 일반 idle helper보다 먼저 알린다.
+2. holding/ready/running 상태는 save action과 penalty control을 노출하지 않는다.
+3. stopped result와 penalty/save 상태는 같은 visual group에 둔다.
+4. next scramble loading은 새로운 solve input을 잠그고 이유를 text로 알린다.
+5. recent solve action은 Timer touch surface와 event propagation이 충돌하지 않아야 한다.
+
+### Functional regression contract
+
+- reducer state transition과 hold threshold
+- monotonic clock과 stop 시 `Math.round()` canonical integer ms
+- `KEYBOARD`와 `TOUCH` provenance
+- guest history와 authenticated Record create
+- user-scoped single pending solve와 account isolation
+- Retry는 같은 submission identity, Discard는 explicit action
+- malformed pending recovery와 next-solve lock
+- exact scramble과 new scramble lifecycle
+- penalty PATCH, delete, PB, Ao5/Ao12와 recent history
+
+Visual component는 Timer Core command를 재해석하거나 browser global을 직접 읽지 않는다.
+
+## Growth composition
+
+```text
+MyPageLayout
+├─ MyPageSectionNav
+├─ MyGrowth
+│  ├─ GrowthSummary
+│  ├─ PeriodComparison + TrendChart
+│  ├─ ConsistencySummary
+│  ├─ PBProgression
+│  ├─ PracticeActivity
+│  └─ NextPracticeCTA
+├─ Records
+│  └─ SolveList / RecordManagement
+└─ AccountMenu
+   └─ AccountDialog / Drawer
+```
+
+Growth component는 full Record history를 내려받아 metric을 계산하지 않는다. ADR-0010 accepted 뒤 dedicated summary, trend와 paginated progression response를 사용한다.
+
+### Chart implementation
+
+| Chart | Recharts composition | DNF·missing | Responsive | Accessible alternative |
+| --- | --- | --- | --- | --- |
+| Daily median | `ResponsiveContainer`, `LineChart`, `Line`, `XAxis`, `YAxis`, `Tooltip` | missing date `null`과 `connectNulls=false`; DNF-only는 numeric point 없음 | 4~5 x ticks mobile, 7~10 desktop; fixed aspect/min height | summary sentence와 visually hidden/expandable daily list |
+| PB progression | step-after `LineChart` 또는 `Area` 없는 `Line` | DNF 제외, current retained Record 기준 notice | latest milestone focus, older page link | chronological milestone list |
+| Activity | `BarChart`, `Bar` | missing day 0; DNF도 total count 포함 | 30 bars, weekly label, tooltip touch target | total, active days와 daily count list |
+
+Chart tooltip에만 정보를 두지 않는다. keyboard 또는 touch로 point를 탐색하기 어려우면 chart 아래 compact data list를 제공한다. y-axis는 seconds label을 표시하고 lower-is-better 해석을 heading copy에서 명시한다.
+
+## Responsive strategy
+
+Priority는 iPhone portrait, desktop/laptop, tablet, Timer landscape 순이다.
+
+| Area | iPhone portrait | Desktop/laptop | Tablet | Timer landscape |
+| --- | --- | --- | --- | --- |
+| Navigation | 5-item bottom nav + compact top context | top nav + Explore + account | bottom 또는 compact top은 900px content fit으로 결정 | Timer에서 shell 최소화, safe-area 유지 |
+| Timer digits | width 기반 clamp, 한 줄 고정 | stage 중심 최대 size | stage와 rail 1~2 column 전환 | height 기반 clamp |
+| Scramble | 2~3줄, VisualCube 접기 가능 | notation + visual two-column | visual size 축소 | single context line, overflow wrap |
+| Recent solves | compact list/drawer | side rail | lower rail | right rail 또는 접힌 panel |
+| Growth chart | full width, sparse axis label, data summary | section width와 explanatory copy 병렬 가능 | single chart column | 해당 없음 |
+| Rankings | rank/nickname/PB compact rows | dense table, current-user row | prioritized columns | 해당 없음 |
+| Modal | full-height Drawer 우선 | centered Modal | width에 따라 Modal/Drawer | Timer interaction 종료 뒤만 표시 |
+
+Mobile을 desktop column stack으로만 만들지 않는다. 각 screen은 DOM 순서, visible metadata, sticky action과 collapse behavior를 acceptance criterion으로 가진다.
+
+## Accessibility contract
+
+- 모든 interactive element는 keyboard로 도달하고 visible focus를 가진다.
+- minimum touch target은 44×44px다.
+- normal text는 4.5:1, large text와 meaningful UI boundary는 3:1 이상을 implementation gate에서 측정한다.
+- Timer holding/ready/running/stopped, PB, +2, DNF와 error는 color 외 text 또는 icon label로 구분한다.
+- form label, helper와 error는 `id`, `aria-describedby`, `aria-invalid`로 연결한다.
+- modal/drawer는 focus trap, Escape close, initial focus와 trigger return focus를 제공한다.
+- toast에만 recovery action이나 필수 오류를 두지 않는다.
+- chart는 summary와 data alternative를 제공하고 tooltip만으로 값을 숨기지 않는다.
+- Timer keyboard interaction은 global shortcut과 focused form/control을 구분하는 current behavior를 유지한다.
+- screen reader용 Timer status는 매 frame announce하지 않고 state transition과 stopped result만 알린다.
+- `prefers-reduced-motion`에서 chart reveal, PB effect와 overlay transition을 줄이거나 제거한다.
+
+## Iconography and assets
+
+Lucide outline icon을 유지한다.
+
+- size는 16px inline, 20px control, 24px empty/status focal point를 기본으로 한다.
+- stroke width는 1.75~2로 제한한다.
+- icon-only action은 accessible name과 Tooltip을 제공한다.
+- selected/disabled/error를 icon만으로 표현하지 않는다.
+- decorative header icon box와 모든 card의 leading icon은 제거 후보로 둔다.
+- functional cube diagram은 VisualCube를 사용한다. AI image로 대체하지 않는다.
+
+AI asset의 허용 범위와 prompt는 [UI Visual Direction](../00-product/ui-visual-direction.md)이 관리한다. Asset은 explicit width/height, lazy loading, responsive source와 format/size budget을 implementation acceptance에 포함한다.
+
+## Loading, empty, error and feedback
+
+| State | Component | Rule |
+| --- | --- | --- |
+| route/auth loading | `PageSkeleton` 또는 compact status | layout shift를 줄이고 decorative spinner card를 반복하지 않는다. |
+| local data loading | row/chart skeleton | final density와 같은 geometry를 유지한다. |
+| empty | `EmptyState` | 이유, scope와 가능한 next action을 제공한다. image는 optional이다. |
+| insufficient Growth | metric-specific state | 0으로 표시하지 않고 required sample과 next Practice를 설명한다. |
+| recoverable error | `InlineAlert` | affected region과 Retry를 함께 둔다. |
+| destructive confirmation | `ConfirmDialog` | target, consequence, cancel과 destructive action을 명시한다. |
+| success | inline state 또는 Toast | 다음 interaction에 필요한 정보는 inline으로 유지한다. |
+
+## Screenshot and visual regression strategy
+
+Current repository에는 executable visual regression infrastructure가 없다. Storybook, Chromatic과 Playwright를 Design Gate prerequisite로 추가하지 않는다.
+
+### Initial baseline
+
+첫 UI implementation PR을 시작하기 전에 exact `origin/dev` commit에서 다음 화면을 fixed state로 캡처한다.
+
+| Screen | State | Viewport |
+| --- | --- | --- |
+| Home | guest, authenticated | 1440×900, 390×844 |
+| Timer | idle, stopped, pending recovery | 1440×900, 390×844; landscape 844×390 추가 |
+| Rankings | populated, current user visible | 1440×900, 390×844 |
+| MyPage | populated records | 1440×900, 390×844 |
+| Auth | login default, validation error | 1440×900, 390×844 |
+
+- production data를 사용하지 않고 isolated development/test fixture를 사용한다.
+- screenshot에는 base commit, route, viewport와 state를 기록한다.
+- before/after pair는 implementation PR evidence에 첨부하고 binary를 repository에 무조건 commit하지 않는다.
+- dynamic date, nickname와 network state를 고정할 수 없으면 pixel comparison 근거로 사용하지 않는다.
+
+### Tool comparison
+
+| Option | Cost | Value | Proposal |
+| --- | --- | --- | --- |
+| Manual before/after | dependency 없음, 사람이 state를 준비 | 초기 방향과 responsive review에 충분 | 지금 사용 |
+| Playwright screenshot | browser/config/mock API와 baseline 관리 필요 | stable screen의 repeatable regression | shell과 2개 핵심 화면이 안정된 뒤 재평가 |
+| Storybook | component story와 state fixture 작성 필요 | primitive catalog와 isolated QA | component 수요가 늘 때 검토 |
+| Chromatic | external service와 snapshot lifecycle 필요 | hosted review·diff | 현재 규모에서는 사용하지 않음 |
+
+Manual matrix가 반복 누락되거나 cross-page shell regression이 두 번 이상 발생하면 targeted Playwright 도입을 별도 PR로 연다. 도입 시 AppShell, Timer state와 Growth empty/populated처럼 deterministic state만 먼저 포함한다.
+
+## Test strategy
+
+### Unit and component
+
+- primitive variant, keyboard, disabled/loading, focus return과 accessible name
+- navigation item visibility, active route, auth/admin guard와 return path
+- responsive semantic behavior는 DOM order와 visible label을 component test로 검증
+- Timer presentation state가 existing core command와 save/recovery action을 그대로 호출하는지 검증
+- Growth formatter는 backend response를 표시하고 metric을 재계산하지 않는지 검증
+- chart summary, empty, insufficient, DNF-only와 missing-day fixture
+
+### Integration and build
+
+- page별 current loading, error, auth와 interaction test 유지
+- frontend lint, Vitest, Vite build
+- Growth backend PR은 domain fixture, repository/query integration, MockMvc와 REST Docs를 별도 수행
+
+### Manual checks
+
+- iPhone portrait Safari 기준 touch, keyboard, safe area, modal/drawer와 scroll
+- desktop keyboard-only navigation과 visible focus
+- Timer keyboard, touch, pending Retry/Discard, penalty, delete와 scramble lifecycle
+- mobile landscape Timer
+- contrast와 200% zoom, reduced motion
+- fixed viewport before/after screenshot pair
+
+## Implementation sequence
+
+V2.2 Growth frontend를 current UI로 먼저 만들지 않는다. Growth backend는 ADR-0010 acceptance 뒤 UI foundation과 병렬로 진행할 수 있고, Growth frontend는 App Shell과 MyPage migration 뒤에 연결한다.
+
+```text
+Design Gate
+→ UI Foundation
+→ App Shell
+→ Timer / Home / Ranking / MyPage migration
+                    ↘ Growth backend/API
+→ My Growth frontend
+→ Content / Auth / Utility consistency
+```
+
+### PR 1 — Design tokens and core primitives
+
+- Goal/scope: semantic color/type/spacing/radius/shadow/motion token과 Button, Field, Select, InlineAlert, Skeleton, EmptyState의 first consumers
+- Main files: `frontend/src/styles` foundation, new shared primitives와 focused tests
+- Dependency: Design Gate 승인
+- Functional boundary: page behavior와 route 변경 없음
+- Visual acceptance: arbitrary gradient/shadow를 새 primitive에 넣지 않고 focus, touch target과 state가 token으로 표현됨
+- Tests/manual: primitive interaction/accessibility, lint/test/build, sample states desktop/mobile
+- Risk/rollback: global token leak가 가장 큰 위험이다. page migration 전 compatibility alias를 유지하고 PR revert로 복구한다.
+
+### PR 2 — App Shell and navigation
+
+- Goal/scope: AppShell, desktop top nav, mobile context/bottom nav, Explore/More와 account menu
+- Main files: `App.jsx`, shell/navigation components, base/responsive style와 route tests
+- Dependency: PR 1
+- Functional boundary: current path, lazy route, auth/guest/admin guard와 return path 유지
+- Visual acceptance: 320px에서 overflow 없음, mobile 5 destinations와 safe area, desktop primary/utility 구분
+- Tests/manual: active route, auth/admin visibility, keyboard menu, 1440×900·390×844 screenshot
+- Risk/rollback: route 접근성과 destination 발견성이 위험이다. old shell을 한 commit 경계에서 복원할 수 있게 한다.
+
+### PR 3 — Timer redesign
+
+- Goal/scope: focus stage, scramble/context, result/recovery action과 recent performance rail
+- Main files: `TimerPage.jsx`, presentation components, `timer.css`, existing Timer tests
+- Dependency: PR 1~2
+- Functional boundary: Timer Core, canonical time, provenance, pending solve, Retry/Discard, scramble, Record/PB/Ao 계약 변경 없음
+- Visual acceptance: digits 안정성, 상태를 text+accent로 구분, portrait/landscape/desktop hierarchy와 running distraction 제거
+- Tests/manual: current Timer focused tests 전체, keyboard/touch/device viewport, pending/error/next-scramble screenshot
+- Risk/rollback: event propagation과 state presentation drift가 높다. core 파일은 수정하지 않고 presentation commit을 revert한다.
+
+### PR 4 — Home action hierarchy
+
+- Goal/scope: Continue Practice 중심 Home, compact performance/activity preview와 secondary Community feed
+- Main files: `HomePage.jsx`, `home.css`, shared summary/list component와 tests
+- Dependency: PR 1~2, Timer route 유지
+- Functional boundary: current API call과 guest/auth 분기 유지
+- Visual acceptance: 하나의 primary action, MyPage full summary/history 중복 제거, guest empty metric 미노출
+- Tests/manual: guest/member/loading/error, CTA route, portrait/desktop screenshot
+- Risk/rollback: 정보 제거로 보일 수 있다. 상세 destination link를 확인하고 Home page만 revert한다.
+
+### PR 5 — Ranking leaderboard
+
+- Goal/scope: compact top 3, my-rank highlight, dense desktop table와 mobile row
+- Main files: `RankingsPage.jsx`, `rankings.css`, data list/table primitives와 tests
+- Dependency: PR 1~2
+- Functional boundary: search, pagination, event capability, Redis/MySQL response 의미 변경 없음
+- Visual acceptance: mobile에서 rank/nickname/PB 한 줄 비교, current user를 color 외 label로 식별
+- Tests/manual: search, page, empty/loading/error, long nickname, 390px screenshot
+- Risk/rollback: responsive column 누락이 위험이다. current table markup을 migration commit 단위로 복구한다.
+
+### PR 6 — MyPage current UX migration
+
+- Goal/scope: `/mypage` section navigation, Records 관리와 Account dialog/drawer 분리. Growth placeholder를 구현하지 않음
+- Main files: `MyPage.jsx`, MyPage layout/components, `mypage.css`, tests
+- Dependency: PR 1~2
+- Functional boundary: profile/password, logout, penalty/delete, history pagination 유지
+- Visual acceptance: Records와 Account 책임 분리, 미구현 Growth metric을 fake empty로 노출하지 않음
+- Tests/manual: account modal/drawer focus, penalty/delete/logout, mobile keyboard와 record list
+- Risk/rollback: monolithic page 분리 중 state coupling이 위험이다. data/action hook을 유지하고 section presentation만 revert 가능하게 나눈다.
+
+### PR 7 — V2.2 Growth backend/domain/API
+
+- Goal/scope: approved metric calculator, dedicated summary/trend/progression API와 query
+- Main files: backend domain/repository/service/controller, REST Docs와 tests
+- Dependency: ADR-0010와 MUST metric 승인. UI PR 1~6과 병렬 가능
+- Functional boundary: current Record correction/delete, WCA_333, Asia/Seoul와 no-migration proposal 유지
+- Visual acceptance: 해당 없음. frontend fixture에 필요한 canonical response 제공
+- Tests/manual: DNF/+2/median/IQR/Ao/PB/time boundary fixture, MySQL integration, REST Docs, query release gate
+- Risk/rollback: metric drift와 query cost가 위험이다. endpoint는 additive이며 application revert로 제거한다. schema rollback은 없다.
+
+### PR 8 — V2.2 My Growth frontend
+
+- Goal/scope: Growth summary, period comparison, charts, consistency, PB progression, activity와 Next Practice
+- Main files: `/mypage` Growth components, API client, Recharts composition와 tests
+- Dependency: PR 1~2, PR 6~7
+- Functional boundary: backend metric을 표시하며 frontend 재계산과 신규 Public Profile을 추가하지 않음
+- Visual acceptance: question-order hierarchy, metric card 남용 없음, insufficient/DNF/missing-day와 text alternative
+- Tests/manual: empty/insufficient/populated/API error, chart summary, iPhone/desktop screenshot
+- Risk/rollback: chart가 의미를 과장할 위험이 있다. Growth section을 feature boundary로 revert하고 Records/Account를 유지한다.
+
+### PR 9 — Community and Q&A consistency
+
+- Goal/scope: content list, filter, metadata, reading column, comment/form과 pagination primitive 적용
+- Main files: Community/Q&A pages, `community.css`, shared content components와 tests
+- Dependency: PR 1~2
+- Functional boundary: authorization, image, post/comment CRUD와 Q&A workflow 유지
+- Visual acceptance: desktop/mobile information hierarchy 일치, badge는 category/status에만 사용
+- Tests/manual: list/detail/write/edit/comment, empty/error, long content와 mobile actions
+- Risk/rollback: 여러 route의 shared style 영향이 위험이다. Community와 Q&A migration commit을 분리하거나 route별 revert가 가능해야 한다.
+
+### PR 10 — Learning content system
+
+- Goal/scope: Learning tabs, case list/grid와 notation/algorithm hierarchy
+- Main files: `LearningPage.jsx`, `learning.css`, static data consumers와 tests
+- Dependency: PR 1~2
+- Functional boundary: case data, algorithm과 VisualCube mapping 유지
+- Visual acceptance: content card만 유지하고 page/card nesting 제거, mobile에서 image와 algorithm scan order 보존
+- Tests/manual: tab keyboard, case rendering, image fallback, portrait/desktop screenshot
+- Risk/rollback: static content mapping 회귀가 위험이다. data file은 변경하지 않고 page presentation을 revert한다.
+
+### PR 11 — Auth consistency
+
+- Goal/scope: Login, Signup/verification, Password Reset의 AuthShell, Field와 feedback 통합
+- Main files: auth pages, `auth.css`, shared form components와 tests
+- Dependency: PR 1~2
+- Functional boundary: token, redirect, email verification와 password reset API 흐름 유지
+- Visual acceptance: form-first, wide visual optional, mobile keyboard에서 error/submit 접근 가능
+- Tests/manual: normal/error/loading/redirect, keyboard-only, 390px viewport
+- Risk/rollback: shared form state와 autofill이 위험이다. route별 migration으로 rollback한다.
+
+### PR 12 — Feedback, Admin and common-state polish
+
+- Goal/scope: Feedback/Admin/NotFound/route loading을 common form, data list, status와 overlay pattern으로 migration하고 전체 accessibility audit 수행
+- Main files: Feedback/Admin/NotFound pages, admin/feedback CSS, shared feedback components와 tests
+- Dependency: PR 1~2, 앞선 primitive 안정화
+- Functional boundary: ADMIN authorization, feedback/memo behavior와 route loading 유지
+- Visual acceptance: operational density, consistent loading/empty/error, no decorative hover lift
+- Tests/manual: role guard, filter, memo/feedback action, focus/contrast/reduced-motion audit
+- Risk/rollback: lower-use route regression이 늦게 발견될 수 있다. public/core PR과 분리해 revert한다.
+
+### Optional PR — Approved visual assets
+
+Key visual 또는 empty-state asset이 별도 승인되고 UI 구조가 안정된 경우에만 연다. generated source, crop, license/usage record, format, width/height, size budget, lazy loading과 light surface QA를 포함한다. Asset이 없더라도 core redesign은 완료할 수 있다.
+
+## Release gates
+
+각 screen migration PR은 다음을 통과해야 한다.
+
+- 관련 current behavior test와 newly introduced primitive test
+- frontend lint, Vitest와 Vite build
+- application route/API/schema 변경 범위 확인
+- 390×844와 1440×900 before/after screenshot review
+- Timer PR의 844×390 landscape와 keyboard/touch manual regression
+- visible focus, 200% zoom, contrast와 reduced-motion focused check
+- unresolved functional change는 UI PR에서 분리
+
+Growth frontend release는 ADR-0010 acceptance, Growth backend contract와 query release gate를 추가로 요구한다. Design Gate 승인만으로 production implementation이나 release를 시작하지 않는다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ related:
 ### 00 Product
 
 - [Vision](00-product/vision.md) · [PRD](00-product/prd.md) · [Roadmap](00-product/roadmap.md)
+- [UI Visual Direction](00-product/ui-visual-direction.md) (Design Gate draft)
 - [Metrics](00-product/metrics.md) · [Business Model](00-product/business-model.md)
 - [Market Validation](00-product/market-validation.md)
 - Research: [csTimer](00-product/research/cstimer.md), [CubeDesk](00-product/research/cubedesk.md), [CubingTime](00-product/research/cubingtime.md), [Cubeast](00-product/research/cubeast.md), [Cubing Contests + RecordRanks](00-product/research/cubing-contests-recordranks.md), [WCA + WCA Live](00-product/research/wca-wca-live.md)
@@ -61,6 +62,7 @@ related:
 
 - [System Context](03-architecture/system-context.md) · [Application](03-architecture/application-architecture.md)
 - [Backend](03-architecture/backend-architecture.md) · [Frontend](03-architecture/frontend-architecture.md)
+- [Frontend Design System](03-architecture/frontend-design-system.md) (Design Gate draft)
 - [Growth](03-architecture/growth-architecture.md) (V2.2 draft)
 - [Auth and Security](03-architecture/auth-security.md)
 - [Ranking](03-architecture/ranking-architecture.md) · [Storage](03-architecture/storage-architecture.md)


### PR DESCRIPTION
## Scope

- current frontend route, component, CSS와 historical visual evidence 기반 UI audit
- Precision Bench, Measured Momentum, Arena Signal 비교와 Measured Momentum 추천안
- semantic design token, typography, density, App Shell과 responsive navigation
- Timer, Growth, Home, Rankings, MyPage, content와 Auth UX contract
- accessibility, motion, AI asset prompt pack과 visual regression strategy
- Design System component architecture와 단계별 implementation PR plan

## Boundary

- Design Gate proposal 문서만 추가
- Timer/Record와 V2.2 Growth metric contract 변경 없음
- application code, dependency, image, Flyway, workflow와 runtime 변경 없음

## Validation

- frontmatter, H1, code fence와 local link 확인
- duplicate prose, style lint와 secret pattern 확인
- exact-path staging과 `git diff --check` 확인
