### PR TITLE
feat: add V2.2 growth metric calculator

### DIFF
--- a/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthMetricCalculator.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthMetricCalculator.java
@@ -1,0 +1,469 @@
+package com.cubinghub.domain.growth.metric;
+
+import com.cubinghub.domain.record.entity.Penalty;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+public final class GrowthMetricCalculator {
+
+    public static final int AO5_WINDOW_SIZE = 5;
+    public static final int AO12_WINDOW_SIZE = 12;
+    public static final int CONSISTENCY_WINDOW_SIZE = 12;
+    public static final int MIN_PERIOD_RANKABLE_RECORD_COUNT = 5;
+    public static final int MIN_PERIOD_ACTIVE_DAY_COUNT = 2;
+    public static final int MIN_IQR_RANKABLE_RECORD_COUNT = 8;
+
+    private static final Comparator<GrowthRecord> RECENT_ORDER = Comparator
+            .comparing(GrowthRecord::createdAt)
+            .thenComparingLong(GrowthRecord::id)
+            .reversed();
+
+    private static final Comparator<GrowthRecord> CHRONOLOGICAL_ORDER = Comparator
+            .comparing(GrowthRecord::createdAt)
+            .thenComparingLong(GrowthRecord::id);
+
+    private GrowthMetricCalculator() {
+    }
+
+    public static AverageResult calculateRecentAo5(Collection<GrowthRecord> records) {
+        return calculateRecentAo(records, AO5_WINDOW_SIZE);
+    }
+
+    public static AverageResult calculateRecentAo12(Collection<GrowthRecord> records) {
+        return calculateRecentAo(records, AO12_WINDOW_SIZE);
+    }
+
+    public static AverageResult calculateRecentAo(Collection<GrowthRecord> records, int windowSize) {
+        if (windowSize < 3) {
+            throw new IllegalArgumentException("Ao window size는 3 이상이어야 합니다.");
+        }
+
+        List<GrowthRecord> recentRecords = recentRecords(records).stream()
+                .limit(windowSize)
+                .toList();
+
+        if (recentRecords.size() < windowSize) {
+            return new AverageResult(
+                    GrowthMetricStatus.INSUFFICIENT_DATA,
+                    windowSize,
+                    recentRecords.size(),
+                    null
+            );
+        }
+
+        List<Integer> effectiveTimes = recentRecords.stream()
+                .map(GrowthRecord::effectiveTimeMs)
+                .toList();
+        long dnfCount = effectiveTimes.stream().filter(Objects::isNull).count();
+        if (dnfCount >= 2) {
+            return new AverageResult(GrowthMetricStatus.DNF, windowSize, windowSize, null);
+        }
+
+        List<Integer> trimmedTimes = new ArrayList<>(effectiveTimes);
+        trimmedTimes.sort(GrowthMetricCalculator::compareAoTime);
+        trimmedTimes = trimmedTimes.subList(1, trimmedTimes.size() - 1);
+
+        if (trimmedTimes.stream().anyMatch(Objects::isNull)) {
+            return new AverageResult(GrowthMetricStatus.DNF, windowSize, windowSize, null);
+        }
+
+        long sum = trimmedTimes.stream().mapToLong(Integer::longValue).sum();
+        return new AverageResult(
+                GrowthMetricStatus.AVAILABLE,
+                windowSize,
+                windowSize,
+                roundToInt((double) sum / trimmedTimes.size())
+        );
+    }
+
+    public static MedianResult calculateMedian(Collection<GrowthRecord> records) {
+        List<GrowthRecord> values = copyRecords(records);
+        List<Integer> rankableTimes = sortedRankableTimes(values);
+        int dnfCount = (int) values.stream().filter(record -> record.penalty() == Penalty.DNF).count();
+        int plusTwoCount = (int) values.stream().filter(record -> record.penalty() == Penalty.PLUS_TWO).count();
+
+        if (rankableTimes.isEmpty()) {
+            return new MedianResult(
+                    GrowthMetricStatus.NO_DATA,
+                    values.size(),
+                    0,
+                    dnfCount,
+                    plusTwoCount,
+                    null
+            );
+        }
+
+        int middle = rankableTimes.size() / 2;
+        Integer medianTimeMs = rankableTimes.size() % 2 == 1
+                ? rankableTimes.get(middle)
+                : roundToInt(((long) rankableTimes.get(middle - 1) + rankableTimes.get(middle)) / 2.0d);
+
+        return new MedianResult(
+                GrowthMetricStatus.AVAILABLE,
+                values.size(),
+                rankableTimes.size(),
+                dnfCount,
+                plusTwoCount,
+                medianTimeMs
+        );
+    }
+
+    public static PeriodComparisonResult comparePerformancePeriods(
+            Collection<GrowthRecord> records,
+            GrowthTimeWindows.PerformanceComparisonWindow window
+    ) {
+        Objects.requireNonNull(window, "window는 필수입니다.");
+        List<GrowthRecord> allRecords = copyRecords(records);
+        PeriodMetrics recentPeriod = calculatePeriodMetrics(allRecords, window.recentPeriod());
+        PeriodMetrics previousPeriod = calculatePeriodMetrics(allRecords, window.previousPeriod());
+
+        if (recentPeriod.recordCount() == 0 || previousPeriod.recordCount() == 0) {
+            return new PeriodComparisonResult(
+                    GrowthMetricStatus.NO_DATA,
+                    recentPeriod,
+                    previousPeriod,
+                    PerformanceDirection.NOT_AVAILABLE,
+                    null
+            );
+        }
+
+        if (!isPeriodEligible(recentPeriod) || !isPeriodEligible(previousPeriod)) {
+            return new PeriodComparisonResult(
+                    GrowthMetricStatus.INSUFFICIENT_SAMPLE,
+                    recentPeriod,
+                    previousPeriod,
+                    PerformanceDirection.NOT_AVAILABLE,
+                    null
+            );
+        }
+
+        int recentMedian = recentPeriod.medianTimeMs();
+        int previousMedian = previousPeriod.medianTimeMs();
+        PerformanceDirection direction = directionFor(previousMedian, recentMedian);
+        BigDecimal improvementPercent = BigDecimal.valueOf((long) previousMedian - recentMedian)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(previousMedian), MathContext.DECIMAL64);
+
+        return new PeriodComparisonResult(
+                GrowthMetricStatus.AVAILABLE,
+                recentPeriod,
+                previousPeriod,
+                direction,
+                improvementPercent
+        );
+    }
+
+    public static ConsistencyResult calculateRecentConsistency(Collection<GrowthRecord> records) {
+        List<GrowthRecord> recentRecords = recentRecords(records);
+        ConsistencyWindow current = calculateConsistencyWindow(
+                recentRecords.subList(0, Math.min(CONSISTENCY_WINDOW_SIZE, recentRecords.size()))
+        );
+        ConsistencyWindow previous = calculateConsistencyWindow(
+                recentRecords.subList(
+                        Math.min(CONSISTENCY_WINDOW_SIZE, recentRecords.size()),
+                        Math.min(CONSISTENCY_WINDOW_SIZE * 2, recentRecords.size())
+                )
+        );
+
+        if (current.status() != GrowthMetricStatus.AVAILABLE
+                || previous.status() != GrowthMetricStatus.AVAILABLE) {
+            GrowthMetricStatus status = current.recordCount() == 0 && previous.recordCount() == 0
+                    ? GrowthMetricStatus.NO_DATA
+                    : GrowthMetricStatus.INSUFFICIENT_DATA;
+            return new ConsistencyResult(
+                    status,
+                    current,
+                    previous,
+                    ConsistencyDirection.NOT_AVAILABLE,
+                    null
+            );
+        }
+
+        int differenceMs = previous.iqrMs() - current.iqrMs();
+        ConsistencyDirection direction = differenceMs > 0
+                ? ConsistencyDirection.NARROWER
+                : differenceMs < 0 ? ConsistencyDirection.WIDER : ConsistencyDirection.UNCHANGED;
+
+        return new ConsistencyResult(
+                GrowthMetricStatus.AVAILABLE,
+                current,
+                previous,
+                direction,
+                differenceMs
+        );
+    }
+
+    public static List<PbProgressionPoint> calculatePbProgression(Collection<GrowthRecord> records) {
+        List<GrowthRecord> chronologicalRecords = copyRecords(records).stream()
+                .sorted(CHRONOLOGICAL_ORDER)
+                .toList();
+        List<PbProgressionPoint> points = new ArrayList<>();
+        Integer runningMinimum = null;
+
+        for (GrowthRecord record : chronologicalRecords) {
+            Integer effectiveTimeMs = record.effectiveTimeMs();
+            if (effectiveTimeMs == null || (runningMinimum != null && effectiveTimeMs >= runningMinimum)) {
+                continue;
+            }
+
+            points.add(PbProgressionPoint.from(record, effectiveTimeMs));
+            runningMinimum = effectiveTimeMs;
+        }
+
+        return List.copyOf(points);
+    }
+
+    private static PeriodMetrics calculatePeriodMetrics(
+            List<GrowthRecord> records,
+            GrowthTimeWindows.CalendarWindow window
+    ) {
+        List<GrowthRecord> periodRecords = records.stream()
+                .filter(record -> window.contains(record.createdAt()))
+                .toList();
+        MedianResult median = calculateMedian(periodRecords);
+        int activeDays = (int) periodRecords.stream()
+                .filter(GrowthRecord::isRankable)
+                .map(record -> activityDate(record.createdAt()))
+                .distinct()
+                .count();
+
+        return new PeriodMetrics(
+                window,
+                periodRecords.size(),
+                median.rankableCount(),
+                activeDays,
+                median.dnfCount(),
+                median.plusTwoCount(),
+                median.valueMs()
+        );
+    }
+
+    private static ConsistencyWindow calculateConsistencyWindow(List<GrowthRecord> records) {
+        MedianResult median = calculateMedian(records);
+        if (median.rankableCount() < MIN_IQR_RANKABLE_RECORD_COUNT) {
+            GrowthMetricStatus status = records.isEmpty()
+                    ? GrowthMetricStatus.NO_DATA
+                    : GrowthMetricStatus.INSUFFICIENT_DATA;
+            return new ConsistencyWindow(
+                    status,
+                    CONSISTENCY_WINDOW_SIZE,
+                    median.recordCount(),
+                    median.rankableCount(),
+                    median.dnfCount(),
+                    median.plusTwoCount(),
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        List<Integer> rankableTimes = sortedRankableTimes(records);
+        int q1 = percentile(rankableTimes, 0.25d);
+        int q3 = percentile(rankableTimes, 0.75d);
+        return new ConsistencyWindow(
+                GrowthMetricStatus.AVAILABLE,
+                CONSISTENCY_WINDOW_SIZE,
+                median.recordCount(),
+                median.rankableCount(),
+                median.dnfCount(),
+                median.plusTwoCount(),
+                q1,
+                q3,
+                q3 - q1
+        );
+    }
+
+    private static boolean isPeriodEligible(PeriodMetrics period) {
+        return period.rankableCount() >= MIN_PERIOD_RANKABLE_RECORD_COUNT
+                && period.activeDays() >= MIN_PERIOD_ACTIVE_DAY_COUNT;
+    }
+
+    private static PerformanceDirection directionFor(int previousMedian, int recentMedian) {
+        if (recentMedian < previousMedian) {
+            return PerformanceDirection.FASTER;
+        }
+        if (recentMedian > previousMedian) {
+            return PerformanceDirection.SLOWER;
+        }
+        return PerformanceDirection.UNCHANGED;
+    }
+
+    private static LocalDate activityDate(Instant createdAt) {
+        return createdAt.atZone(GrowthTimeWindows.SERVICE_ZONE).toLocalDate();
+    }
+
+    private static int percentile(List<Integer> sortedValues, double percentile) {
+        double index = (sortedValues.size() - 1) * percentile;
+        int lowerIndex = (int) Math.floor(index);
+        int upperIndex = (int) Math.ceil(index);
+        double lowerValue = sortedValues.get(lowerIndex);
+        double upperValue = sortedValues.get(upperIndex);
+        return roundToInt(lowerValue + (upperValue - lowerValue) * (index - lowerIndex));
+    }
+
+    private static List<Integer> sortedRankableTimes(Collection<GrowthRecord> records) {
+        return records.stream()
+                .map(GrowthRecord::effectiveTimeMs)
+                .filter(Objects::nonNull)
+                .sorted()
+                .toList();
+    }
+
+    private static List<GrowthRecord> recentRecords(Collection<GrowthRecord> records) {
+        return copyRecords(records).stream()
+                .sorted(RECENT_ORDER)
+                .toList();
+    }
+
+    private static List<GrowthRecord> copyRecords(Collection<GrowthRecord> records) {
+        Objects.requireNonNull(records, "records는 필수입니다.");
+        return List.copyOf(records);
+    }
+
+    private static int compareAoTime(Integer left, Integer right) {
+        if (left == null && right == null) {
+            return 0;
+        }
+        if (left == null) {
+            return 1;
+        }
+        if (right == null) {
+            return -1;
+        }
+        return Integer.compare(left, right);
+    }
+
+    private static int roundToInt(double value) {
+        return Math.toIntExact(Math.round(value));
+    }
+
+    public record AverageResult(
+            GrowthMetricStatus status,
+            int windowSize,
+            int recordCount,
+            Integer valueMs
+    ) {
+
+        public AverageResult {
+            Objects.requireNonNull(status, "status는 필수입니다.");
+        }
+    }
+
+    public record MedianResult(
+            GrowthMetricStatus status,
+            int recordCount,
+            int rankableCount,
+            int dnfCount,
+            int plusTwoCount,
+            Integer valueMs
+    ) {
+
+        public MedianResult {
+            Objects.requireNonNull(status, "status는 필수입니다.");
+        }
+    }
+
+    public record PeriodMetrics(
+            GrowthTimeWindows.CalendarWindow window,
+            int recordCount,
+            int rankableCount,
+            int activeDays,
+            int dnfCount,
+            int plusTwoCount,
+            Integer medianTimeMs
+    ) {
+
+        public PeriodMetrics {
+            Objects.requireNonNull(window, "window는 필수입니다.");
+        }
+    }
+
+    public record PeriodComparisonResult(
+            GrowthMetricStatus status,
+            PeriodMetrics recentPeriod,
+            PeriodMetrics previousPeriod,
+            PerformanceDirection direction,
+            BigDecimal improvementPercent
+    ) {
+
+        public PeriodComparisonResult {
+            Objects.requireNonNull(status, "status는 필수입니다.");
+            Objects.requireNonNull(recentPeriod, "recentPeriod는 필수입니다.");
+            Objects.requireNonNull(previousPeriod, "previousPeriod는 필수입니다.");
+            Objects.requireNonNull(direction, "direction은 필수입니다.");
+        }
+    }
+
+    public record ConsistencyWindow(
+            GrowthMetricStatus status,
+            int windowSize,
+            int recordCount,
+            int rankableCount,
+            int dnfCount,
+            int plusTwoCount,
+            Integer q1Ms,
+            Integer q3Ms,
+            Integer iqrMs
+    ) {
+
+        public ConsistencyWindow {
+            Objects.requireNonNull(status, "status는 필수입니다.");
+        }
+    }
+
+    public record ConsistencyResult(
+            GrowthMetricStatus status,
+            ConsistencyWindow current,
+            ConsistencyWindow previous,
+            ConsistencyDirection direction,
+            Integer differenceMs
+    ) {
+
+        public ConsistencyResult {
+            Objects.requireNonNull(status, "status는 필수입니다.");
+            Objects.requireNonNull(current, "current는 필수입니다.");
+            Objects.requireNonNull(previous, "previous는 필수입니다.");
+            Objects.requireNonNull(direction, "direction은 필수입니다.");
+        }
+    }
+
+    public record PbProgressionPoint(
+            long recordId,
+            int timeMs,
+            Penalty penalty,
+            int effectiveTimeMs,
+            Instant createdAt
+    ) {
+
+        private static PbProgressionPoint from(GrowthRecord record, int effectiveTimeMs) {
+            return new PbProgressionPoint(
+                    record.id(),
+                    record.timeMs(),
+                    record.penalty(),
+                    effectiveTimeMs,
+                    record.createdAt()
+            );
+        }
+    }
+
+    public enum PerformanceDirection {
+        FASTER,
+        SLOWER,
+        UNCHANGED,
+        NOT_AVAILABLE
+    }
+
+    public enum ConsistencyDirection {
+        NARROWER,
+        WIDER,
+        UNCHANGED,
+        NOT_AVAILABLE
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthMetricStatus.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthMetricStatus.java
@@ -1,0 +1,9 @@
+package com.cubinghub.domain.growth.metric;
+
+public enum GrowthMetricStatus {
+    AVAILABLE,
+    DNF,
+    INSUFFICIENT_DATA,
+    NO_DATA,
+    INSUFFICIENT_SAMPLE
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthRecord.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthRecord.java
@@ -1,0 +1,36 @@
+package com.cubinghub.domain.growth.metric;
+
+import com.cubinghub.domain.record.entity.Penalty;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Current retained Practice Record를 Growth metric 계산에 필요한 값만으로 표현한다.
+ * event ownership과 capability 검증은 read service 경계에서 처리한다.
+ */
+public record GrowthRecord(
+        long id,
+        int timeMs,
+        Penalty penalty,
+        Instant createdAt
+) {
+
+    public GrowthRecord {
+        if (id <= 0) {
+            throw new IllegalArgumentException("Record id는 양수여야 합니다.");
+        }
+        if (timeMs <= 0) {
+            throw new IllegalArgumentException("Record timeMs는 양수여야 합니다.");
+        }
+        Objects.requireNonNull(penalty, "penalty는 필수입니다.");
+        Objects.requireNonNull(createdAt, "createdAt은 필수입니다.");
+    }
+
+    public Integer effectiveTimeMs() {
+        return penalty.applyTo(timeMs);
+    }
+
+    public boolean isRankable() {
+        return penalty.isRankable();
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthTimeWindows.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthTimeWindows.java
@@ -1,0 +1,98 @@
+package com.cubinghub.domain.growth.metric;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public final class GrowthTimeWindows {
+
+    public static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
+    private GrowthTimeWindows() {
+    }
+
+    public static ActivityWindow activityWindow(Clock clock, int days) {
+        Objects.requireNonNull(clock, "clock은 필수입니다.");
+        return activityWindow(clock.instant(), days);
+    }
+
+    public static ActivityWindow activityWindow(Instant generatedAt, int days) {
+        if (days < 1) {
+            throw new IllegalArgumentException("activity window 일수는 1 이상이어야 합니다.");
+        }
+
+        LocalDate asOfDate = asOfDate(generatedAt);
+        LocalDate fromDate = asOfDate.minusDays(days - 1L);
+        return new ActivityWindow(asOfDate, calendarWindow(fromDate, asOfDate.plusDays(1)));
+    }
+
+    public static PerformanceComparisonWindow performanceComparisonWindow(Clock clock) {
+        Objects.requireNonNull(clock, "clock은 필수입니다.");
+        return performanceComparisonWindow(clock.instant());
+    }
+
+    public static PerformanceComparisonWindow performanceComparisonWindow(Instant generatedAt) {
+        LocalDate asOfDate = asOfDate(generatedAt);
+        CalendarWindow recentPeriod = calendarWindow(asOfDate.minusDays(7), asOfDate);
+        CalendarWindow previousPeriod = calendarWindow(asOfDate.minusDays(14), asOfDate.minusDays(7));
+
+        return new PerformanceComparisonWindow(asOfDate, recentPeriod, previousPeriod);
+    }
+
+    private static LocalDate asOfDate(Instant generatedAt) {
+        return Objects.requireNonNull(generatedAt, "generatedAt은 필수입니다.")
+                .atZone(SERVICE_ZONE)
+                .toLocalDate();
+    }
+
+    private static CalendarWindow calendarWindow(LocalDate fromDate, LocalDate toDateExclusive) {
+        Instant fromInclusive = fromDate.atStartOfDay(SERVICE_ZONE).toInstant();
+        Instant toExclusive = toDateExclusive.atStartOfDay(SERVICE_ZONE).toInstant();
+        return new CalendarWindow(fromDate, toDateExclusive, fromInclusive, toExclusive);
+    }
+
+    public record ActivityWindow(LocalDate asOfDate, CalendarWindow range) {
+
+        public ActivityWindow {
+            Objects.requireNonNull(asOfDate, "asOfDate는 필수입니다.");
+            Objects.requireNonNull(range, "range는 필수입니다.");
+        }
+    }
+
+    public record PerformanceComparisonWindow(
+            LocalDate asOfDate,
+            CalendarWindow recentPeriod,
+            CalendarWindow previousPeriod
+    ) {
+
+        public PerformanceComparisonWindow {
+            Objects.requireNonNull(asOfDate, "asOfDate는 필수입니다.");
+            Objects.requireNonNull(recentPeriod, "recentPeriod는 필수입니다.");
+            Objects.requireNonNull(previousPeriod, "previousPeriod는 필수입니다.");
+        }
+    }
+
+    public record CalendarWindow(
+            LocalDate fromDate,
+            LocalDate toDateExclusive,
+            Instant fromInclusive,
+            Instant toExclusive
+    ) {
+
+        public CalendarWindow {
+            Objects.requireNonNull(fromDate, "fromDate는 필수입니다.");
+            Objects.requireNonNull(toDateExclusive, "toDateExclusive는 필수입니다.");
+            Objects.requireNonNull(fromInclusive, "fromInclusive는 필수입니다.");
+            Objects.requireNonNull(toExclusive, "toExclusive는 필수입니다.");
+            if (!fromDate.isBefore(toDateExclusive) || !fromInclusive.isBefore(toExclusive)) {
+                throw new IllegalArgumentException("calendar window는 양수 길이여야 합니다.");
+            }
+        }
+
+        public boolean contains(Instant instant) {
+            return !instant.isBefore(fromInclusive) && instant.isBefore(toExclusive);
+        }
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthMetricCalculatorTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthMetricCalculatorTest.java
@@ -1,0 +1,461 @@
+package com.cubinghub.domain.growth.metric;
+
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.ConsistencyDirection.NARROWER;
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.ConsistencyDirection.WIDER;
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.PerformanceDirection.FASTER;
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.PerformanceDirection.NOT_AVAILABLE;
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.PerformanceDirection.SLOWER;
+import static com.cubinghub.domain.growth.metric.GrowthMetricCalculator.PerformanceDirection.UNCHANGED;
+import static com.cubinghub.domain.growth.metric.GrowthMetricFixtures.record;
+import static com.cubinghub.domain.growth.metric.GrowthMetricFixtures.recordsForConsistency;
+import static com.cubinghub.domain.growth.metric.GrowthMetricFixtures.values;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cubinghub.domain.record.entity.Penalty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("GrowthMetricCalculator 단위 테스트")
+class GrowthMetricCalculatorTest {
+
+    private static final GrowthTimeWindows.PerformanceComparisonWindow COMPARISON_WINDOW =
+            GrowthTimeWindows.performanceComparisonWindow(Instant.parse("2026-08-11T15:01:00Z"));
+
+    @Test
+    @DisplayName("NONE, PLUS_TWO, DNF의 effective result를 Penalty 규칙으로 계산한다")
+    void should_apply_canonical_effective_result_when_penalty_is_none_plus_two_or_dnf() {
+        assertThat(record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z").effectiveTimeMs()).isEqualTo(10000);
+        assertThat(record(2L, 10000, Penalty.PLUS_TWO, "2026-08-01T00:01:00Z").effectiveTimeMs()).isEqualTo(12000);
+        assertThat(record(3L, 10000, Penalty.DNF, "2026-08-01T00:02:00Z").effectiveTimeMs()).isNull();
+    }
+
+    @Test
+    @DisplayName("latest Record 수가 부족하면 Ao5와 Ao12를 INSUFFICIENT_DATA로 반환한다")
+    void should_return_insufficient_data_when_recent_record_count_is_less_than_ao_window() {
+        List<GrowthRecord> fourRecords = List.of(
+                record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 11000, Penalty.NONE, "2026-08-01T00:01:00Z"),
+                record(3L, 12000, Penalty.NONE, "2026-08-01T00:02:00Z"),
+                record(4L, 13000, Penalty.NONE, "2026-08-01T00:03:00Z")
+        );
+
+        GrowthMetricCalculator.AverageResult ao5 = GrowthMetricCalculator.calculateRecentAo5(fourRecords);
+        GrowthMetricCalculator.AverageResult ao12 = GrowthMetricCalculator.calculateRecentAo12(fourRecords);
+
+        assertThat(ao5.status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_DATA);
+        assertThat(ao5.valueMs()).isNull();
+        assertThat(ao12.status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_DATA);
+        assertThat(ao12.recordCount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("Ao는 createdAt DESC, id DESC의 latest window에서 best와 worst를 trim한다")
+    void should_calculate_ao_from_stably_ordered_latest_records() {
+        List<GrowthRecord> shuffledRecords = List.of(
+                record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(5L, 14000, Penalty.NONE, "2026-08-01T00:04:00Z"),
+                record(3L, 12000, Penalty.NONE, "2026-08-01T00:02:00Z"),
+                record(4L, 13000, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(2L, 11000, Penalty.NONE, "2026-08-01T00:01:00Z")
+        );
+
+        GrowthMetricCalculator.AverageResult result = GrowthMetricCalculator.calculateRecentAo5(shuffledRecords);
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(result.valueMs()).isEqualTo(12000);
+    }
+
+    @Test
+    @DisplayName("Ao12는 latest 12 Record의 numeric trim result를 반환한다")
+    void should_calculate_numeric_ao12_when_twelve_recent_records_exist() {
+        List<GrowthRecord> records = new java.util.ArrayList<>();
+        for (int index = 0; index < 12; index++) {
+            records.add(record(
+                    index + 1L,
+                    10000 + index * 1000,
+                    Penalty.NONE,
+                    "2026-08-01T00:" + String.format("%02d", index) + ":00Z"
+            ));
+        }
+
+        GrowthMetricCalculator.AverageResult result = GrowthMetricCalculator.calculateRecentAo12(records);
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(result.recordCount()).isEqualTo(12);
+        assertThat(result.valueMs()).isEqualTo(15500);
+    }
+
+    @Test
+    @DisplayName("Ao는 PLUS_TWO의 effective time과 integer millisecond 반올림을 사용한다")
+    void should_use_plus_two_effective_time_and_round_ao_to_integer_milliseconds() {
+        List<GrowthRecord> plusTwoRecords = List.of(
+                record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 9001, Penalty.PLUS_TWO, "2026-08-01T00:01:00Z"),
+                record(3L, 12000, Penalty.NONE, "2026-08-01T00:02:00Z"),
+                record(4L, 13001, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(5L, 14000, Penalty.NONE, "2026-08-01T00:04:00Z")
+        );
+        List<GrowthRecord> roundingRecords = List.of(
+                record(6L, 10000, Penalty.NONE, "2026-08-01T00:05:00Z"),
+                record(7L, 10001, Penalty.NONE, "2026-08-01T00:06:00Z"),
+                record(8L, 10003, Penalty.NONE, "2026-08-01T00:07:00Z"),
+                record(9L, 10004, Penalty.NONE, "2026-08-01T00:08:00Z"),
+                record(10L, 10005, Penalty.NONE, "2026-08-01T00:09:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculateRecentAo5(plusTwoRecords).valueMs()).isEqualTo(12001);
+        assertThat(GrowthMetricCalculator.calculateRecentAo5(roundingRecords).valueMs()).isEqualTo(10003);
+    }
+
+    @Test
+    @DisplayName("Ao는 DNF 한 개를 worst로 trim하고 DNF 두 개 이상을 DNF로 반환한다")
+    void should_trim_one_dnf_but_return_dnf_when_two_or_more_dnfs_exist() {
+        List<GrowthRecord> oneDnf = List.of(
+                record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 11000, Penalty.NONE, "2026-08-01T00:01:00Z"),
+                record(3L, 12000, Penalty.DNF, "2026-08-01T00:02:00Z"),
+                record(4L, 13000, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(5L, 14000, Penalty.NONE, "2026-08-01T00:04:00Z")
+        );
+        List<GrowthRecord> twoDnfs = List.of(
+                record(6L, 10000, Penalty.NONE, "2026-08-01T00:05:00Z"),
+                record(7L, 11000, Penalty.DNF, "2026-08-01T00:06:00Z"),
+                record(8L, 12000, Penalty.DNF, "2026-08-01T00:07:00Z"),
+                record(9L, 13000, Penalty.NONE, "2026-08-01T00:08:00Z"),
+                record(10L, 14000, Penalty.NONE, "2026-08-01T00:09:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculateRecentAo5(oneDnf).valueMs()).isEqualTo(12667);
+        assertThat(GrowthMetricCalculator.calculateRecentAo5(twoDnfs).status()).isEqualTo(GrowthMetricStatus.DNF);
+    }
+
+    @Test
+    @DisplayName("Ao tie는 같은 effective time을 그대로 포함하고 trim 결과를 안정적으로 계산한다")
+    void should_calculate_ao_when_effective_times_are_tied() {
+        List<GrowthRecord> records = List.of(
+                record(1L, 10000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 10000, Penalty.NONE, "2026-08-01T00:01:00Z"),
+                record(3L, 11000, Penalty.NONE, "2026-08-01T00:02:00Z"),
+                record(4L, 12000, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(5L, 12000, Penalty.NONE, "2026-08-01T00:04:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculateRecentAo5(records).valueMs()).isEqualTo(11000);
+    }
+
+    @Test
+    @DisplayName("median은 홀수와 짝수 rankable population을 integer millisecond로 계산한다")
+    void should_calculate_odd_and_even_median_with_integer_millisecond_rounding() {
+        GrowthMetricCalculator.MedianResult odd = GrowthMetricCalculator.calculateMedian(List.of(
+                record(1L, 12000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 10000, Penalty.NONE, "2026-08-01T00:01:00Z"),
+                record(3L, 11000, Penalty.NONE, "2026-08-01T00:02:00Z")
+        ));
+        GrowthMetricCalculator.MedianResult even = GrowthMetricCalculator.calculateMedian(List.of(
+                record(4L, 10000, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(5L, 10001, Penalty.NONE, "2026-08-01T00:04:00Z")
+        ));
+
+        assertThat(odd.valueMs()).isEqualTo(11000);
+        assertThat(even.valueMs()).isEqualTo(10001);
+    }
+
+    @Test
+    @DisplayName("median은 DNF를 제외하고 PLUS_TWO와 penalty count를 보존한다")
+    void should_exclude_dnf_from_median_and_preserve_plus_two_and_dnf_counts() {
+        GrowthMetricCalculator.MedianResult result = GrowthMetricCalculator.calculateMedian(List.of(
+                record(1L, 9000, Penalty.PLUS_TWO, "2026-08-01T00:00:00Z"),
+                record(2L, 11000, Penalty.DNF, "2026-08-01T00:01:00Z"),
+                record(3L, 12000, Penalty.NONE, "2026-08-01T00:02:00Z")
+        ));
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(result.valueMs()).isEqualTo(11500);
+        assertThat(result.rankableCount()).isEqualTo(2);
+        assertThat(result.dnfCount()).isEqualTo(1);
+        assertThat(result.plusTwoCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("빈 median population은 NO_DATA로 반환한다")
+    void should_return_no_data_when_median_population_is_empty() {
+        GrowthMetricCalculator.MedianResult result = GrowthMetricCalculator.calculateMedian(List.of());
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.NO_DATA);
+        assertThat(result.valueMs()).isNull();
+        assertThat(result.rankableCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("comparison은 한 period에 record가 없으면 NO_DATA를 반환한다")
+    void should_return_no_data_when_one_comparison_period_has_no_records() {
+        GrowthMetricCalculator.PeriodComparisonResult result = GrowthMetricCalculator.comparePerformancePeriods(
+                periodRecords(1L, new int[] {18000, 19000, 20000, 21000, 22000}, "2026-08-06"),
+                COMPARISON_WINDOW
+        );
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.NO_DATA);
+        assertThat(result.direction()).isEqualTo(NOT_AVAILABLE);
+    }
+
+    @Test
+    @DisplayName("comparison은 rankable Record 수가 부족하면 INSUFFICIENT_SAMPLE을 반환한다")
+    void should_return_insufficient_sample_when_rankable_record_count_is_below_minimum() {
+        List<GrowthRecord> records = new java.util.ArrayList<>();
+        records.addAll(periodRecords(1L, new int[] {18000, 19000, 20000, 21000}, "2026-08-06"));
+        records.addAll(periodRecords(10L, new int[] {22000, 23000, 24000, 25000}, "2026-08-01"));
+
+        GrowthMetricCalculator.PeriodComparisonResult result = GrowthMetricCalculator.comparePerformancePeriods(
+                records,
+                COMPARISON_WINDOW
+        );
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_SAMPLE);
+        assertThat(result.recentPeriod().rankableCount()).isEqualTo(4);
+        assertThat(result.previousPeriod().rankableCount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("comparison은 rankable Record가 한 active day에만 있으면 INSUFFICIENT_SAMPLE을 반환한다")
+    void should_return_insufficient_sample_when_rankable_records_exist_on_only_one_active_day() {
+        List<GrowthRecord> records = new java.util.ArrayList<>();
+        records.addAll(periodRecordsOnOneDay(1L, new int[] {18000, 19000, 20000, 21000, 22000}, "2026-08-06"));
+        records.addAll(periodRecordsOnOneDay(10L, new int[] {22000, 23000, 24000, 25000, 26000}, "2026-08-01"));
+
+        GrowthMetricCalculator.PeriodComparisonResult result = GrowthMetricCalculator.comparePerformancePeriods(
+                records,
+                COMPARISON_WINDOW
+        );
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_SAMPLE);
+        assertThat(result.recentPeriod().activeDays()).isEqualTo(1);
+        assertThat(result.previousPeriod().activeDays()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("comparison은 faster, slower, unchanged 방향과 raw millisecond improvement percent를 계산한다")
+    void should_calculate_comparison_direction_and_improvement_percent_when_sample_is_eligible() {
+        GrowthMetricCalculator.PeriodComparisonResult faster = GrowthMetricCalculator.comparePerformancePeriods(
+                comparisonRecords(new int[] {18000, 19000, 20000, 21000, 22000}, new int[] {20000, 21000, 22000, 23000, 24000}),
+                COMPARISON_WINDOW
+        );
+        GrowthMetricCalculator.PeriodComparisonResult slower = GrowthMetricCalculator.comparePerformancePeriods(
+                comparisonRecords(new int[] {22000, 23000, 24000, 25000, 26000}, new int[] {20000, 21000, 22000, 23000, 24000}),
+                COMPARISON_WINDOW
+        );
+        GrowthMetricCalculator.PeriodComparisonResult unchanged = GrowthMetricCalculator.comparePerformancePeriods(
+                comparisonRecords(new int[] {20000, 21000, 22000, 23000, 24000}, new int[] {20000, 21000, 22000, 23000, 24000}),
+                COMPARISON_WINDOW
+        );
+
+        assertThat(faster.status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(faster.direction()).isEqualTo(FASTER);
+        assertThat(faster.improvementPercent()).isEqualByComparingTo(new BigDecimal("9.090909090909091"));
+        assertThat(slower.direction()).isEqualTo(SLOWER);
+        assertThat(slower.improvementPercent()).isEqualByComparingTo(new BigDecimal("-9.090909090909091"));
+        assertThat(unchanged.direction()).isEqualTo(UNCHANGED);
+        assertThat(unchanged.improvementPercent()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("IQR은 rankable Record가 8개 미만이면 계산하지 않는다")
+    void should_not_calculate_iqr_when_rankable_record_count_is_below_eight() {
+        GrowthMetricCalculator.ConsistencyResult result = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 1000, 7), new int[0])
+        );
+
+        assertThat(result.status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_DATA);
+        assertThat(result.current().status()).isEqualTo(GrowthMetricStatus.INSUFFICIENT_DATA);
+        assertThat(result.current().iqrMs()).isNull();
+    }
+
+    @Test
+    @DisplayName("IQR은 exact 8 rankable Record에서 linear interpolation을 사용한다")
+    void should_calculate_iqr_with_linear_interpolation_when_eight_rankable_records_exist() {
+        GrowthMetricCalculator.ConsistencyResult result = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 1000, 8), new int[0])
+        );
+
+        assertThat(result.current().status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(result.current().q1Ms()).isEqualTo(11750);
+        assertThat(result.current().q3Ms()).isEqualTo(15250);
+        assertThat(result.current().iqrMs()).isEqualTo(3500);
+    }
+
+    @Test
+    @DisplayName("IQR은 odd와 even rankable population에 같은 percentile contract를 적용한다")
+    void should_apply_percentile_contract_to_odd_and_even_rankable_populations() {
+        GrowthMetricCalculator.ConsistencyResult odd = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 1000, 9), new int[0])
+        );
+        GrowthMetricCalculator.ConsistencyResult even = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 1000, 10), new int[0])
+        );
+
+        assertThat(odd.current().iqrMs()).isEqualTo(4000);
+        assertThat(even.current().q1Ms()).isEqualTo(12250);
+        assertThat(even.current().q3Ms()).isEqualTo(16750);
+        assertThat(even.current().iqrMs()).isEqualTo(4500);
+    }
+
+    @Test
+    @DisplayName("IQR window는 DNF와 PLUS_TWO count를 보존하고 PLUS_TWO effective time을 사용한다")
+    void should_preserve_dnf_and_plus_two_counts_when_calculating_iqr() {
+        List<GrowthRecord> records = new java.util.ArrayList<>();
+        records.add(record(100L, 8000, Penalty.PLUS_TWO, "2026-08-12T00:00:00Z"));
+        records.add(record(99L, 9000, Penalty.DNF, "2026-08-11T23:59:00Z"));
+        for (int index = 0; index < 10; index++) {
+            records.add(record(98L - index, 11000 + index * 1000, Penalty.NONE, "2026-08-11T23:" + String.format("%02d", 58 - index) + ":00Z"));
+        }
+
+        GrowthMetricCalculator.ConsistencyResult result = GrowthMetricCalculator.calculateRecentConsistency(records);
+
+        assertThat(result.current().status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(result.current().recordCount()).isEqualTo(12);
+        assertThat(result.current().rankableCount()).isEqualTo(11);
+        assertThat(result.current().dnfCount()).isEqualTo(1);
+        assertThat(result.current().plusTwoCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("IQR comparison은 narrower, wider, unchanged를 시간 성과와 분리해 반환한다")
+    void should_return_consistency_direction_without_interpreting_it_as_speed() {
+        GrowthMetricCalculator.ConsistencyResult narrower = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 100, 12), values(10000, 200, 12))
+        );
+        GrowthMetricCalculator.ConsistencyResult wider = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 200, 12), values(10000, 100, 12))
+        );
+        GrowthMetricCalculator.ConsistencyResult unchanged = GrowthMetricCalculator.calculateRecentConsistency(
+                recordsForConsistency(values(10000, 100, 12), values(10000, 100, 12))
+        );
+
+        assertThat(narrower.status()).isEqualTo(GrowthMetricStatus.AVAILABLE);
+        assertThat(narrower.direction()).isEqualTo(NARROWER);
+        assertThat(wider.direction()).isEqualTo(WIDER);
+        assertThat(unchanged.direction()).isEqualTo(GrowthMetricCalculator.ConsistencyDirection.UNCHANGED);
+    }
+
+    @Test
+    @DisplayName("PB progression은 첫 rankable Record와 strictly improving running minimum만 남긴다")
+    void should_emit_only_strictly_improving_pb_progression_points() {
+        List<GrowthRecord> records = List.of(
+                record(5L, 21000, Penalty.NONE, "2026-08-01T00:04:00Z"),
+                record(4L, 23000, Penalty.NONE, "2026-08-01T00:03:00Z"),
+                record(3L, 22000, Penalty.NONE, "2026-08-01T00:02:00Z"),
+                record(2L, 22000, Penalty.NONE, "2026-08-01T00:01:00Z"),
+                record(1L, 23000, Penalty.NONE, "2026-08-01T00:00:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculatePbProgression(records))
+                .extracting(GrowthMetricCalculator.PbProgressionPoint::recordId)
+                .containsExactly(1L, 2L, 5L);
+    }
+
+    @Test
+    @DisplayName("PB progression은 PLUS_TWO effective time을 사용하고 DNF를 point로 만들지 않는다")
+    void should_use_plus_two_effective_time_and_exclude_dnf_from_pb_progression() {
+        List<GrowthRecord> records = List.of(
+                record(1L, 19000, Penalty.PLUS_TWO, "2026-08-01T00:00:00Z"),
+                record(2L, 18000, Penalty.DNF, "2026-08-01T00:01:00Z"),
+                record(3L, 20500, Penalty.NONE, "2026-08-01T00:02:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculatePbProgression(records))
+                .extracting(
+                        GrowthMetricCalculator.PbProgressionPoint::recordId,
+                        GrowthMetricCalculator.PbProgressionPoint::effectiveTimeMs
+                )
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(1L, 21000),
+                        org.assertj.core.groups.Tuple.tuple(3L, 20500)
+                );
+    }
+
+    @Test
+    @DisplayName("PB progression은 같은 timestamp에서 id ASC를 chronological tie-break로 사용한다")
+    void should_use_id_ascending_when_pb_progression_records_share_created_at() {
+        List<GrowthRecord> records = List.of(
+                record(3L, 23000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 22000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(1L, 24000, Penalty.NONE, "2026-08-01T00:00:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculatePbProgression(records))
+                .extracting(GrowthMetricCalculator.PbProgressionPoint::recordId)
+                .containsExactly(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("PB progression은 penalty mutation 뒤 current retained state에서 다시 계산한다")
+    void should_recalculate_pb_progression_from_current_penalty_state() {
+        List<GrowthRecord> beforePenaltyMutation = List.of(
+                record(1L, 20000, Penalty.NONE, "2026-08-01T00:00:00Z"),
+                record(2L, 20500, Penalty.NONE, "2026-08-01T00:01:00Z")
+        );
+        List<GrowthRecord> afterPenaltyMutation = List.of(
+                record(1L, 20000, Penalty.DNF, "2026-08-01T00:00:00Z"),
+                record(2L, 20500, Penalty.NONE, "2026-08-01T00:01:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculatePbProgression(beforePenaltyMutation))
+                .extracting(GrowthMetricCalculator.PbProgressionPoint::recordId)
+                .containsExactly(1L);
+        assertThat(GrowthMetricCalculator.calculatePbProgression(afterPenaltyMutation))
+                .extracting(GrowthMetricCalculator.PbProgressionPoint::recordId)
+                .containsExactly(2L);
+    }
+
+    @Test
+    @DisplayName("PB progression은 삭제된 Record가 없는 current retained fixture만 사용한다")
+    void should_not_include_deleted_record_in_pb_progression_fixture() {
+        List<GrowthRecord> retainedRecords = List.of(
+                record(1L, 20000, Penalty.NONE, "2026-08-01T00:00:00Z")
+        );
+
+        assertThat(GrowthMetricCalculator.calculatePbProgression(retainedRecords))
+                .extracting(GrowthMetricCalculator.PbProgressionPoint::recordId)
+                .containsExactly(1L);
+    }
+
+    private static List<GrowthRecord> comparisonRecords(int[] recentValues, int[] previousValues) {
+        List<GrowthRecord> records = new java.util.ArrayList<>();
+        records.addAll(periodRecords(1L, recentValues, "2026-08-06"));
+        records.addAll(periodRecords(100L, previousValues, "2026-08-01"));
+        return records;
+    }
+
+    private static List<GrowthRecord> periodRecords(long firstId, int[] values, String kstDate) {
+        List<GrowthRecord> records = new java.util.ArrayList<>(values.length);
+        for (int index = 0; index < values.length; index++) {
+            String day = index < 3 ? kstDate : incrementKstDate(kstDate);
+            records.add(record(
+                    firstId + index,
+                    values[index],
+                    Penalty.NONE,
+                    day + (index < 3 ? "T00:0" + index + ":00+09:00" : "T00:0" + (index - 3) + ":00+09:00")
+            ));
+        }
+        return records;
+    }
+
+    private static List<GrowthRecord> periodRecordsOnOneDay(long firstId, int[] values, String kstDate) {
+        List<GrowthRecord> records = new java.util.ArrayList<>(values.length);
+        for (int index = 0; index < values.length; index++) {
+            records.add(record(
+                    firstId + index,
+                    values[index],
+                    Penalty.NONE,
+                    kstDate + "T00:0" + index + ":00+09:00"
+            ));
+        }
+        return records;
+    }
+
+    private static String incrementKstDate(String date) {
+        return java.time.LocalDate.parse(date).plusDays(1).toString();
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthMetricFixtures.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthMetricFixtures.java
@@ -1,0 +1,45 @@
+package com.cubinghub.domain.growth.metric;
+
+import com.cubinghub.domain.record.entity.Penalty;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+final class GrowthMetricFixtures {
+
+    private GrowthMetricFixtures() {
+    }
+
+    static GrowthRecord record(long id, int timeMs, Penalty penalty, String createdAt) {
+        return new GrowthRecord(id, timeMs, penalty, OffsetDateTime.parse(createdAt).toInstant());
+    }
+
+    static List<GrowthRecord> recordsForConsistency(int[] currentValues, int[] previousValues) {
+        Instant newest = Instant.parse("2026-08-12T00:00:00Z");
+        List<GrowthRecord> records = new ArrayList<>(currentValues.length + previousValues.length);
+        long id = 100L;
+
+        for (int index = 0; index < currentValues.length; index++) {
+            records.add(new GrowthRecord(id--, currentValues[index], Penalty.NONE, newest.minusSeconds(index * 60L)));
+        }
+        for (int index = 0; index < previousValues.length; index++) {
+            records.add(new GrowthRecord(
+                    id--,
+                    previousValues[index],
+                    Penalty.NONE,
+                    newest.minusSeconds((currentValues.length + index) * 60L)
+            ));
+        }
+
+        return records;
+    }
+
+    static int[] values(int base, int step, int count) {
+        int[] values = new int[count];
+        for (int index = 0; index < count; index++) {
+            values[index] = base + step * index;
+        }
+        return values;
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthTimeWindowsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthTimeWindowsTest.java
@@ -1,0 +1,71 @@
+package com.cubinghub.domain.growth.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("GrowthTimeWindows 단위 테스트")
+class GrowthTimeWindowsTest {
+
+    private static final Clock AS_OF_AUGUST_12_KST = Clock.fixed(
+            Instant.parse("2026-08-11T15:01:00Z"),
+            ZoneOffset.UTC
+    );
+
+    @Test
+    @DisplayName("activity window는 Asia/Seoul 오늘을 포함한 7 calendar date를 만든다")
+    void should_create_last_seven_activity_days_including_as_of_date_in_asia_seoul() {
+        GrowthTimeWindows.ActivityWindow window = GrowthTimeWindows.activityWindow(AS_OF_AUGUST_12_KST, 7);
+
+        assertThat(window.asOfDate()).hasToString("2026-08-12");
+        assertThat(window.range().fromDate()).hasToString("2026-08-06");
+        assertThat(window.range().toDateExclusive()).hasToString("2026-08-13");
+        assertThat(window.range().fromInclusive()).isEqualTo(Instant.parse("2026-08-05T15:00:00Z"));
+        assertThat(window.range().toExclusive()).isEqualTo(Instant.parse("2026-08-12T15:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("performance comparison은 partial today를 제외한 recent와 previous 7-day range를 만든다")
+    void should_create_completed_recent_and_previous_seven_day_ranges() {
+        GrowthTimeWindows.PerformanceComparisonWindow window = GrowthTimeWindows.performanceComparisonWindow(
+                AS_OF_AUGUST_12_KST
+        );
+
+        assertThat(window.asOfDate()).hasToString("2026-08-12");
+        assertThat(window.recentPeriod().fromInclusive()).isEqualTo(Instant.parse("2026-08-04T15:00:00Z"));
+        assertThat(window.recentPeriod().toExclusive()).isEqualTo(Instant.parse("2026-08-11T15:00:00Z"));
+        assertThat(window.previousPeriod().fromInclusive()).isEqualTo(Instant.parse("2026-07-28T15:00:00Z"));
+        assertThat(window.previousPeriod().toExclusive()).isEqualTo(Instant.parse("2026-08-04T15:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("UTC previous-day instant는 Asia/Seoul next-day asOfDate로 해석한다")
+    void should_resolve_utc_previous_day_instant_as_next_kst_calendar_date() {
+        GrowthTimeWindows.PerformanceComparisonWindow beforeMidnight = GrowthTimeWindows.performanceComparisonWindow(
+                Instant.parse("2026-08-11T14:59:59Z")
+        );
+        GrowthTimeWindows.PerformanceComparisonWindow afterMidnight = GrowthTimeWindows.performanceComparisonWindow(
+                Instant.parse("2026-08-11T15:00:00Z")
+        );
+
+        assertThat(beforeMidnight.asOfDate()).hasToString("2026-08-11");
+        assertThat(afterMidnight.asOfDate()).hasToString("2026-08-12");
+    }
+
+    @Test
+    @DisplayName("partial today Record는 activity에는 포함하고 performance comparison에서는 제외한다")
+    void should_include_partial_today_in_activity_but_exclude_it_from_performance_comparison() {
+        Instant kstTodayStart = Instant.parse("2026-08-11T15:00:00Z");
+        GrowthTimeWindows.ActivityWindow activityWindow = GrowthTimeWindows.activityWindow(AS_OF_AUGUST_12_KST, 7);
+        GrowthTimeWindows.PerformanceComparisonWindow comparisonWindow = GrowthTimeWindows.performanceComparisonWindow(
+                AS_OF_AUGUST_12_KST
+        );
+
+        assertThat(activityWindow.range().contains(kstTodayStart)).isTrue();
+        assertThat(comparisonWindow.recentPeriod().contains(kstTodayStart)).isFalse();
+    }
+}

--- a/docs/01-domain/growth-metrics.md
+++ b/docs/01-domain/growth-metrics.md
@@ -1,8 +1,8 @@
 ---
 doc_type: domain
-status: draft
+status: active
 created: 2026-08-11
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -17,16 +17,19 @@ related:
 
 ## 문서 상태
 
-V2.2 Growth metric contract는 `draft`다. 아래 `MUST`, `SHOULD`, `NOT NOW`는 V2.2 proposal이며 current 구현이나 accepted contract를 뜻하지 않는다.
+V2.2 `MUST` metric formula와 edge case는 active contract다. PR A의 pure calculator는 이 문서의 effective result, Ao, median, period comparison, IQR, PB progression, timezone 규칙을 구현한다.
+
+Read API, MySQL aggregate/window query, My Growth UI와 release는 아직 구현하지 않았다. `SHOULD`, `NOT NOW`, future candidate는 implementation commitment가 아니다.
 
 ```text
 Current
 - V2.1 Record, current PB projection, event history, Timer Ao5/Ao12
+- Growth pure calculator와 canonical unit fixture
 
-V2.2 proposal
-- event별 private My Growth metric
-- current canonical Record 기준 재계산
-- 명명된 population과 시간 경계
+Next implementation
+- event별 private My Growth read API
+- current canonical Record 기준 aggregate query
+- My Growth dashboard
 
 Future candidate
 - best Ao progression, pre-aggregation, user timezone

--- a/docs/02-requirements/features/growth.md
+++ b/docs/02-requirements/features/growth.md
@@ -2,7 +2,7 @@
 doc_type: requirement
 status: draft
 created: 2026-08-11
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -19,15 +19,16 @@ related:
 
 ## 문서 상태
 
-V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. application contract나 출시 약속이 아니다.
+V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. metric formula와 pure calculator는 PR A에서 구현했지만, read API와 My Growth UI는 아직 application contract나 출시 약속이 아니다.
 
 ```text
 Current
 - Timer의 recent Ao5/Ao12
 - private MyPage의 전체 요약, 최근 raw Record chart, history 관리
 - Ranking의 nickname과 event PB
+- current Record projection을 계산하는 Growth metric calculator
 
-V2.2 proposal
+Next implementation
 - private My Growth dashboard
 - event별 canonical Growth metric과 bounded aggregate API
 - next Practice로 돌아가는 명확한 action

--- a/docs/03-architecture/growth-architecture.md
+++ b/docs/03-architecture/growth-architecture.md
@@ -2,7 +2,7 @@
 doc_type: architecture
 status: draft
 created: 2026-08-11
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -22,7 +22,7 @@ related:
 
 ## 문서 상태와 경계
 
-V2.2 Growth & Profile architecture는 `draft`다. endpoint, Java type, SQL, schema가 current 구현이라는 뜻이 아니다. 구현 시 exact request·response는 Spring REST Docs test가 Source of Truth가 된다.
+V2.2 Growth & Profile architecture는 `draft`다. pure metric calculator 외 endpoint, repository projection, SQL, schema는 아직 구현하지 않았다. exact request·response는 구현 시 Spring REST Docs test가 Source of Truth가 된다.
 
 ```text
 Current
@@ -30,9 +30,10 @@ Current
 - MySQL records·user_pbs Source of Truth
 - WCA_333 event-filtered history와 stable ordering
 - Timer client의 recent Ao5/Ao12
+- current Record projection을 받는 pure Growth metric calculator
 - Redis ranking read model
 
-V2.2 proposal
+Next implementation
 - private server-side Growth read API
 - bounded summary와 30-day series
 - current Record 기반 paginated PB progression
@@ -594,8 +595,9 @@ Build와 CI success는 production request 성공을 뜻하지 않는다. main me
 
 ### PR A — Growth contract와 calculator
 
+- status: implemented
 - scope: accepted metric/ADR 반영, backend pure calculator와 fixture, no endpoint
-- dependency: ADR-0010과 MUST metric proposal acceptance
+- dependency: ADR-0010과 MUST metric contract acceptance
 - acceptance: DNF/+2/Ao/median/IQR/time-window contract가 executable test와 일치
 - tests: focused domain unit tests
 - rollback risk: production behavior 없음, 새 internal code 제거 가능

--- a/docs/08-decisions/README.md
+++ b/docs/08-decisions/README.md
@@ -2,7 +2,7 @@
 doc_type: index
 status: active
 created: 2026-08-10
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -23,7 +23,7 @@ ADR은 구현과 운영에 영향을 주는 중요한 기술 결정과 trade-off
 | [ADR-0007](adr-0007-canonical-timer-time-input-provenance.md) | accepted | Practice Timer canonical time과 Input Method provenance 분리 |
 | [ADR-0008](adr-0008-record-submission-idempotency.md) | accepted | client submission identity 기반 Record 저장 idempotency |
 | [ADR-0009](adr-0009-practice-event-capability.md) | accepted | EventType identity와 WCA_333 Practice capability 분리 |
-| [ADR-0010](adr-0010-current-record-growth-read-contract.md) | proposed | Current Record 기반 private Growth read contract |
+| [ADR-0010](adr-0010-current-record-growth-read-contract.md) | accepted | Current Record 기반 private Growth read contract |
 
 과거 최초 결정일을 신뢰성 있게 특정하지 못해, 기존 구현을 ADR로 공식 기록한 2026-08-10을 created로 사용한다.
 

--- a/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+++ b/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
@@ -1,8 +1,8 @@
 ---
 doc_type: adr
-status: proposed
+status: accepted
 created: 2026-08-11
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -60,9 +60,9 @@ Current canonical Record를 요청 시 계산하고, summary·trend·PB progress
 - 단점: PB progression은 user/event 전체 history O(N) scan일 수 있다.
 - 단점: 과거에 보았던 PB snapshot을 복원하지 않는다.
 
-## Decision proposal
+## Decision
 
-Option C를 V2.2 proposal로 둔다. ADR-0010은 `proposed`이며 accepted contract가 아니다.
+Option C를 V2.2 Growth read contract로 채택한다.
 
 1. Growth의 canonical population은 요청 event의 current retained completed Practice Record다.
 2. `NONE`은 raw time, `PLUS_TWO`는 raw + 2,000ms, `DNF`는 non-numeric result다. DNF는 일반 median/percentile에서 제외하고 count/rate로 보존한다. Ao5/Ao12는 V2.1의 별도 trim rule을 유지한다.
@@ -74,6 +74,12 @@ Option C를 V2.2 proposal로 둔다. ADR-0010은 `proposed`이며 accepted contr
 8. Event dimension은 유지하되 current public Growth capability는 WCA_333만 허용한다. Unsupported known event에 fake empty Growth를 제공하지 않는다.
 
 세부 metric formula는 [Growth Metrics](../01-domain/growth-metrics.md), endpoint와 query proposal은 [Growth Architecture](../03-architecture/growth-architecture.md)가 관리한다.
+
+## Implementation status
+
+PR A는 current Record projection을 입력으로 받는 pure metric calculator와 canonical fixture를 구현한다. effective result, Ao5/Ao12, median, period comparison, IQR, PB progression과 Asia/Seoul time window는 해당 calculator가 기준이다.
+
+Dedicated read API, repository projection, MySQL 8 aggregate/window query와 My Growth frontend는 후속 PR에서 구현한다. 이 ADR의 accepted status는 API와 UI의 구현 완료를 뜻하지 않는다.
 
 ## Consequences
 
@@ -96,13 +102,12 @@ Option C를 V2.2 proposal로 둔다. ADR-0010은 `proposed`이며 accepted contr
 
 ### Required follow-up
 
-- 구현 전에 ADR-0010과 MUST metric proposal을 accepted contract로 확정한다.
-- Backend calculator fixture에서 DNF/+2/Ao/median/IQR/time boundary를 고정한다.
+- Backend calculator fixture에서 DNF/+2/Ao/median/IQR/time boundary를 유지한다.
 - MySQL 8 integration test와 10,000-record `EXPLAIN ANALYZE` evidence를 남긴다.
 - UI에 `현재 남아 있는 기록 기준`, `기록된 활동`, `Asia/Seoul`, sample count를 필요한 위치에 표시한다.
 - Public Profile, immutable audit, user timezone 또는 measured pre-aggregation 필요가 생기면 각각 별도 product/architecture decision을 연다.
 
-## Rejected as part of this proposal
+## Rejected alternatives
 
 - current `averageTimeMs`를 이름만 바꿔 canonical Growth metric으로 재사용
 - DNF를 arbitrary worst millisecond나 infinity로 바꿔 일반 mean에 포함


### PR DESCRIPTION
## Goal

V2.2 Growth & Profile의 metric contract를 executable calculator와 unit test로 고정합니다.

## Accepted contract

- ADR-0010 accepted
- current retained WCA_333 Record, DNF/+2, Asia/Seoul, stable ordering
- private dedicated Growth read model 방향

## Calculators

- effective result, Recent Ao5/Ao12, median
- completed 7-day comparison, IQR, PB progression
- Clock/Instant 기반 Asia/Seoul time window

## Edge cases

- Ao 부족 표본, DNF trim, PLUS_TWO, integer millisecond rounding
- period sample gate, partial today, percentile interpolation
- penalty correction, delete, same timestamp/id PB ordering

## Tests

- framework-free Growth calculator unit test와 canonical fixture 추가
- local Java/Node runtime 부재로 Validate에서 backend test 확인 예정

## Out of scope

- Growth endpoint, repository/native query, REST Docs
- Flyway, index, Redis, cache, snapshot table
- My Growth frontend와 UI redesign

## Rollback

이 PR은 additive domain code와 contract 문서만 포함합니다. endpoint, schema, runtime 변경 없이 revert할 수 있습니다.