### PR TITLE
feat: add V2.2 growth read API

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -223,6 +223,68 @@ include::{snippets}/user/password/update/request-fields.adoc[]
 include::{snippets}/user/password/update/http-response.adoc[]
 include::{snippets}/user/password/update/response-fields.adoc[]
 
+== Growth
+
+=== Growth 요약 조회
+==== 요청
+include::{snippets}/growth/summary/http-request.adoc[]
+include::{snippets}/growth/summary/request-headers.adoc[]
+include::{snippets}/growth/summary/query-parameters.adoc[]
+
+==== 응답
+include::{snippets}/growth/summary/http-response.adoc[]
+include::{snippets}/growth/summary/response-fields.adoc[]
+
+==== 상태 예시
+===== Empty
+include::{snippets}/growth/summary/empty/http-response.adoc[]
+
+===== Insufficient data
+include::{snippets}/growth/summary/insufficient/http-response.adoc[]
+
+===== DNF
+include::{snippets}/growth/summary/dnf/http-response.adoc[]
+
+==== 실패 응답
+===== 인증 헤더 누락
+include::{snippets}/growth/summary/unauthorized/http-response.adoc[]
+include::{snippets}/growth/summary/unauthorized/response-fields.adoc[]
+
+===== 지원하지 않는 Practice 종목
+include::{snippets}/growth/summary/unsupported-event/http-request.adoc[]
+include::{snippets}/growth/summary/unsupported-event/request-headers.adoc[]
+include::{snippets}/growth/summary/unsupported-event/query-parameters.adoc[]
+include::{snippets}/growth/summary/unsupported-event/http-response.adoc[]
+include::{snippets}/growth/summary/unsupported-event/response-fields.adoc[]
+
+=== Growth 추세 조회
+==== 요청
+include::{snippets}/growth/trend/http-request.adoc[]
+include::{snippets}/growth/trend/request-headers.adoc[]
+include::{snippets}/growth/trend/query-parameters.adoc[]
+
+==== 응답
+include::{snippets}/growth/trend/http-response.adoc[]
+include::{snippets}/growth/trend/response-fields.adoc[]
+
+==== 실패 응답
+===== 지원하지 않는 period
+include::{snippets}/growth/trend/unsupported-period/http-response.adoc[]
+
+=== PB progression 조회
+==== 요청
+include::{snippets}/growth/pb-progression/http-request.adoc[]
+include::{snippets}/growth/pb-progression/request-headers.adoc[]
+include::{snippets}/growth/pb-progression/query-parameters.adoc[]
+
+==== 응답
+include::{snippets}/growth/pb-progression/http-response.adoc[]
+include::{snippets}/growth/pb-progression/response-fields.adoc[]
+
+==== 상태 예시
+===== Empty
+include::{snippets}/growth/pb-progression/empty/http-response.adoc[]
+
 == 기록 (Record)
 
 === 기록 저장

--- a/backend/src/main/java/com/cubinghub/domain/growth/controller/GrowthController.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/controller/GrowthController.java
@@ -1,0 +1,70 @@
+package com.cubinghub.domain.growth.controller;
+
+import com.cubinghub.common.response.ApiResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthPbProgressionPageResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthTrendResponse;
+import com.cubinghub.domain.growth.service.GrowthReadService;
+import com.cubinghub.domain.record.entity.EventType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/me/growth")
+@RequiredArgsConstructor
+public class GrowthController {
+
+    private final GrowthReadService growthReadService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<GrowthSummaryResponse>> getSummary(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam EventType eventType
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        HttpStatus.OK,
+                        "성장 요약을 조회했습니다.",
+                        growthReadService.getSummary(userDetails.getUsername(), eventType)
+                )
+        );
+    }
+
+    @GetMapping("/trend")
+    public ResponseEntity<ApiResponse<GrowthTrendResponse>> getTrend(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam EventType eventType,
+            @RequestParam String period
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        HttpStatus.OK,
+                        "성장 추세를 조회했습니다.",
+                        growthReadService.getTrend(userDetails.getUsername(), eventType, period)
+                )
+        );
+    }
+
+    @GetMapping("/pb-progression")
+    public ResponseEntity<ApiResponse<GrowthPbProgressionPageResponse>> getPbProgression(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam EventType eventType,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "50") Integer size
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        HttpStatus.OK,
+                        "PB progression을 조회했습니다.",
+                        growthReadService.getPbProgression(userDetails.getUsername(), eventType, page, size)
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthPbProgressionPageResponse.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthPbProgressionPageResponse.java
@@ -1,0 +1,33 @@
+package com.cubinghub.domain.growth.dto.response;
+
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import java.time.Instant;
+import java.util.List;
+
+public record GrowthPbProgressionPageResponse(
+        EventType eventType,
+        String basis,
+        String timeZone,
+        List<PbProgressionPointResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext,
+        boolean hasPrevious
+) {
+
+    public GrowthPbProgressionPageResponse {
+        content = List.copyOf(content);
+    }
+
+    public record PbProgressionPointResponse(
+            long recordId,
+            int timeMs,
+            Penalty penalty,
+            int effectiveTimeMs,
+            Instant createdAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthSummaryResponse.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthSummaryResponse.java
@@ -1,0 +1,95 @@
+package com.cubinghub.domain.growth.dto.response;
+
+import com.cubinghub.domain.growth.metric.GrowthMetricCalculator;
+import com.cubinghub.domain.growth.metric.GrowthMetricStatus;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record GrowthSummaryResponse(
+        EventType eventType,
+        String timeZone,
+        Instant generatedAt,
+        LocalDate asOfDate,
+        CurrentPbResponse currentPb,
+        AverageMetricResponse recentAo5,
+        AverageMetricResponse recentAo12,
+        PerformanceComparisonResponse performanceComparison,
+        ConsistencyResponse consistency,
+        ActivityResponse activity
+) {
+
+    public record CurrentPbResponse(
+            GrowthMetricStatus status,
+            Long recordId,
+            Integer timeMs,
+            Penalty penalty,
+            Integer effectiveTimeMs,
+            Instant createdAt
+    ) {
+    }
+
+    public record AverageMetricResponse(
+            GrowthMetricStatus status,
+            int windowSize,
+            int recordCount,
+            Integer valueMs
+    ) {
+    }
+
+    public record PerformanceComparisonResponse(
+            GrowthMetricStatus status,
+            PeriodResponse recentPeriod,
+            PeriodResponse previousPeriod,
+            GrowthMetricCalculator.PerformanceDirection direction,
+            BigDecimal improvementPercent
+    ) {
+    }
+
+    public record PeriodResponse(
+            LocalDate fromDate,
+            LocalDate toDateExclusive,
+            Integer medianTimeMs,
+            int recordCount,
+            int rankableCount,
+            int activeDays,
+            int dnfCount,
+            int plusTwoCount
+    ) {
+    }
+
+    public record ConsistencyResponse(
+            GrowthMetricStatus status,
+            ConsistencyWindowResponse current,
+            ConsistencyWindowResponse previous,
+            GrowthMetricCalculator.ConsistencyDirection direction,
+            Integer differenceMs
+    ) {
+    }
+
+    public record ConsistencyWindowResponse(
+            GrowthMetricStatus status,
+            int windowSize,
+            int recordCount,
+            int rankableCount,
+            Integer iqrMs,
+            int dnfCount,
+            BigDecimal dnfRatePercent,
+            int plusTwoCount,
+            BigDecimal plusTwoRatePercent
+    ) {
+    }
+
+    public record ActivityResponse(
+            long totalSolveCount,
+            long last7DaysSolveCount,
+            long previous7DaysSolveCount,
+            long last30DaysSolveCount,
+            int activeDaysLast30Days,
+            Instant firstRecordedAt,
+            Instant latestRecordedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthTrendResponse.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthTrendResponse.java
@@ -1,6 +1,7 @@
 package com.cubinghub.domain.growth.dto.response;
 
 import com.cubinghub.domain.record.entity.EventType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -24,6 +25,7 @@ public record GrowthTrendResponse(
             LocalDate date,
             int recordCount,
             int rankableCount,
+            @JsonInclude(JsonInclude.Include.ALWAYS)
             Integer medianTimeMs,
             int dnfCount,
             int plusTwoCount

--- a/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthTrendResponse.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/dto/response/GrowthTrendResponse.java
@@ -1,0 +1,32 @@
+package com.cubinghub.domain.growth.dto.response;
+
+import com.cubinghub.domain.record.entity.EventType;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public record GrowthTrendResponse(
+        EventType eventType,
+        String period,
+        String timeZone,
+        Instant generatedAt,
+        LocalDate fromDate,
+        LocalDate toDate,
+        boolean todayPartial,
+        List<TrendPointResponse> points
+) {
+
+    public GrowthTrendResponse {
+        points = List.copyOf(points);
+    }
+
+    public record TrendPointResponse(
+            LocalDate date,
+            int recordCount,
+            int rankableCount,
+            Integer medianTimeMs,
+            int dnfCount,
+            int plusTwoCount
+    ) {
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/repository/GrowthReadRepository.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/repository/GrowthReadRepository.java
@@ -1,0 +1,404 @@
+package com.cubinghub.domain.growth.repository;
+
+import com.cubinghub.domain.growth.metric.GrowthRecord;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GrowthReadRepository {
+
+    static final String LATEST_RECORDS_QUERY = """
+            SELECT id, time_ms, penalty, created_at
+            FROM records FORCE INDEX (idx_record_user_event_created_at_id)
+            WHERE user_id = :userId
+              AND event_type = :eventType
+            ORDER BY created_at DESC, id DESC
+            LIMIT :limit
+            """;
+
+    static final String RANGE_RECORDS_QUERY = """
+            SELECT id, time_ms, penalty, created_at
+            FROM records FORCE INDEX (idx_record_user_event_created_at_id)
+            WHERE user_id = :userId
+              AND event_type = :eventType
+              AND created_at >= :fromUtc
+              AND created_at < :toUtc
+            ORDER BY created_at DESC, id DESC
+            """;
+
+    static final String CURRENT_PB_QUERY = """
+            SELECT r.id, r.time_ms, r.penalty, up.best_time_ms, r.created_at
+            FROM user_pbs up
+            JOIN records r ON r.id = up.record_id
+            WHERE up.user_id = :userId
+              AND up.event_type = :eventType
+            """;
+
+    static final String ACTIVITY_SUMMARY_QUERY = """
+            SELECT
+                COUNT(*) AS total_solve_count,
+                SUM(CASE
+                    WHEN created_at >= :last7FromUtc AND created_at < :last7ToUtc THEN 1
+                    ELSE 0
+                END) AS last_7_days_solve_count,
+                SUM(CASE
+                    WHEN created_at >= :previous7FromUtc AND created_at < :previous7ToUtc THEN 1
+                    ELSE 0
+                END) AS previous_7_days_solve_count,
+                SUM(CASE
+                    WHEN created_at >= :last30FromUtc AND created_at < :last30ToUtc THEN 1
+                    ELSE 0
+                END) AS last_30_days_solve_count,
+                COUNT(DISTINCT CASE
+                    WHEN created_at >= :last30FromUtc AND created_at < :last30ToUtc
+                    THEN DATE(DATE_ADD(created_at, INTERVAL 9 HOUR))
+                END) AS active_days_last_30_days,
+                MIN(created_at) AS first_recorded_at,
+                MAX(created_at) AS latest_recorded_at
+            FROM records FORCE INDEX (idx_record_user_event_created_at_id)
+            WHERE user_id = :userId
+              AND event_type = :eventType
+            """;
+
+    static final String DAILY_AGGREGATE_QUERY = """
+            WITH ranged AS (
+                SELECT
+                    DATE(DATE_ADD(created_at, INTERVAL 9 HOUR)) AS practice_date,
+                    penalty,
+                    CASE penalty
+                        WHEN 'NONE' THEN time_ms
+                        WHEN 'PLUS_TWO' THEN time_ms + 2000
+                        ELSE NULL
+                    END AS effective_time_ms
+                FROM records FORCE INDEX (idx_record_user_event_created_at_id)
+                WHERE user_id = :userId
+                  AND event_type = :eventType
+                  AND created_at >= :fromUtc
+                  AND created_at < :toUtc
+            ),
+            ranked AS (
+                SELECT
+                    practice_date,
+                    effective_time_ms,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY practice_date
+                        ORDER BY effective_time_ms
+                    ) AS position_in_day,
+                    COUNT(*) OVER (PARTITION BY practice_date) AS rankable_count
+                FROM ranged
+                WHERE effective_time_ms IS NOT NULL
+            ),
+            daily_medians AS (
+                SELECT practice_date, ROUND(AVG(effective_time_ms)) AS median_time_ms
+                FROM ranked
+                WHERE position_in_day IN (
+                    FLOOR((rankable_count + 1) / 2),
+                    FLOOR((rankable_count + 2) / 2)
+                )
+                GROUP BY practice_date
+            ),
+            daily_counts AS (
+                SELECT
+                    practice_date,
+                    COUNT(*) AS record_count,
+                    SUM(CASE WHEN penalty <> 'DNF' THEN 1 ELSE 0 END) AS rankable_count,
+                    SUM(CASE WHEN penalty = 'DNF' THEN 1 ELSE 0 END) AS dnf_count,
+                    SUM(CASE WHEN penalty = 'PLUS_TWO' THEN 1 ELSE 0 END) AS plus_two_count
+                FROM ranged
+                GROUP BY practice_date
+            )
+            SELECT
+                daily_counts.practice_date,
+                daily_counts.record_count,
+                daily_counts.rankable_count,
+                daily_medians.median_time_ms,
+                daily_counts.dnf_count,
+                daily_counts.plus_two_count
+            FROM daily_counts
+            LEFT JOIN daily_medians ON daily_medians.practice_date = daily_counts.practice_date
+            ORDER BY daily_counts.practice_date ASC
+            """;
+
+    static final String PB_PROGRESSION_CTE = """
+            WITH canonical AS (
+                SELECT
+                    id,
+                    time_ms,
+                    penalty,
+                    created_at,
+                    CASE penalty
+                        WHEN 'NONE' THEN time_ms
+                        WHEN 'PLUS_TWO' THEN time_ms + 2000
+                    END AS effective_time_ms
+                FROM records FORCE INDEX (idx_record_user_event_created_at_id)
+                WHERE user_id = :userId
+                  AND event_type = :eventType
+                  AND penalty <> 'DNF'
+            ),
+            running AS (
+                SELECT
+                    canonical.*,
+                    MIN(effective_time_ms) OVER (
+                        ORDER BY created_at ASC, id ASC
+                        ROWS UNBOUNDED PRECEDING
+                    ) AS running_best_time_ms
+                FROM canonical
+            ),
+            scanned AS (
+                SELECT
+                    running.*,
+                    LAG(running_best_time_ms) OVER (
+                        ORDER BY created_at ASC, id ASC
+                    ) AS previous_best_time_ms
+                FROM running
+            )
+            """;
+
+    static final String PB_PROGRESSION_POINTS_QUERY = PB_PROGRESSION_CTE + """
+            SELECT id, time_ms, penalty, effective_time_ms, created_at
+            FROM scanned
+            WHERE previous_best_time_ms IS NULL
+               OR effective_time_ms < previous_best_time_ms
+            ORDER BY created_at DESC, id DESC
+            LIMIT :limit OFFSET :offset
+            """;
+
+    static final String PB_PROGRESSION_COUNT_QUERY = PB_PROGRESSION_CTE + """
+            SELECT COUNT(*)
+            FROM scanned
+            WHERE previous_best_time_ms IS NULL
+               OR effective_time_ms < previous_best_time_ms
+            """;
+
+    private final EntityManager entityManager;
+
+    public List<GrowthRecord> findRecentRecords(Long userId, EventType eventType, int limit) {
+        if (limit < 1) {
+            throw new IllegalArgumentException("recent Record limit은 1 이상이어야 합니다.");
+        }
+
+        return resultList(entityManager.createNativeQuery(LATEST_RECORDS_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .setParameter("limit", limit))
+                .stream()
+                .map(this::toGrowthRecord)
+                .toList();
+    }
+
+    public List<GrowthRecord> findRecordsInRange(
+            Long userId,
+            EventType eventType,
+            Instant fromUtc,
+            Instant toUtc
+    ) {
+        return resultList(entityManager.createNativeQuery(RANGE_RECORDS_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .setParameter("fromUtc", Timestamp.from(fromUtc))
+                .setParameter("toUtc", Timestamp.from(toUtc)))
+                .stream()
+                .map(this::toGrowthRecord)
+                .toList();
+    }
+
+    public Optional<CurrentPb> findCurrentPb(Long userId, EventType eventType) {
+        return resultList(entityManager.createNativeQuery(CURRENT_PB_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name()))
+                .stream()
+                .findFirst()
+                .map(row -> new CurrentPb(
+                        number(row[0]).longValue(),
+                        number(row[1]).intValue(),
+                        Penalty.valueOf((String) row[2]),
+                        number(row[3]).intValue(),
+                        toInstant(row[4])
+                ));
+    }
+
+    public ActivitySummary findActivitySummary(
+            Long userId,
+            EventType eventType,
+            Instant last7FromUtc,
+            Instant last7ToUtc,
+            Instant previous7FromUtc,
+            Instant previous7ToUtc,
+            Instant last30FromUtc,
+            Instant last30ToUtc
+    ) {
+        Object[] row = (Object[]) entityManager.createNativeQuery(ACTIVITY_SUMMARY_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .setParameter("last7FromUtc", Timestamp.from(last7FromUtc))
+                .setParameter("last7ToUtc", Timestamp.from(last7ToUtc))
+                .setParameter("previous7FromUtc", Timestamp.from(previous7FromUtc))
+                .setParameter("previous7ToUtc", Timestamp.from(previous7ToUtc))
+                .setParameter("last30FromUtc", Timestamp.from(last30FromUtc))
+                .setParameter("last30ToUtc", Timestamp.from(last30ToUtc))
+                .getSingleResult();
+
+        return new ActivitySummary(
+                numberOrZero(row[0]).longValue(),
+                numberOrZero(row[1]).longValue(),
+                numberOrZero(row[2]).longValue(),
+                numberOrZero(row[3]).longValue(),
+                numberOrZero(row[4]).intValue(),
+                row[5] == null ? null : toInstant(row[5]),
+                row[6] == null ? null : toInstant(row[6])
+        );
+    }
+
+    public List<DailyAggregate> findDailyAggregates(
+            Long userId,
+            EventType eventType,
+            Instant fromUtc,
+            Instant toUtc
+    ) {
+        return resultList(entityManager.createNativeQuery(DAILY_AGGREGATE_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .setParameter("fromUtc", Timestamp.from(fromUtc))
+                .setParameter("toUtc", Timestamp.from(toUtc)))
+                .stream()
+                .map(row -> new DailyAggregate(
+                        toLocalDate(row[0]),
+                        number(row[1]).intValue(),
+                        number(row[2]).intValue(),
+                        row[3] == null ? null : number(row[3]).intValue(),
+                        number(row[4]).intValue(),
+                        number(row[5]).intValue()
+                ))
+                .toList();
+    }
+
+    public PbProgressionPage findPbProgression(Long userId, EventType eventType, int page, int size) {
+        long offset = (long) (page - 1) * size;
+        List<PbProgressionRecord> content = resultList(entityManager.createNativeQuery(PB_PROGRESSION_POINTS_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .setParameter("limit", size)
+                .setParameter("offset", offset))
+                .stream()
+                .map(row -> new PbProgressionRecord(
+                        number(row[0]).longValue(),
+                        number(row[1]).intValue(),
+                        Penalty.valueOf((String) row[2]),
+                        number(row[3]).intValue(),
+                        toInstant(row[4])
+                ))
+                .toList();
+
+        Number total = (Number) entityManager.createNativeQuery(PB_PROGRESSION_COUNT_QUERY)
+                .setParameter("userId", userId)
+                .setParameter("eventType", eventType.name())
+                .getSingleResult();
+
+        return new PbProgressionPage(content, total.longValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object[]> resultList(Query query) {
+        return (List<Object[]>) query.getResultList();
+    }
+
+    private GrowthRecord toGrowthRecord(Object[] row) {
+        return new GrowthRecord(
+                number(row[0]).longValue(),
+                number(row[1]).intValue(),
+                Penalty.valueOf((String) row[2]),
+                toInstant(row[3])
+        );
+    }
+
+    private Number number(Object value) {
+        if (!(value instanceof Number number)) {
+            throw new IllegalStateException("Growth query가 numeric 값을 반환하지 않았습니다.");
+        }
+        return number;
+    }
+
+    private Number numberOrZero(Object value) {
+        return value == null ? 0 : number(value);
+    }
+
+    private Instant toInstant(Object value) {
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toInstant();
+        }
+        if (value instanceof java.util.Date date) {
+            return date.toInstant();
+        }
+        throw new IllegalStateException("Growth query가 timestamp 값을 반환하지 않았습니다.");
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof Date date) {
+            return date.toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    public record CurrentPb(
+            long recordId,
+            int timeMs,
+            Penalty penalty,
+            int effectiveTimeMs,
+            Instant createdAt
+    ) {
+    }
+
+    public record ActivitySummary(
+            long totalSolveCount,
+            long last7DaysSolveCount,
+            long previous7DaysSolveCount,
+            long last30DaysSolveCount,
+            int activeDaysLast30Days,
+            Instant firstRecordedAt,
+            Instant latestRecordedAt
+    ) {
+    }
+
+    public record DailyAggregate(
+            LocalDate date,
+            int recordCount,
+            int rankableCount,
+            Integer medianTimeMs,
+            int dnfCount,
+            int plusTwoCount
+    ) {
+    }
+
+    public record PbProgressionRecord(
+            long recordId,
+            int timeMs,
+            Penalty penalty,
+            int effectiveTimeMs,
+            Instant createdAt
+    ) {
+    }
+
+    public record PbProgressionPage(List<PbProgressionRecord> content, long totalElements) {
+
+        public PbProgressionPage {
+            content = List.copyOf(content);
+        }
+    }
+}

--- a/backend/src/main/java/com/cubinghub/domain/growth/service/GrowthReadService.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/service/GrowthReadService.java
@@ -1,0 +1,302 @@
+package com.cubinghub.domain.growth.service;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.growth.dto.response.GrowthPbProgressionPageResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthPbProgressionPageResponse.PbProgressionPointResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.ActivityResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.AverageMetricResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.ConsistencyResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.ConsistencyWindowResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.CurrentPbResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.PerformanceComparisonResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse.PeriodResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthTrendResponse;
+import com.cubinghub.domain.growth.dto.response.GrowthTrendResponse.TrendPointResponse;
+import com.cubinghub.domain.growth.metric.GrowthMetricCalculator;
+import com.cubinghub.domain.growth.metric.GrowthMetricStatus;
+import com.cubinghub.domain.growth.metric.GrowthRecord;
+import com.cubinghub.domain.growth.metric.GrowthTimeWindows;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.ActivitySummary;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.CurrentPb;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.DailyAggregate;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.PbProgressionPage;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.repository.UserRepository;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GrowthReadService {
+
+    public static final String SUPPORTED_TREND_PERIOD = "30D";
+    public static final String PB_PROGRESSION_BASIS = "CURRENT_RECORD_STATE";
+    private static final int RECENT_RECORD_LIMIT = 24;
+    private static final int ACTIVITY_LAST_7_DAYS = 7;
+    private static final int ACTIVITY_LAST_30_DAYS = 30;
+    private static final int DEFAULT_PB_PAGE_SIZE = 50;
+    private static final int MAX_PB_PAGE_SIZE = 100;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    private final UserRepository userRepository;
+    private final GrowthReadRepository growthReadRepository;
+    private final PracticeEventCapabilities eventCapabilities;
+    private final Clock clock;
+
+    public GrowthSummaryResponse getSummary(String email, EventType eventType) {
+        eventCapabilities.requirePracticeRecordSupported(eventType);
+        User user = findUser(email);
+        Instant generatedAt = clock.instant();
+
+        GrowthTimeWindows.ActivityWindow last7Days = GrowthTimeWindows.activityWindow(
+                generatedAt,
+                ACTIVITY_LAST_7_DAYS
+        );
+        GrowthTimeWindows.ActivityWindow last30Days = GrowthTimeWindows.activityWindow(
+                generatedAt,
+                ACTIVITY_LAST_30_DAYS
+        );
+        GrowthTimeWindows.PerformanceComparisonWindow comparisonWindow =
+                GrowthTimeWindows.performanceComparisonWindow(generatedAt);
+
+        List<GrowthRecord> recentRecords = growthReadRepository.findRecentRecords(
+                user.getId(),
+                eventType,
+                RECENT_RECORD_LIMIT
+        );
+        List<GrowthRecord> comparisonRecords = growthReadRepository.findRecordsInRange(
+                user.getId(),
+                eventType,
+                comparisonWindow.previousPeriod().fromInclusive(),
+                comparisonWindow.recentPeriod().toExclusive()
+        );
+        ActivitySummary activity = growthReadRepository.findActivitySummary(
+                user.getId(),
+                eventType,
+                last7Days.range().fromInclusive(),
+                last7Days.range().toExclusive(),
+                comparisonWindow.previousPeriod().fromInclusive(),
+                comparisonWindow.previousPeriod().toExclusive(),
+                last30Days.range().fromInclusive(),
+                last30Days.range().toExclusive()
+        );
+
+        return new GrowthSummaryResponse(
+                eventType,
+                GrowthTimeWindows.SERVICE_ZONE.getId(),
+                generatedAt,
+                last30Days.asOfDate(),
+                toCurrentPb(growthReadRepository.findCurrentPb(user.getId(), eventType).orElse(null)),
+                toAverage(GrowthMetricCalculator.calculateRecentAo5(recentRecords)),
+                toAverage(GrowthMetricCalculator.calculateRecentAo12(recentRecords)),
+                toComparison(GrowthMetricCalculator.comparePerformancePeriods(comparisonRecords, comparisonWindow)),
+                toConsistency(GrowthMetricCalculator.calculateRecentConsistency(recentRecords)),
+                toActivity(activity)
+        );
+    }
+
+    public GrowthTrendResponse getTrend(String email, EventType eventType, String period) {
+        eventCapabilities.requirePracticeRecordSupported(eventType);
+        validateTrendPeriod(period);
+        User user = findUser(email);
+        Instant generatedAt = clock.instant();
+        GrowthTimeWindows.ActivityWindow window = GrowthTimeWindows.activityWindow(
+                generatedAt,
+                ACTIVITY_LAST_30_DAYS
+        );
+
+        Map<LocalDate, DailyAggregate> aggregatesByDate = new HashMap<>();
+        for (DailyAggregate aggregate : growthReadRepository.findDailyAggregates(
+                user.getId(),
+                eventType,
+                window.range().fromInclusive(),
+                window.range().toExclusive()
+        )) {
+            aggregatesByDate.put(aggregate.date(), aggregate);
+        }
+
+        List<TrendPointResponse> points = window.range().fromDate().datesUntil(window.range().toDateExclusive())
+                .map(date -> toTrendPoint(date, aggregatesByDate.get(date)))
+                .toList();
+
+        return new GrowthTrendResponse(
+                eventType,
+                SUPPORTED_TREND_PERIOD,
+                GrowthTimeWindows.SERVICE_ZONE.getId(),
+                generatedAt,
+                window.range().fromDate(),
+                window.asOfDate(),
+                true,
+                points
+        );
+    }
+
+    public GrowthPbProgressionPageResponse getPbProgression(
+            String email,
+            EventType eventType,
+            Integer page,
+            Integer size
+    ) {
+        eventCapabilities.requirePracticeRecordSupported(eventType);
+        validatePbPageRequest(page, size);
+        User user = findUser(email);
+        PbProgressionPage progression = growthReadRepository.findPbProgression(user.getId(), eventType, page, size);
+        int totalPages = (int) Math.ceil((double) progression.totalElements() / size);
+
+        return new GrowthPbProgressionPageResponse(
+                eventType,
+                PB_PROGRESSION_BASIS,
+                GrowthTimeWindows.SERVICE_ZONE.getId(),
+                progression.content().stream()
+                        .map(point -> new PbProgressionPointResponse(
+                                point.recordId(),
+                                point.timeMs(),
+                                point.penalty(),
+                                point.effectiveTimeMs(),
+                                point.createdAt()
+                        ))
+                        .toList(),
+                page,
+                size,
+                progression.totalElements(),
+                totalPages,
+                page < totalPages,
+                page > 1
+        );
+    }
+
+    private User findUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomApiException("사용자를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED));
+    }
+
+    private void validateTrendPeriod(String period) {
+        if (!SUPPORTED_TREND_PERIOD.equals(period)) {
+            throw new IllegalArgumentException("지원하지 않는 Growth 기간입니다.");
+        }
+    }
+
+    private void validatePbPageRequest(Integer page, Integer size) {
+        if (page == null || page < 1) {
+            throw new IllegalArgumentException("잘못된 페이지 번호입니다.");
+        }
+        if (size == null || size < 1 || size > MAX_PB_PAGE_SIZE) {
+            throw new IllegalArgumentException("한 번에 조회할 수 있는 개수는 1개 이상 100개 이하여야 합니다.");
+        }
+    }
+
+    private CurrentPbResponse toCurrentPb(CurrentPb currentPb) {
+        if (currentPb == null) {
+            return new CurrentPbResponse(GrowthMetricStatus.NO_DATA, null, null, null, null, null);
+        }
+        return new CurrentPbResponse(
+                GrowthMetricStatus.AVAILABLE,
+                currentPb.recordId(),
+                currentPb.timeMs(),
+                currentPb.penalty(),
+                currentPb.effectiveTimeMs(),
+                currentPb.createdAt()
+        );
+    }
+
+    private AverageMetricResponse toAverage(GrowthMetricCalculator.AverageResult result) {
+        return new AverageMetricResponse(result.status(), result.windowSize(), result.recordCount(), result.valueMs());
+    }
+
+    private PerformanceComparisonResponse toComparison(GrowthMetricCalculator.PeriodComparisonResult result) {
+        return new PerformanceComparisonResponse(
+                result.status(),
+                toPeriod(result.recentPeriod()),
+                toPeriod(result.previousPeriod()),
+                result.direction(),
+                result.improvementPercent()
+        );
+    }
+
+    private PeriodResponse toPeriod(GrowthMetricCalculator.PeriodMetrics period) {
+        return new PeriodResponse(
+                period.window().fromDate(),
+                period.window().toDateExclusive(),
+                period.medianTimeMs(),
+                period.recordCount(),
+                period.rankableCount(),
+                period.activeDays(),
+                period.dnfCount(),
+                period.plusTwoCount()
+        );
+    }
+
+    private ConsistencyResponse toConsistency(GrowthMetricCalculator.ConsistencyResult result) {
+        return new ConsistencyResponse(
+                result.status(),
+                toConsistencyWindow(result.current()),
+                toConsistencyWindow(result.previous()),
+                result.direction(),
+                result.differenceMs()
+        );
+    }
+
+    private ConsistencyWindowResponse toConsistencyWindow(GrowthMetricCalculator.ConsistencyWindow window) {
+        return new ConsistencyWindowResponse(
+                window.status(),
+                window.windowSize(),
+                window.recordCount(),
+                window.rankableCount(),
+                window.iqrMs(),
+                window.dnfCount(),
+                ratePercent(window.dnfCount(), window.recordCount()),
+                window.plusTwoCount(),
+                ratePercent(window.plusTwoCount(), window.recordCount())
+        );
+    }
+
+    private BigDecimal ratePercent(int count, int total) {
+        if (total == 0) {
+            return null;
+        }
+        return BigDecimal.valueOf(count)
+                .multiply(HUNDRED)
+                .divide(BigDecimal.valueOf(total), MathContext.DECIMAL64);
+    }
+
+    private ActivityResponse toActivity(ActivitySummary activity) {
+        return new ActivityResponse(
+                activity.totalSolveCount(),
+                activity.last7DaysSolveCount(),
+                activity.previous7DaysSolveCount(),
+                activity.last30DaysSolveCount(),
+                activity.activeDaysLast30Days(),
+                activity.firstRecordedAt(),
+                activity.latestRecordedAt()
+        );
+    }
+
+    private TrendPointResponse toTrendPoint(LocalDate date, DailyAggregate aggregate) {
+        if (aggregate == null) {
+            return new TrendPointResponse(date, 0, 0, null, 0, 0);
+        }
+        return new TrendPointResponse(
+                aggregate.date(),
+                aggregate.recordCount(),
+                aggregate.rankableCount(),
+                aggregate.medianTimeMs(),
+                aggregate.dnfCount(),
+                aggregate.plusTwoCount()
+        );
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/GrowthDocsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/GrowthDocsTest.java
@@ -1,0 +1,440 @@
+package com.cubinghub.domain.growth;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.entity.Record;
+import com.cubinghub.domain.record.entity.UserPB;
+import com.cubinghub.domain.record.repository.RecordRepository;
+import com.cubinghub.domain.record.repository.UserPBRepository;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.entity.UserRole;
+import com.cubinghub.domain.user.entity.UserStatus;
+import com.cubinghub.domain.user.repository.UserRepository;
+import com.cubinghub.integration.RestDocsIntegrationTest;
+import com.cubinghub.security.JwtTokenProvider;
+import com.cubinghub.support.TestFixtures;
+import jakarta.persistence.EntityManager;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Import(GrowthDocsTest.FixedClockConfiguration.class)
+class GrowthDocsTest extends RestDocsIntegrationTest {
+
+    private static final Instant GENERATED_AT = Instant.parse("2026-08-11T15:01:00Z");
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RecordRepository recordRepository;
+
+    @Autowired
+    private UserPBRepository userPBRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("Growth summary의 available response를 문서화한다")
+    void should_document_available_growth_summary_when_authorized() throws Exception {
+        User user = saveUser("growth-summary@cubinghub.com", "GrowthSummary");
+        createAvailableGrowthFixture(user);
+        String accessToken = TestFixtures.generateAccessToken(jwtTokenProvider, user);
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.currentPb.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data.recentAo5.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data.recentAo12.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data.performanceComparison.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data.consistency.status").value("AVAILABLE"))
+                .andDo(document("growth/summary",
+                        requestHeaders(
+                                headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
+                        ),
+                        queryParameters(
+                                parameterWithName("eventType").description("Growth를 조회할 Practice 종목 (V2.2는 WCA_333만 지원)")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("private Growth summary"),
+                                fieldWithPath("data.eventType").type(JsonFieldType.STRING).description("조회한 Practice 종목"),
+                                fieldWithPath("data.timeZone").type(JsonFieldType.STRING).description("Growth calendar timezone"),
+                                fieldWithPath("data.generatedAt").type(JsonFieldType.STRING).description("같은 summary 계산에 사용한 UTC instant"),
+                                fieldWithPath("data.asOfDate").type(JsonFieldType.STRING).description("Growth calendar 기준 Asia/Seoul 날짜"),
+                                fieldWithPath("data.currentPb").type(JsonFieldType.OBJECT).description("current user_pbs PB projection"),
+                                fieldWithPath("data.currentPb.status").type(JsonFieldType.STRING).description("PB status"),
+                                fieldWithPath("data.currentPb.recordId").type(JsonFieldType.NUMBER).description("PB source Record ID"),
+                                fieldWithPath("data.currentPb.timeMs").type(JsonFieldType.NUMBER).description("PB source raw time (ms)"),
+                                fieldWithPath("data.currentPb.penalty").type(JsonFieldType.STRING).description("PB source current penalty"),
+                                fieldWithPath("data.currentPb.effectiveTimeMs").type(JsonFieldType.NUMBER).description("PB effective time (ms)"),
+                                fieldWithPath("data.currentPb.createdAt").type(JsonFieldType.STRING).description("PB source recorded UTC instant"),
+                                fieldWithPath("data.recentAo5").type(JsonFieldType.OBJECT).description("latest 5 Record Ao"),
+                                fieldWithPath("data.recentAo12").type(JsonFieldType.OBJECT).description("latest 12 Record Ao"),
+                                fieldWithPath("data.recentAo5.status").type(JsonFieldType.STRING).description("Ao5 status"),
+                                fieldWithPath("data.recentAo5.windowSize").type(JsonFieldType.NUMBER).description("Ao5 target window size"),
+                                fieldWithPath("data.recentAo5.recordCount").type(JsonFieldType.NUMBER).description("Ao5 available Record count"),
+                                fieldWithPath("data.recentAo5.valueMs").type(JsonFieldType.NUMBER).description("Ao5 value (ms)"),
+                                fieldWithPath("data.recentAo12.status").type(JsonFieldType.STRING).description("Ao12 status"),
+                                fieldWithPath("data.recentAo12.windowSize").type(JsonFieldType.NUMBER).description("Ao12 target window size"),
+                                fieldWithPath("data.recentAo12.recordCount").type(JsonFieldType.NUMBER).description("Ao12 available Record count"),
+                                fieldWithPath("data.recentAo12.valueMs").type(JsonFieldType.NUMBER).description("Ao12 value (ms)"),
+                                fieldWithPath("data.performanceComparison").type(JsonFieldType.OBJECT).description("completed 7-day performance comparison"),
+                                fieldWithPath("data.performanceComparison.status").type(JsonFieldType.STRING).description("comparison sample status"),
+                                fieldWithPath("data.performanceComparison.recentPeriod").type(JsonFieldType.OBJECT).description("completed recent 7-day period"),
+                                fieldWithPath("data.performanceComparison.previousPeriod").type(JsonFieldType.OBJECT).description("previous completed 7-day period"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.fromDate").type(JsonFieldType.STRING).description("inclusive KST date"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.toDateExclusive").type(JsonFieldType.STRING).description("exclusive KST date"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.medianTimeMs").type(JsonFieldType.NUMBER).description("rankable effective median (ms)"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.recordCount").type(JsonFieldType.NUMBER).description("Record count including DNF"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.rankableCount").type(JsonFieldType.NUMBER).description("rankable Record count"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.activeDays").type(JsonFieldType.NUMBER).description("rankable Record active day count"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                                fieldWithPath("data.performanceComparison.recentPeriod.plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.fromDate").type(JsonFieldType.STRING).description("inclusive KST date"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.toDateExclusive").type(JsonFieldType.STRING).description("exclusive KST date"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.medianTimeMs").type(JsonFieldType.NUMBER).description("rankable effective median (ms)"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.recordCount").type(JsonFieldType.NUMBER).description("Record count including DNF"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.rankableCount").type(JsonFieldType.NUMBER).description("rankable Record count"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.activeDays").type(JsonFieldType.NUMBER).description("rankable Record active day count"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                                fieldWithPath("data.performanceComparison.previousPeriod.plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count"),
+                                fieldWithPath("data.performanceComparison.direction").type(JsonFieldType.STRING).description("FASTER, SLOWER, UNCHANGED, or NOT_AVAILABLE"),
+                                fieldWithPath("data.performanceComparison.improvementPercent").type(JsonFieldType.NUMBER).description("raw millisecond median improvement percent"),
+                                fieldWithPath("data.consistency").type(JsonFieldType.OBJECT).description("latest 12 and previous 12 IQR comparison"),
+                                fieldWithPath("data.consistency.status").type(JsonFieldType.STRING).description("consistency sample status"),
+                                fieldWithPath("data.consistency.current").type(JsonFieldType.OBJECT).description("latest 12 Record window"),
+                                fieldWithPath("data.consistency.previous").type(JsonFieldType.OBJECT).description("immediately previous 12 Record window"),
+                                fieldWithPath("data.consistency.current.status").type(JsonFieldType.STRING).description("current window status"),
+                                fieldWithPath("data.consistency.current.windowSize").type(JsonFieldType.NUMBER).description("target window size"),
+                                fieldWithPath("data.consistency.current.recordCount").type(JsonFieldType.NUMBER).description("Record count including DNF"),
+                                fieldWithPath("data.consistency.current.rankableCount").type(JsonFieldType.NUMBER).description("rankable Record count"),
+                                fieldWithPath("data.consistency.current.iqrMs").type(JsonFieldType.NUMBER).description("Q3 minus Q1 in milliseconds"),
+                                fieldWithPath("data.consistency.current.dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                                fieldWithPath("data.consistency.current.dnfRatePercent").type(JsonFieldType.NUMBER).description("DNF count divided by Record count"),
+                                fieldWithPath("data.consistency.current.plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count"),
+                                fieldWithPath("data.consistency.current.plusTwoRatePercent").type(JsonFieldType.NUMBER).description("PLUS_TWO count divided by Record count"),
+                                fieldWithPath("data.consistency.previous.status").type(JsonFieldType.STRING).description("previous window status"),
+                                fieldWithPath("data.consistency.previous.windowSize").type(JsonFieldType.NUMBER).description("target window size"),
+                                fieldWithPath("data.consistency.previous.recordCount").type(JsonFieldType.NUMBER).description("Record count including DNF"),
+                                fieldWithPath("data.consistency.previous.rankableCount").type(JsonFieldType.NUMBER).description("rankable Record count"),
+                                fieldWithPath("data.consistency.previous.iqrMs").type(JsonFieldType.NUMBER).description("Q3 minus Q1 in milliseconds"),
+                                fieldWithPath("data.consistency.previous.dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                                fieldWithPath("data.consistency.previous.dnfRatePercent").type(JsonFieldType.NUMBER).description("DNF count divided by Record count"),
+                                fieldWithPath("data.consistency.previous.plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count"),
+                                fieldWithPath("data.consistency.previous.plusTwoRatePercent").type(JsonFieldType.NUMBER).description("PLUS_TWO count divided by Record count"),
+                                fieldWithPath("data.consistency.direction").type(JsonFieldType.STRING).description("NARROWER, WIDER, UNCHANGED, or NOT_AVAILABLE"),
+                                fieldWithPath("data.consistency.differenceMs").type(JsonFieldType.NUMBER).description("previous IQR minus current IQR"),
+                                fieldWithPath("data.activity").type(JsonFieldType.OBJECT).description("recorded Practice activity summary"),
+                                fieldWithPath("data.activity.totalSolveCount").type(JsonFieldType.NUMBER).description("all current retained Record count"),
+                                fieldWithPath("data.activity.last7DaysSolveCount").type(JsonFieldType.NUMBER).description("today-inclusive 7 KST date Record count"),
+                                fieldWithPath("data.activity.previous7DaysSolveCount").type(JsonFieldType.NUMBER).description("previous completed 7 KST date Record count"),
+                                fieldWithPath("data.activity.last30DaysSolveCount").type(JsonFieldType.NUMBER).description("today-inclusive 30 KST date Record count"),
+                                fieldWithPath("data.activity.activeDaysLast30Days").type(JsonFieldType.NUMBER).description("30-day KST date count with at least one Record"),
+                                fieldWithPath("data.activity.firstRecordedAt").type(JsonFieldType.STRING).description("first retained Record UTC instant"),
+                                fieldWithPath("data.activity.latestRecordedAt").type(JsonFieldType.STRING).description("latest retained Record UTC instant")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("Growth summary의 empty, insufficient, DNF response를 문서화한다")
+    void should_document_empty_insufficient_and_dnf_growth_summary_states() throws Exception {
+        User empty = saveUser("growth-empty@cubinghub.com", "GrowthEmpty");
+        String emptyToken = TestFixtures.generateAccessToken(jwtTokenProvider, empty);
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + emptyToken)
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.currentPb.status").value("NO_DATA"))
+                .andExpect(jsonPath("$.data.recentAo5.status").value("INSUFFICIENT_DATA"))
+                .andDo(document("growth/summary/empty"));
+
+        User insufficient = saveUser("growth-insufficient@cubinghub.com", "GrowthInsufficient");
+        for (int index = 0; index < 4; index++) {
+            saveRecord(insufficient, 20000 + index * 100, Penalty.NONE,
+                    Instant.parse("2026-08-06T0" + index + ":00:00Z"));
+        }
+        String insufficientToken = TestFixtures.generateAccessToken(jwtTokenProvider, insufficient);
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + insufficientToken)
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentAo5.status").value("INSUFFICIENT_DATA"))
+                .andExpect(jsonPath("$.data.consistency.status").value("INSUFFICIENT_DATA"))
+                .andDo(document("growth/summary/insufficient"));
+
+        User dnf = saveUser("growth-dnf@cubinghub.com", "GrowthDnf");
+        for (int index = 0; index < 5; index++) {
+            Penalty penalty = index < 2 ? Penalty.DNF : Penalty.NONE;
+            saveRecord(dnf, 20000 + index * 100, penalty,
+                    Instant.parse("2026-08-07T0" + index + ":00:00Z"));
+        }
+        String dnfToken = TestFixtures.generateAccessToken(jwtTokenProvider, dnf);
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + dnfToken)
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentAo5.status").value("DNF"))
+                .andDo(document("growth/summary/dnf"));
+    }
+
+    @Test
+    @DisplayName("Growth summary의 인증과 unsupported event failure를 문서화한다")
+    void should_document_growth_summary_authentication_and_capability_failures() throws Exception {
+        mockMvc.perform(get("/api/users/me/growth")
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("growth/summary/unauthorized",
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("실패 원인"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("실패 시 추가 데이터 없음")
+                        )
+                ));
+
+        User user = saveUser("growth-unsupported@cubinghub.com", "GrowthUnsupported");
+        String accessToken = TestFixtures.generateAccessToken(jwtTokenProvider, user);
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_222.name()))
+                .andExpect(status().isBadRequest())
+                .andDo(document("growth/summary/unsupported-event",
+                        requestHeaders(
+                                headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
+                        ),
+                        queryParameters(
+                                parameterWithName("eventType").description("지원하지 않는 known Practice 종목")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("지원하지 않는 Practice 종목 안내"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("실패 시 추가 데이터 없음")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("Growth trend의 30-point response와 period validation을 문서화한다")
+    void should_document_growth_trend_when_authorized() throws Exception {
+        User user = saveUser("growth-trend@cubinghub.com", "GrowthTrend");
+        saveRecord(user, 10000, Penalty.NONE, Instant.parse("2026-08-09T15:30:00Z"));
+        saveRecord(user, 12000, Penalty.DNF, Instant.parse("2026-08-10T15:30:00Z"));
+        String accessToken = TestFixtures.generateAccessToken(jwtTokenProvider, user);
+
+        mockMvc.perform(get("/api/users/me/growth/trend")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("period", "30D"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.points.length()").value(30))
+                .andExpect(jsonPath("$.data.points[28].medianTimeMs").value(nullValue()))
+                .andDo(document("growth/trend",
+                        requestHeaders(
+                                headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
+                        ),
+                        queryParameters(
+                                parameterWithName("eventType").description("Growth를 조회할 Practice 종목 (V2.2는 WCA_333만 지원)"),
+                                parameterWithName("period").description("조회 period. V2.2는 30D만 지원")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("private Growth trend"),
+                                fieldWithPath("data.eventType").type(JsonFieldType.STRING).description("조회한 Practice 종목"),
+                                fieldWithPath("data.period").type(JsonFieldType.STRING).description("지원된 period"),
+                                fieldWithPath("data.timeZone").type(JsonFieldType.STRING).description("Growth calendar timezone"),
+                                fieldWithPath("data.generatedAt").type(JsonFieldType.STRING).description("series 계산 UTC instant"),
+                                fieldWithPath("data.fromDate").type(JsonFieldType.STRING).description("첫 KST date"),
+                                fieldWithPath("data.toDate").type(JsonFieldType.STRING).description("오늘 KST date"),
+                                fieldWithPath("data.todayPartial").type(JsonFieldType.BOOLEAN).description("오늘 point가 진행 중인 day인지 여부"),
+                                fieldWithPath("data.points").type(JsonFieldType.ARRAY).description("항상 30개의 KST date point"),
+                                fieldWithPath("data.points[].date").type(JsonFieldType.STRING).description("KST calendar date"),
+                                fieldWithPath("data.points[].recordCount").type(JsonFieldType.NUMBER).description("DNF를 포함한 Record count"),
+                                fieldWithPath("data.points[].rankableCount").type(JsonFieldType.NUMBER).description("numeric effective Record count"),
+                                fieldWithPath("data.points[].medianTimeMs").type(JsonFieldType.VARIES).description("rankable effective median. missing 또는 DNF-only day는 null"),
+                                fieldWithPath("data.points[].dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                                fieldWithPath("data.points[].plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count")
+                        )
+                ));
+
+        mockMvc.perform(get("/api/users/me/growth/trend")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("period", "90D"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("growth/trend/unsupported-period"));
+    }
+
+    @Test
+    @DisplayName("Growth PB progression의 pagination과 current-state basis를 문서화한다")
+    void should_document_growth_pb_progression_when_authorized() throws Exception {
+        User user = saveUser("growth-progression@cubinghub.com", "GrowthProgression");
+        Record first = saveRecord(user, 24000, Penalty.NONE, Instant.parse("2026-08-01T00:00:00Z"));
+        Record second = saveRecord(user, 22000, Penalty.NONE, Instant.parse("2026-08-01T00:01:00Z"));
+        saveRecord(user, 22000, Penalty.NONE, Instant.parse("2026-08-01T00:02:00Z"));
+        Record currentPb = saveRecord(user, 19000, Penalty.PLUS_TWO, Instant.parse("2026-08-01T00:03:00Z"));
+        User managedUser = userRepository.findById(user.getId()).orElseThrow();
+        userPBRepository.save(UserPB.builder()
+                .user(managedUser)
+                .eventType(EventType.WCA_333)
+                .bestTimeMs(21000)
+                .record(currentPb)
+                .build());
+        String accessToken = TestFixtures.generateAccessToken(jwtTokenProvider, user);
+
+        mockMvc.perform(get("/api/users/me/growth/pb-progression")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("page", "1")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.basis").value("CURRENT_RECORD_STATE"))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].recordId").value(currentPb.getId()))
+                .andExpect(jsonPath("$.data.content[1].recordId").value(second.getId()))
+                .andDo(document("growth/pb-progression",
+                        requestHeaders(
+                                headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
+                        ),
+                        queryParameters(
+                                parameterWithName("eventType").description("Growth를 조회할 Practice 종목 (V2.2는 WCA_333만 지원)"),
+                                parameterWithName("page").optional().description("1부터 시작하는 page 번호. 기본값 1"),
+                                parameterWithName("size").optional().description("page 크기. 기본값 50, 최대 100")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("PB progression page"),
+                                fieldWithPath("data.eventType").type(JsonFieldType.STRING).description("조회한 Practice 종목"),
+                                fieldWithPath("data.basis").type(JsonFieldType.STRING).description("CURRENT_RECORD_STATE"),
+                                fieldWithPath("data.timeZone").type(JsonFieldType.STRING).description("Growth calendar timezone"),
+                                fieldWithPath("data.content").type(JsonFieldType.ARRAY).description("current PB부터 과거 방향의 PB milestone page"),
+                                fieldWithPath("data.content[].recordId").type(JsonFieldType.NUMBER).description("PB milestone Record ID"),
+                                fieldWithPath("data.content[].timeMs").type(JsonFieldType.NUMBER).description("raw time (ms)"),
+                                fieldWithPath("data.content[].penalty").type(JsonFieldType.STRING).description("current penalty"),
+                                fieldWithPath("data.content[].effectiveTimeMs").type(JsonFieldType.NUMBER).description("effective time (ms)"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("recorded UTC instant"),
+                                fieldWithPath("data.page").type(JsonFieldType.NUMBER).description("현재 page 번호 (1부터 시작)"),
+                                fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("현재 page 크기"),
+                                fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER).description("전체 PB milestone 수"),
+                                fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("전체 page 수"),
+                                fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 page 존재 여부"),
+                                fieldWithPath("data.hasPrevious").type(JsonFieldType.BOOLEAN).description("이전 page 존재 여부")
+                        )
+                ));
+
+        User empty = saveUser("growth-progression-empty@cubinghub.com", "GrowthProgressionEmpty");
+        String emptyToken = TestFixtures.generateAccessToken(jwtTokenProvider, empty);
+        mockMvc.perform(get("/api/users/me/growth/pb-progression")
+                        .header("Authorization", "Bearer " + emptyToken)
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(0))
+                .andDo(document("growth/pb-progression/empty"));
+    }
+
+    private User saveUser(String email, String nickname) {
+        return userRepository.save(User.builder()
+                .email(email)
+                .password("password")
+                .nickname(nickname)
+                .role(UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .mainEvent("WCA_333")
+                .build());
+    }
+
+    private void createAvailableGrowthFixture(User user) {
+        List<Record> records = new ArrayList<>();
+        for (int index = 0; index < 12; index++) {
+            Instant createdAt = index < 6
+                    ? Instant.parse("2026-08-05T15:" + String.format("%02d", index) + ":00Z")
+                    : Instant.parse("2026-08-06T15:" + String.format("%02d", index - 6) + ":00Z");
+            Penalty penalty = index == 11 ? Penalty.DNF : index == 10 ? Penalty.PLUS_TWO : Penalty.NONE;
+            records.add(saveRecord(user, 10000 + index * 100, penalty, createdAt));
+        }
+        for (int index = 0; index < 12; index++) {
+            Instant createdAt = index < 6
+                    ? Instant.parse("2026-07-28T15:" + String.format("%02d", index) + ":00Z")
+                    : Instant.parse("2026-07-29T15:" + String.format("%02d", index - 6) + ":00Z");
+            records.add(saveRecord(user, 12000 + index * 100, Penalty.NONE, createdAt));
+        }
+
+        Record currentPb = records.get(0);
+        User managedUser = userRepository.findById(user.getId()).orElseThrow();
+        userPBRepository.save(UserPB.builder()
+                .user(managedUser)
+                .eventType(EventType.WCA_333)
+                .bestTimeMs(currentPb.getEffectiveTimeMs())
+                .record(recordRepository.findById(currentPb.getId()).orElseThrow())
+                .build());
+    }
+
+    private Record saveRecord(User user, int timeMs, Penalty penalty, Instant createdAt) {
+        User managedUser = userRepository.findById(user.getId()).orElseThrow();
+        Record record = recordRepository.saveAndFlush(Record.builder()
+                .user(managedUser)
+                .eventType(EventType.WCA_333)
+                .timeMs(timeMs)
+                .penalty(penalty)
+                .scramble("growth-docs-scramble")
+                .build());
+        recordRepository.flush();
+        jdbcTemplate.update(
+                "UPDATE records SET created_at = ?, updated_at = ? WHERE id = ?",
+                Timestamp.from(createdAt),
+                Timestamp.from(createdAt),
+                record.getId()
+        );
+        entityManager.clear();
+        return recordRepository.findById(record.getId()).orElseThrow();
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class FixedClockConfiguration {
+
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(GENERATED_AT, ZoneOffset.UTC);
+        }
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/GrowthDocsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/GrowthDocsTest.java
@@ -1,5 +1,6 @@
 package com.cubinghub.domain.growth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -25,10 +26,14 @@ import com.cubinghub.domain.user.repository.UserRepository;
 import com.cubinghub.integration.RestDocsIntegrationTest;
 import com.cubinghub.security.JwtTokenProvider;
 import com.cubinghub.support.TestFixtures;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +46,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MvcResult;
 
 @Import(GrowthDocsTest.FixedClockConfiguration.class)
 class GrowthDocsTest extends RestDocsIntegrationTest {
@@ -64,6 +70,9 @@ class GrowthDocsTest extends RestDocsIntegrationTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("Growth summary의 available response를 문서화한다")
@@ -259,41 +268,71 @@ class GrowthDocsTest extends RestDocsIntegrationTest {
         saveRecord(user, 12000, Penalty.DNF, Instant.parse("2026-08-10T15:30:00Z"));
         String accessToken = TestFixtures.generateAccessToken(jwtTokenProvider, user);
 
-        mockMvc.perform(get("/api/users/me/growth/trend")
+        MvcResult result = mockMvc.perform(get("/api/users/me/growth/trend")
                         .header("Authorization", "Bearer " + accessToken)
                         .param("eventType", EventType.WCA_333.name())
                         .param("period", "30D"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.points.length()").value(30))
                 .andExpect(jsonPath("$.data.points[28].medianTimeMs").value(nullValue()))
-                .andDo(document("growth/trend",
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
-                        ),
-                        queryParameters(
-                                parameterWithName("eventType").description("Growth를 조회할 Practice 종목 (V2.2는 WCA_333만 지원)"),
-                                parameterWithName("period").description("조회 period. V2.2는 30D만 지원")
-                        ),
-                        responseFields(
-                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
-                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("private Growth trend"),
-                                fieldWithPath("data.eventType").type(JsonFieldType.STRING).description("조회한 Practice 종목"),
-                                fieldWithPath("data.period").type(JsonFieldType.STRING).description("지원된 period"),
-                                fieldWithPath("data.timeZone").type(JsonFieldType.STRING).description("Growth calendar timezone"),
-                                fieldWithPath("data.generatedAt").type(JsonFieldType.STRING).description("series 계산 UTC instant"),
-                                fieldWithPath("data.fromDate").type(JsonFieldType.STRING).description("첫 KST date"),
-                                fieldWithPath("data.toDate").type(JsonFieldType.STRING).description("오늘 KST date"),
-                                fieldWithPath("data.todayPartial").type(JsonFieldType.BOOLEAN).description("오늘 point가 진행 중인 day인지 여부"),
-                                fieldWithPath("data.points").type(JsonFieldType.ARRAY).description("항상 30개의 KST date point"),
-                                fieldWithPath("data.points[].date").type(JsonFieldType.STRING).description("KST calendar date"),
-                                fieldWithPath("data.points[].recordCount").type(JsonFieldType.NUMBER).description("DNF를 포함한 Record count"),
-                                fieldWithPath("data.points[].rankableCount").type(JsonFieldType.NUMBER).description("numeric effective Record count"),
-                                fieldWithPath("data.points[].medianTimeMs").type(JsonFieldType.VARIES).description("rankable effective median. missing 또는 DNF-only day는 null"),
-                                fieldWithPath("data.points[].dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
-                                fieldWithPath("data.points[].plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count")
-                        )
-                ));
+                .andReturn();
+
+        JsonNode points = objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("data")
+                .path("points");
+        assertThat(points).hasSize(30);
+        points.forEach(point -> assertThat(point.has("medianTimeMs")).isTrue());
+        assertThat(pointForDate(points, "2026-08-10").path("medianTimeMs").isNumber()).isTrue();
+        assertThat(pointForDate(points, "2026-08-11").path("medianTimeMs").isNull()).isTrue();
+        assertThat(pointForDate(points, "2026-08-09").path("medianTimeMs").isNull()).isTrue();
+
+        User docsUser = saveUser("growth-trend-docs@cubinghub.com", "GrowthTrendDocs");
+        createNumericTrendFixture(docsUser);
+        String docsAccessToken = TestFixtures.generateAccessToken(jwtTokenProvider, docsUser);
+        MvcResult docsResult = mockMvc.perform(get("/api/users/me/growth/trend")
+                        .header("Authorization", "Bearer " + docsAccessToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("period", "30D"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode docsPoints = objectMapper.readTree(docsResult.getResponse().getContentAsString())
+                .path("data")
+                .path("points");
+        assertThat(docsPoints).hasSize(30);
+        docsPoints.forEach(point -> {
+            assertThat(point.has("medianTimeMs")).isTrue();
+            assertThat(point.path("medianTimeMs").isNumber()).isTrue();
+        });
+
+        document("growth/trend",
+                requestHeaders(
+                        headerWithName("Authorization").description("Access Token을 담은 Bearer 인증 헤더")
+                ),
+                queryParameters(
+                        parameterWithName("eventType").description("Growth를 조회할 Practice 종목 (V2.2는 WCA_333만 지원)"),
+                        parameterWithName("period").description("조회 period. V2.2는 30D만 지원")
+                ),
+                responseFields(
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("private Growth trend"),
+                        fieldWithPath("data.eventType").type(JsonFieldType.STRING).description("조회한 Practice 종목"),
+                        fieldWithPath("data.period").type(JsonFieldType.STRING).description("지원된 period"),
+                        fieldWithPath("data.timeZone").type(JsonFieldType.STRING).description("Growth calendar timezone"),
+                        fieldWithPath("data.generatedAt").type(JsonFieldType.STRING).description("series 계산 UTC instant"),
+                        fieldWithPath("data.fromDate").type(JsonFieldType.STRING).description("첫 KST date"),
+                        fieldWithPath("data.toDate").type(JsonFieldType.STRING).description("오늘 KST date"),
+                        fieldWithPath("data.todayPartial").type(JsonFieldType.BOOLEAN).description("오늘 point가 진행 중인 day인지 여부"),
+                        fieldWithPath("data.points").type(JsonFieldType.ARRAY).description("항상 30개의 KST date point"),
+                        fieldWithPath("data.points[].date").type(JsonFieldType.STRING).description("KST calendar date"),
+                        fieldWithPath("data.points[].recordCount").type(JsonFieldType.NUMBER).description("DNF를 포함한 Record count"),
+                        fieldWithPath("data.points[].rankableCount").type(JsonFieldType.NUMBER).description("numeric effective Record count"),
+                        fieldWithPath("data.points[].medianTimeMs").type(JsonFieldType.VARIES).description("rankable effective median. missing 또는 DNF-only day는 null"),
+                        fieldWithPath("data.points[].dnfCount").type(JsonFieldType.NUMBER).description("DNF count"),
+                        fieldWithPath("data.points[].plusTwoCount").type(JsonFieldType.NUMBER).description("PLUS_TWO count")
+                )
+        ).handle(docsResult);
 
         mockMvc.perform(get("/api/users/me/growth/trend")
                         .header("Authorization", "Bearer " + accessToken)
@@ -426,6 +465,28 @@ class GrowthDocsTest extends RestDocsIntegrationTest {
         );
         entityManager.clear();
         return recordRepository.findById(record.getId()).orElseThrow();
+    }
+
+    private void createNumericTrendFixture(User user) {
+        LocalDate fromDate = LocalDate.of(2026, 7, 14);
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        for (int index = 0; index < 30; index++) {
+            saveRecord(
+                    user,
+                    10000 + index,
+                    Penalty.NONE,
+                    fromDate.plusDays(index).atStartOfDay(zoneId).toInstant()
+            );
+        }
+    }
+
+    private JsonNode pointForDate(JsonNode points, String date) {
+        for (JsonNode point : points) {
+            if (date.equals(point.path("date").asText())) {
+                return point;
+            }
+        }
+        throw new AssertionError("trend point가 없습니다: " + date);
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/backend/src/test/java/com/cubinghub/domain/growth/GrowthReadApiIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/GrowthReadApiIntegrationTest.java
@@ -1,0 +1,320 @@
+package com.cubinghub.domain.growth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cubinghub.domain.growth.dto.response.GrowthPbProgressionPageResponse;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.DailyAggregate;
+import com.cubinghub.domain.growth.service.GrowthReadService;
+import com.cubinghub.domain.record.dto.request.RecordPenaltyUpdateRequest;
+import com.cubinghub.domain.record.dto.request.RecordSaveRequest;
+import com.cubinghub.domain.record.dto.response.RecordCreateResponse;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.entity.Record;
+import com.cubinghub.domain.record.entity.UserPB;
+import com.cubinghub.domain.record.repository.RecordRepository;
+import com.cubinghub.domain.record.repository.UserPBRepository;
+import com.cubinghub.domain.record.service.RecordService;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.entity.UserRole;
+import com.cubinghub.domain.user.entity.UserStatus;
+import com.cubinghub.domain.user.repository.UserRepository;
+import com.cubinghub.integration.JpaIntegrationTest;
+import com.cubinghub.security.JwtTokenProvider;
+import com.cubinghub.support.TestFixtures;
+import jakarta.persistence.EntityManager;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@Import(GrowthReadApiIntegrationTest.FixedClockConfiguration.class)
+@DisplayName("Growth read API MySQL 통합 테스트")
+class GrowthReadApiIntegrationTest extends JpaIntegrationTest {
+
+    private static final Instant GENERATED_AT = Instant.parse("2026-08-11T15:01:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RecordRepository recordRepository;
+
+    @Autowired
+    private UserPBRepository userPBRepository;
+
+    @Autowired
+    private GrowthReadRepository growthReadRepository;
+
+    @Autowired
+    private GrowthReadService growthReadService;
+
+    @Autowired
+    private RecordService recordService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private User owner;
+    private String ownerToken;
+
+    @BeforeEach
+    void setUp() {
+        owner = saveUser("owner@cubinghub.com", "Owner");
+        ownerToken = TestFixtures.generateAccessToken(jwtTokenProvider, owner);
+    }
+
+    @Test
+    @DisplayName("summary는 owner의 empty history를 NO_DATA와 fixed activity response로 반환한다")
+    void should_return_no_data_summary_when_owner_has_no_records() throws Exception {
+        User otherUser = saveUser("other@cubinghub.com", "Other");
+        saveRecord(otherUser, 15000, Penalty.NONE, Instant.parse("2026-08-10T00:00:00Z"));
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.eventType").value("WCA_333"))
+                .andExpect(jsonPath("$.data.timeZone").value("Asia/Seoul"))
+                .andExpect(jsonPath("$.data.generatedAt").value("2026-08-11T15:01:00Z"))
+                .andExpect(jsonPath("$.data.asOfDate").value("2026-08-12"))
+                .andExpect(jsonPath("$.data.currentPb.status").value("NO_DATA"))
+                .andExpect(jsonPath("$.data.currentPb.recordId").value(nullValue()))
+                .andExpect(jsonPath("$.data.recentAo5.status").value("INSUFFICIENT_DATA"))
+                .andExpect(jsonPath("$.data.recentAo12.status").value("INSUFFICIENT_DATA"))
+                .andExpect(jsonPath("$.data.activity.totalSolveCount").value(0))
+                .andExpect(jsonPath("$.data.activity.firstRecordedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.scramble").doesNotExist())
+                .andExpect(jsonPath("$.data.inputMethod").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("trend는 30개의 KST date point에서 missing day와 DNF-only day를 구분한다")
+    void should_return_fixed_trend_points_when_days_are_missing_or_dnf_only() throws Exception {
+        saveRecord(owner, 10000, Penalty.NONE, Instant.parse("2026-08-09T15:30:00Z"));
+        saveRecord(owner, 12000, Penalty.DNF, Instant.parse("2026-08-10T15:30:00Z"));
+
+        mockMvc.perform(get("/api/users/me/growth/trend")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("period", "30D")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.period").value("30D"))
+                .andExpect(jsonPath("$.data.timeZone").value("Asia/Seoul"))
+                .andExpect(jsonPath("$.data.fromDate").value("2026-07-14"))
+                .andExpect(jsonPath("$.data.toDate").value("2026-08-12"))
+                .andExpect(jsonPath("$.data.todayPartial").value(true))
+                .andExpect(jsonPath("$.data.points.length()").value(30))
+                .andExpect(jsonPath("$.data.points[0].date").value("2026-07-14"))
+                .andExpect(jsonPath("$.data.points[0].recordCount").value(0))
+                .andExpect(jsonPath("$.data.points[0].medianTimeMs").value(nullValue()))
+                .andExpect(jsonPath("$.data.points[27].date").value("2026-08-10"))
+                .andExpect(jsonPath("$.data.points[27].recordCount").value(1))
+                .andExpect(jsonPath("$.data.points[27].medianTimeMs").value(10000))
+                .andExpect(jsonPath("$.data.points[28].date").value("2026-08-11"))
+                .andExpect(jsonPath("$.data.points[28].recordCount").value(1))
+                .andExpect(jsonPath("$.data.points[28].rankableCount").value(0))
+                .andExpect(jsonPath("$.data.points[28].medianTimeMs").value(nullValue()))
+                .andExpect(jsonPath("$.data.points[28].dnfCount").value(1));
+    }
+
+    @Test
+    @DisplayName("daily aggregate는 KST boundary와 PLUS_TWO effective median을 MySQL에서 계산한다")
+    void should_calculate_daily_median_with_kst_boundary_and_plus_two_in_mysql() {
+        saveRecord(owner, 9000, Penalty.NONE, Instant.parse("2026-08-10T14:59:59Z"));
+        saveRecord(owner, 10000, Penalty.NONE, Instant.parse("2026-08-10T15:00:00Z"));
+        saveRecord(owner, 9000, Penalty.PLUS_TWO, Instant.parse("2026-08-10T15:01:00Z"));
+        saveRecord(owner, 13000, Penalty.DNF, Instant.parse("2026-08-10T15:02:00Z"));
+
+        List<DailyAggregate> aggregates = growthReadRepository.findDailyAggregates(
+                owner.getId(),
+                EventType.WCA_333,
+                Instant.parse("2026-08-10T15:00:00Z"),
+                Instant.parse("2026-08-11T15:00:00Z")
+        );
+
+        assertThat(aggregates).containsExactly(new DailyAggregate(
+                java.time.LocalDate.parse("2026-08-11"),
+                3,
+                2,
+                10500,
+                1,
+                1
+        ));
+    }
+
+    @Test
+    @DisplayName("PB progression은 same timestamp id ordering과 tie를 current record state로 처리한다")
+    void should_return_descending_pb_points_when_records_share_timestamp_and_tie() {
+        Instant sameTimestamp = Instant.parse("2026-08-01T00:00:00Z");
+        Record first = saveRecord(owner, 24000, Penalty.NONE, sameTimestamp);
+        Record second = saveRecord(owner, 22000, Penalty.NONE, sameTimestamp);
+        saveRecord(owner, 22000, Penalty.NONE, sameTimestamp);
+        Record plusTwo = saveRecord(owner, 19000, Penalty.PLUS_TWO, sameTimestamp);
+        saveRecord(owner, 18000, Penalty.DNF, sameTimestamp);
+
+        GrowthReadRepository.PbProgressionPage result = growthReadRepository.findPbProgression(
+                owner.getId(),
+                EventType.WCA_333,
+                1,
+                50
+        );
+
+        assertThat(result.content())
+                .extracting(GrowthReadRepository.PbProgressionRecord::recordId)
+                .containsExactly(plusTwo.getId(), second.getId(), first.getId());
+        assertThat(result.content())
+                .extracting(GrowthReadRepository.PbProgressionRecord::effectiveTimeMs)
+                .containsExactly(21000, 22000, 24000);
+    }
+
+    @Test
+    @DisplayName("penalty PATCH와 delete 뒤 progression final point는 current user PB와 일치한다")
+    void should_recalculate_pb_progression_after_penalty_update_and_delete() {
+        RecordCreateResponse first = createRecord(20000, Penalty.NONE);
+        RecordCreateResponse second = createRecord(18000, Penalty.NONE);
+        RecordCreateResponse third = createRecord(19000, Penalty.NONE);
+        setRecordTimestamp(first.getId(), Instant.parse("2026-08-01T00:00:00Z"));
+        setRecordTimestamp(second.getId(), Instant.parse("2026-08-01T00:01:00Z"));
+        setRecordTimestamp(third.getId(), Instant.parse("2026-08-01T00:02:00Z"));
+
+        recordService.updateRecordPenalty(second.getId(), owner.getEmail(), new RecordPenaltyUpdateRequest(Penalty.DNF));
+        assertProgressionFinalPointMatchesCurrentPb(third.getId());
+
+        recordService.deleteRecord(third.getId(), owner.getEmail());
+        assertProgressionFinalPointMatchesCurrentPb(first.getId());
+    }
+
+    @Test
+    @DisplayName("known unsupported event와 invalid trend period는 400을 반환한다")
+    void should_return_bad_request_when_event_or_period_is_not_supported() throws Exception {
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .param("eventType", EventType.WCA_222.name()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Practice 종목입니다."));
+
+        mockMvc.perform(get("/api/users/me/growth/trend")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .param("period", "90D"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("지원하지 않는 Growth 기간입니다."));
+    }
+
+    @Test
+    @DisplayName("Growth endpoint는 인증되지 않은 요청을 current 401 contract로 거절한다")
+    void should_return_unauthorized_when_growth_request_has_no_access_token() throws Exception {
+        mockMvc.perform(get("/api/users/me/growth")
+                        .param("eventType", EventType.WCA_333.name()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    private User saveUser(String email, String nickname) {
+        return userRepository.save(User.builder()
+                .email(email)
+                .password("password")
+                .nickname(nickname)
+                .role(UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .mainEvent("WCA_333")
+                .build());
+    }
+
+    private Record saveRecord(User user, int timeMs, Penalty penalty, Instant createdAt) {
+        User managedUser = userRepository.findById(user.getId()).orElseThrow();
+        Record record = recordRepository.saveAndFlush(Record.builder()
+                .user(managedUser)
+                .eventType(EventType.WCA_333)
+                .timeMs(timeMs)
+                .penalty(penalty)
+                .scramble("growth-test-scramble")
+                .build());
+        setRecordTimestamp(record.getId(), createdAt);
+        return recordRepository.findById(record.getId()).orElseThrow();
+    }
+
+    private RecordCreateResponse createRecord(int timeMs, Penalty penalty) {
+        return recordService.createRecord(
+                owner.getEmail(),
+                RecordSaveRequest.builder()
+                        .eventType(EventType.WCA_333)
+                        .timeMs(timeMs)
+                        .penalty(penalty)
+                        .scramble("growth-mutation-scramble")
+                        .build(),
+                null,
+                null
+        );
+    }
+
+    private void setRecordTimestamp(Long recordId, Instant createdAt) {
+        recordRepository.flush();
+        jdbcTemplate.update(
+                "UPDATE records SET created_at = ?, updated_at = ? WHERE id = ?",
+                Timestamp.from(createdAt),
+                Timestamp.from(createdAt),
+                recordId
+        );
+        entityManager.clear();
+    }
+
+    private void assertProgressionFinalPointMatchesCurrentPb(Long expectedRecordId) {
+        GrowthPbProgressionPageResponse progression = growthReadService.getPbProgression(
+                owner.getEmail(),
+                EventType.WCA_333,
+                1,
+                50
+        );
+        User managedOwner = userRepository.findById(owner.getId()).orElseThrow();
+        UserPB currentPb = userPBRepository.findByUserAndEventType(managedOwner, EventType.WCA_333).orElseThrow();
+
+        assertThat(currentPb.getRecord().getId()).isEqualTo(expectedRecordId);
+        assertThat(progression.content()).isNotEmpty();
+        assertThat(progression.content().get(0).recordId()).isEqualTo(currentPb.getRecord().getId());
+        assertThat(progression.content().get(0).effectiveTimeMs()).isEqualTo(currentPb.getBestTimeMs());
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class FixedClockConfiguration {
+
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(GENERATED_AT, ZoneOffset.UTC);
+        }
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
@@ -1,0 +1,127 @@
+package com.cubinghub.domain.growth.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.entity.UserRole;
+import com.cubinghub.domain.user.entity.UserStatus;
+import com.cubinghub.domain.user.repository.UserRepository;
+import com.cubinghub.integration.JpaIntegrationTest;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@DisplayName("Growth query plan MySQL 통합 테스트")
+class GrowthQueryPlanIntegrationTest extends JpaIntegrationTest {
+
+    private static final Instant TREND_FROM = Instant.parse("2026-07-13T15:00:00Z");
+    private static final Instant TREND_TO = Instant.parse("2026-08-12T15:00:00Z");
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GrowthReadRepository growthReadRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Test
+    @DisplayName("10,000-record user/event fixture에서 recent, trend, progression query를 EXPLAIN ANALYZE로 실행한다")
+    void should_execute_growth_queries_with_mysql_explain_analyze_for_ten_thousand_records() {
+        User user = userRepository.save(User.builder()
+                .email("growth-plan@cubinghub.com")
+                .password("password")
+                .nickname("GrowthPlan")
+                .role(UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .mainEvent("WCA_333")
+                .build());
+        insertTenThousandRecords(user.getId());
+        jdbcTemplate.execute("ANALYZE TABLE records");
+
+        MapSqlParameterSource latestParameters = new MapSqlParameterSource(Map.of(
+                "userId", user.getId(),
+                "eventType", EventType.WCA_333.name(),
+                "limit", 24
+        ));
+        MapSqlParameterSource trendParameters = new MapSqlParameterSource()
+                .addValue("userId", user.getId())
+                .addValue("eventType", EventType.WCA_333.name())
+                .addValue("fromUtc", Timestamp.from(TREND_FROM))
+                .addValue("toUtc", Timestamp.from(TREND_TO));
+        MapSqlParameterSource progressionParameters = new MapSqlParameterSource(Map.of(
+                "userId", user.getId(),
+                "eventType", EventType.WCA_333.name(),
+                "limit", 50,
+                "offset", 0L
+        ));
+
+        List<String> latestPlan = explainAnalyze(GrowthReadRepository.LATEST_RECORDS_QUERY, latestParameters);
+        List<String> trendPlan = explainAnalyze(GrowthReadRepository.DAILY_AGGREGATE_QUERY, trendParameters);
+        List<String> progressionPlan = explainAnalyze(
+                GrowthReadRepository.PB_PROGRESSION_POINTS_QUERY,
+                progressionParameters
+        );
+
+        assertThat(String.join("\n", latestPlan)).contains("idx_record_user_event_created_at_id");
+        assertThat(String.join("\n", progressionPlan)).contains("idx_record_user_event_created_at_id");
+        assertThat(trendPlan).isNotEmpty();
+        assertThat(growthReadRepository.findRecentRecords(user.getId(), EventType.WCA_333, 24)).hasSize(24);
+        assertThat(growthReadRepository.findDailyAggregates(
+                user.getId(),
+                EventType.WCA_333,
+                TREND_FROM,
+                TREND_TO
+        )).isNotEmpty();
+        assertThat(growthReadRepository.findPbProgression(user.getId(), EventType.WCA_333, 1, 50).content())
+                .isNotEmpty()
+                .hasSizeLessThanOrEqualTo(50);
+    }
+
+    private void insertTenThousandRecords(Long userId) {
+        jdbcTemplate.execute("SET SESSION cte_max_recursion_depth = 10000");
+        jdbcTemplate.update("""
+                INSERT INTO records (
+                    user_id, event_type, time_ms, penalty, scramble, created_at, updated_at
+                )
+                WITH RECURSIVE sequence_number (value) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT value + 1 FROM sequence_number WHERE value < 10000
+                )
+                SELECT
+                    ?,
+                    'WCA_333',
+                    10000 + MOD(value, 3000),
+                    CASE
+                        WHEN MOD(value, 17) = 0 THEN 'DNF'
+                        WHEN MOD(value, 11) = 0 THEN 'PLUS_TWO'
+                        ELSE 'NONE'
+                    END,
+                    'growth-query-plan-fixture',
+                    TIMESTAMPADD(MINUTE, value, '2026-08-01 00:00:00'),
+                    TIMESTAMPADD(MINUTE, value, '2026-08-01 00:00:00')
+                FROM sequence_number
+                """, userId);
+    }
+
+    private List<String> explainAnalyze(String query, MapSqlParameterSource parameters) {
+        return namedParameterJdbcTemplate.query(
+                "EXPLAIN ANALYZE " + query,
+                parameters,
+                (resultSet, rowNumber) -> resultSet.getString(1)
+        );
+    }
+}

--- a/backend/src/test/java/com/cubinghub/domain/growth/service/GrowthReadServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/service/GrowthReadServiceTest.java
@@ -1,0 +1,120 @@
+package com.cubinghub.domain.growth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.cubinghub.common.exception.CustomApiException;
+import com.cubinghub.domain.growth.dto.response.GrowthSummaryResponse;
+import com.cubinghub.domain.growth.metric.GrowthRecord;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.ActivitySummary;
+import com.cubinghub.domain.growth.repository.GrowthReadRepository.CurrentPb;
+import com.cubinghub.domain.record.entity.EventType;
+import com.cubinghub.domain.record.entity.Penalty;
+import com.cubinghub.domain.record.policy.PracticeEventCapabilities;
+import com.cubinghub.domain.user.entity.User;
+import com.cubinghub.domain.user.entity.UserRole;
+import com.cubinghub.domain.user.entity.UserStatus;
+import com.cubinghub.domain.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GrowthReadService 단위 테스트")
+class GrowthReadServiceTest {
+
+    private static final Instant GENERATED_AT = Instant.parse("2026-08-11T15:01:00Z");
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GrowthReadRepository growthReadRepository;
+
+    @Mock
+    private PracticeEventCapabilities eventCapabilities;
+
+    @Mock
+    private Clock clock;
+
+    private GrowthReadService growthReadService;
+
+    @BeforeEach
+    void setUp() {
+        growthReadService = new GrowthReadService(
+                userRepository,
+                growthReadRepository,
+                eventCapabilities,
+                clock
+        );
+    }
+
+    @Test
+    @DisplayName("summary는 한 Clock snapshot으로 모든 metric 기준 시각을 고정한다")
+    void should_use_one_clock_snapshot_when_building_growth_summary() {
+        User user = User.builder()
+                .email("growth@test.com")
+                .password("password")
+                .nickname("Growth")
+                .role(UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .mainEvent("WCA_333")
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(user, "id", 1L);
+
+        List<GrowthRecord> records = List.of(
+                new GrowthRecord(1L, 20000, Penalty.NONE, Instant.parse("2026-08-10T00:00:00Z"))
+        );
+        when(userRepository.findByEmail("growth@test.com")).thenReturn(Optional.of(user));
+        when(clock.instant()).thenReturn(GENERATED_AT);
+        when(growthReadRepository.findRecentRecords(1L, EventType.WCA_333, 24)).thenReturn(records);
+        when(growthReadRepository.findRecordsInRange(any(), any(), any(), any())).thenReturn(records);
+        when(growthReadRepository.findActivitySummary(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new ActivitySummary(1L, 1L, 0L, 1L, 1, records.get(0).createdAt(), records.get(0).createdAt()));
+        when(growthReadRepository.findCurrentPb(1L, EventType.WCA_333))
+                .thenReturn(Optional.of(new CurrentPb(
+                        1L,
+                        20000,
+                        Penalty.NONE,
+                        20000,
+                        records.get(0).createdAt()
+                )));
+
+        GrowthSummaryResponse response = growthReadService.getSummary("growth@test.com", EventType.WCA_333);
+
+        assertThat(response.generatedAt()).isEqualTo(GENERATED_AT);
+        assertThat(response.asOfDate()).hasToString("2026-08-12");
+        assertThat(response.currentPb().recordId()).isEqualTo(1L);
+        verify(clock, times(1)).instant();
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 event는 user 또는 Growth repository 조회 전에 거절한다")
+    void should_reject_unsupported_event_before_reading_user_or_growth_data() {
+        doThrow(new CustomApiException(
+                PracticeEventCapabilities.UNSUPPORTED_EVENT_MESSAGE,
+                HttpStatus.BAD_REQUEST
+        )).when(eventCapabilities).requirePracticeRecordSupported(EventType.WCA_222);
+
+        assertThatThrownBy(() -> growthReadService.getSummary("growth@test.com", EventType.WCA_222))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage(PracticeEventCapabilities.UNSUPPORTED_EVENT_MESSAGE);
+
+        verifyNoInteractions(userRepository, growthReadRepository, clock);
+    }
+}

--- a/docs/01-domain/growth-metrics.md
+++ b/docs/01-domain/growth-metrics.md
@@ -17,18 +17,17 @@ related:
 
 ## 문서 상태
 
-V2.2 `MUST` metric formula와 edge case는 active contract다. PR A의 pure calculator는 이 문서의 effective result, Ao, median, period comparison, IQR, PB progression, timezone 규칙을 구현한다.
+V2.2 `MUST` metric formula와 edge case는 active contract다. PR A의 pure calculator와 PR B의 private Growth read API는 이 문서의 effective result, Ao, median, period comparison, IQR, PB progression, timezone 규칙을 구현한다.
 
-Read API, MySQL aggregate/window query, My Growth UI와 release는 아직 구현하지 않았다. `SHOULD`, `NOT NOW`, future candidate는 implementation commitment가 아니다.
+My Growth UI와 release는 아직 구현하지 않았다. `SHOULD`, `NOT NOW`, future candidate는 implementation commitment가 아니다.
 
 ```text
 Current
 - V2.1 Record, current PB projection, event history, Timer Ao5/Ao12
 - Growth pure calculator와 canonical unit fixture
+- private Growth summary, 30-day trend, paginated PB progression API
 
 Next implementation
-- event별 private My Growth read API
-- current canonical Record 기준 aggregate query
 - My Growth dashboard
 
 Future candidate

--- a/docs/02-requirements/features/growth.md
+++ b/docs/02-requirements/features/growth.md
@@ -19,7 +19,7 @@ related:
 
 ## 문서 상태
 
-V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. metric formula와 pure calculator는 PR A에서 구현했지만, read API와 My Growth UI는 아직 application contract나 출시 약속이 아니다.
+V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. metric formula, pure calculator와 private Growth read API는 구현했지만, My Growth UI와 release는 아직 application contract나 출시 약속이 아니다.
 
 ```text
 Current
@@ -27,10 +27,10 @@ Current
 - private MyPage의 전체 요약, 최근 raw Record chart, history 관리
 - Ranking의 nickname과 event PB
 - current Record projection을 계산하는 Growth metric calculator
+- event별 private Growth summary, 30-day trend, paginated PB progression API
 
 Next implementation
 - private My Growth dashboard
-- event별 canonical Growth metric과 bounded aggregate API
 - next Practice로 돌아가는 명확한 action
 
 Future candidate

--- a/docs/03-architecture/growth-architecture.md
+++ b/docs/03-architecture/growth-architecture.md
@@ -22,7 +22,7 @@ related:
 
 ## 문서 상태와 경계
 
-V2.2 Growth & Profile architecture는 `draft`다. pure metric calculator 외 endpoint, repository projection, SQL, schema는 아직 구현하지 않았다. exact request·response는 구현 시 Spring REST Docs test가 Source of Truth가 된다.
+V2.2 Growth & Profile architecture는 `draft`다. pure metric calculator와 private Growth read API, repository projection, MySQL query는 구현했다. My Growth UI와 release는 아직 구현하지 않았다. exact request·response는 Spring REST Docs test가 Source of Truth다.
 
 ```text
 Current
@@ -31,13 +31,12 @@ Current
 - WCA_333 event-filtered history와 stable ordering
 - Timer client의 recent Ao5/Ao12
 - current Record projection을 받는 pure Growth metric calculator
+- private Growth summary, 30-day trend, paginated PB progression API
+- lightweight Record projection, MySQL daily median and PB progression query
 - Redis ranking read model
 
 Next implementation
-- private server-side Growth read API
-- bounded summary와 30-day series
-- current Record 기반 paginated PB progression
-- MySQL request-time aggregate, no migration, no Growth Redis
+- My Growth dashboard와 Record mutation 뒤 refresh
 
 Future candidate
 - observed cost에 근거한 PB progression cache/projection
@@ -45,7 +44,7 @@ Future candidate
 - opt-in public Profile read contract
 
 Out of scope
-- application implementation, Flyway, Redis key, analytics platform
+- Flyway, Redis key, analytics platform
 - Challenge, Verification, Competition lifecycle 통합
 ```
 
@@ -110,9 +109,9 @@ DNF      -> numeric result 없음
 | B. 하나의 Growth aggregate endpoint | client 단순, 한 번의 request | 30-day series와 full PB history가 initial payload/query lifecycle을 결합 | 채택하지 않음 |
 | C. summary + trend + PB progression 분리 | initial payload bounded, query 성격·refresh·evolution 분리 | endpoint 3개와 server calculator 필요 | **V2.2 proposal** |
 
-## API proposal
+## Current API
 
-모든 endpoint는 authenticated owner 전용이다. query의 `eventType`은 required로 두고 현재 `WCA_333`만 허용한다. known but unsupported EventType은 current Practice capability 정책과 같은 400 error를 반환한다.
+모든 endpoint는 authenticated owner 전용이다. query의 `eventType`은 required이며 현재 `WCA_333`만 허용한다. known but unsupported EventType은 current Practice capability 정책과 같은 400 error를 반환한다. exact request·response field는 [Spring REST Docs](../../backend/src/docs/asciidoc/index.adoc)가 기준이다.
 
 | Endpoint | 역할 | Payload boundary | Refresh trigger |
 | --- | --- | --- | --- |
@@ -122,181 +121,19 @@ DNF      -> numeric result 없음
 
 V2.2에서 `period`는 `30D`만 지원한다. future 90-day 조회 가능성을 위해 dimension을 유지하되, 지원하지 않는 값에 빈 배열을 반환하지 않고 400으로 거절한다.
 
-### Summary response proposal
+### Summary
 
-JSON은 V2.2 proposal이며 generated REST Docs가 아니다.
+Summary는 `user_pbs` current PB와 latest 24, completed 14-day, activity aggregate projection을 조합한다. `AVAILABLE`, `DNF`, `NO_DATA`, `INSUFFICIENT_DATA`, `INSUFFICIENT_SAMPLE`을 명시적으로 구분한다. 적용되지 않는 numeric field는 `null`일 수 있지만 status 없이 해석하지 않는다.
 
-```json
-{
-  "status": 200,
-  "message": "성장 요약 조회 성공",
-  "data": {
-    "eventType": "WCA_333",
-    "timeZone": "Asia/Seoul",
-    "generatedAt": "2026-08-11T03:15:20.123Z",
-    "asOfDate": "2026-08-11",
-    "currentPb": {
-      "status": "AVAILABLE",
-      "recordId": 438,
-      "timeMs": 17780,
-      "penalty": "PLUS_TWO",
-      "effectiveTimeMs": 19780,
-      "createdAt": "2026-08-09T11:02:14.000Z"
-    },
-    "recentAo5": {
-      "status": "AVAILABLE",
-      "windowSize": 5,
-      "recordCount": 5,
-      "valueMs": 20412
-    },
-    "recentAo12": {
-      "status": "AVAILABLE",
-      "windowSize": 12,
-      "recordCount": 12,
-      "valueMs": 20965
-    },
-    "performanceComparison": {
-      "status": "AVAILABLE",
-      "recentPeriod": {
-        "fromDate": "2026-08-04",
-        "toDateExclusive": "2026-08-11",
-        "medianTimeMs": 20100,
-        "recordCount": 25,
-        "rankableCount": 24,
-        "activeDays": 4,
-        "dnfCount": 1,
-        "plusTwoCount": 1
-      },
-      "previousPeriod": {
-        "fromDate": "2026-07-28",
-        "toDateExclusive": "2026-08-04",
-        "medianTimeMs": 21350,
-        "recordCount": 18,
-        "rankableCount": 18,
-        "activeDays": 3,
-        "dnfCount": 0,
-        "plusTwoCount": 2
-      },
-      "direction": "FASTER",
-      "improvementPercent": 5.9
-    },
-    "consistency": {
-      "status": "AVAILABLE",
-      "current": {
-        "windowSize": 12,
-        "recordCount": 12,
-        "rankableCount": 11,
-        "iqrMs": 1820,
-        "dnfCount": 1,
-        "dnfRatePercent": 8.3,
-        "plusTwoCount": 1,
-        "plusTwoRatePercent": 8.3
-      },
-      "previous": {
-        "windowSize": 12,
-        "recordCount": 12,
-        "rankableCount": 12,
-        "iqrMs": 2250,
-        "dnfCount": 0,
-        "dnfRatePercent": 0.0,
-        "plusTwoCount": 1,
-        "plusTwoRatePercent": 8.3
-      },
-      "direction": "NARROWER",
-      "differenceMs": 430
-    },
-    "activity": {
-      "totalSolveCount": 438,
-      "last7DaysSolveCount": 42,
-      "previous7DaysSolveCount": 31,
-      "last30DaysSolveCount": 126,
-      "activeDaysLast30Days": 12,
-      "firstRecordedAt": "2026-04-22T09:12:00.000Z",
-      "latestRecordedAt": "2026-08-11T03:10:00.000Z"
-    }
-  }
-}
-```
+`currentPb.timeMs`는 raw value, `effectiveTimeMs`는 penalty 반영 value다. PB가 없으면 `status=NO_DATA`이고 Record 관련 field는 null이다.
 
-`AVAILABLE`, `DNF`, `NO_DATA`, `INSUFFICIENT_DATA`, `INSUFFICIENT_SAMPLE`을 명시적으로 구분한다. 적용되지 않는 numeric field는 `null`이 될 수 있지만 status 없이 `null`만 해석하게 만들지 않는다.
+### Trend
 
-`currentPb.timeMs`는 raw value, `effectiveTimeMs`는 penalty 반영 value다. Current PB가 없으면 `status=NO_DATA`이고 Record 관련 field는 null이다.
+Trend는 `asOfDate` 기준 30개의 Asia/Seoul date point를 반환한다. DB query가 반환하지 않은 date는 application이 채운다. missing day는 `recordCount=0`, `medianTimeMs=null`이고 DNF-only day는 `recordCount>0`, `rankableCount=0`, `medianTimeMs=null`이다. 오늘 point는 `todayPartial=true`로 표시한다.
 
-### Trend response proposal
+### PB progression
 
-```json
-{
-  "status": 200,
-  "message": "성장 추세 조회 성공",
-  "data": {
-    "eventType": "WCA_333",
-    "period": "30D",
-    "timeZone": "Asia/Seoul",
-    "generatedAt": "2026-08-11T03:15:20.123Z",
-    "fromDate": "2026-07-13",
-    "toDate": "2026-08-11",
-    "todayPartial": true,
-    "points": [
-      {
-        "date": "2026-07-13",
-        "recordCount": 0,
-        "rankableCount": 0,
-        "medianTimeMs": null,
-        "dnfCount": 0,
-        "plusTwoCount": 0
-      },
-      {
-        "date": "2026-07-14",
-        "recordCount": 7,
-        "rankableCount": 6,
-        "medianTimeMs": 22345,
-        "dnfCount": 1,
-        "plusTwoCount": 1
-      }
-    ]
-  }
-}
-```
-
-DB query가 반환하지 않은 date는 application이 요청 `asOfDate` 기준으로 채운다. missing day는 `recordCount=0`, `medianTimeMs=null`이다. DNF-only day는 `recordCount>0`, `rankableCount=0`, `medianTimeMs=null`로 구분한다.
-
-### PB progression response proposal
-
-```json
-{
-  "status": 200,
-  "message": "PB progression 조회 성공",
-  "data": {
-    "eventType": "WCA_333",
-    "basis": "CURRENT_RECORD_STATE",
-    "timeZone": "Asia/Seoul",
-    "content": [
-      {
-        "recordId": 438,
-        "timeMs": 17780,
-        "penalty": "PLUS_TWO",
-        "effectiveTimeMs": 19780,
-        "createdAt": "2026-08-09T11:02:14.000Z"
-      },
-      {
-        "recordId": 301,
-        "timeMs": 20150,
-        "penalty": "NONE",
-        "effectiveTimeMs": 20150,
-        "createdAt": "2026-06-18T02:20:10.000Z"
-      }
-    ],
-    "page": 1,
-    "size": 50,
-    "totalElements": 4,
-    "totalPages": 1,
-    "hasNext": false,
-    "hasPrevious": false
-  }
-}
-```
-
-Progression content는 current PB부터 과거로 가는 `created_at DESC, id DESC` milestone order다. UI는 받은 page를 chronological order로 바꿔 step chart를 그리며, 다음 page를 명시적으로 더 불러올 수 있다. Page boundary는 pathological하게 모든 solve가 PB인 경우에도 O(N) client transfer를 막는다. DB는 current canonical progression을 판별하기 위해 여전히 전체 user/event history를 볼 수 있으므로 100,000-record gate에서 별도 측정한다.
+Progression content는 current PB부터 과거로 가는 `created_at DESC, id DESC` milestone order다. `basis=CURRENT_RECORD_STATE`는 penalty PATCH와 Record delete 뒤 current canonical state에서 다시 계산된 결과임을 뜻한다. page boundary는 모든 solve가 PB인 경우에도 client transfer를 제한한다. DB는 current progression을 판별하기 위해 user/event history를 모두 읽을 수 있으므로 100,000-record stress는 별도 gate로 둔다.
 
 ### Error와 cache boundary
 
@@ -315,7 +152,7 @@ Progression content는 current PB부터 과거로 가는 `created_at DESC, id DE
 GrowthController
   -> authentication + query validation + response envelope
 
-GrowthService (@Transactional(readOnly = true))
+GrowthReadService (@Transactional(readOnly = true))
   -> one asOf clock/date 결정
   -> capability 검증
   -> repository projection 조합
@@ -324,8 +161,9 @@ GrowthService (@Transactional(readOnly = true))
 GrowthMetricCalculator
   -> effective result, Ao5/Ao12, median, percentile, improvement status
 
-RecordRepository / UserPBRepository
-  -> bounded recent rows, counts/ranges, daily aggregate, progression projection
+GrowthReadRepository
+  -> bounded Record projection, current PB projection, activity aggregate,
+     daily aggregate, progression projection
 ```
 
 - 기존 Timer frontend utility의 Ao fixture를 backend calculator test로 이식해 두 계산이 같은 규칙을 사용하게 한다.
@@ -368,7 +206,7 @@ WHERE 절에는 `created_at` function을 두지 않는다. Application이 KST ca
 | Recent Ao/IQR | user/event recent order `LIMIT 24` | application pure calculator | DNF trim·percentile status를 test하기 쉽고 bounded |
 | total/first/latest | user/event count, min, max | SQL aggregate 또는 index endpoint query | entity 전체 load 불필요 |
 | 7/14/30-day counts | raw UTC range conditional aggregate | SQL | bounded range, payload 없음 |
-| period median | 두 7-day range의 rankable row/window median | MySQL 8 native projection | unbounded entity list보다 명확한 DB aggregate |
+| period median | 두 7-day range의 lightweight Record projection | application pure calculator | PR A period status와 median contract를 그대로 사용 |
 | daily median/count | 30-day range daily aggregate + rankable median | MySQL 8 native projection | 최대 30 row response |
 | PB progression | running previous minimum window query | MySQL 8 native projection | 전체 Record를 application/client로 전달하지 않고 point만 반환 |
 
@@ -400,7 +238,7 @@ WITH ranged AS (
       WHEN 'PLUS_TWO' THEN time_ms + 2000
       WHEN 'DNF' THEN NULL
     END AS effective_time_ms
-  FROM records
+  FROM records FORCE INDEX (idx_record_user_event_created_at_id)
   WHERE user_id = :userId
     AND event_type = :eventType
     AND created_at >= :fromUtc
@@ -444,19 +282,27 @@ WITH canonical AS (
       WHEN 'NONE' THEN time_ms
       WHEN 'PLUS_TWO' THEN time_ms + 2000
     END AS effective_time_ms
-  FROM records
+  FROM records FORCE INDEX (idx_record_user_event_created_at_id)
   WHERE user_id = :userId
     AND event_type = :eventType
     AND penalty <> 'DNF'
 ),
-scanned AS (
+running AS (
   SELECT
     canonical.*,
     MIN(effective_time_ms) OVER (
       ORDER BY created_at, id
-      ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-    ) AS previous_best_time_ms
+      ROWS UNBOUNDED PRECEDING
+    ) AS running_best_time_ms
   FROM canonical
+),
+scanned AS (
+  SELECT
+    running.*,
+    LAG(running_best_time_ms) OVER (
+      ORDER BY created_at, id
+    ) AS previous_best_time_ms
+  FROM running
 )
 SELECT id, time_ms, penalty, effective_time_ms, created_at
 FROM scanned
@@ -469,11 +315,11 @@ Penalty PATCH 또는 delete 뒤 이 query를 다시 실행하면 current canonic
 
 ### Repository 기술 선택
 
-현재 repository의 단순 동적 조건은 Querydsl custom repository가 담당하고, Ranking의 `ROW_NUMBER()`처럼 DB window 기능이 필요한 부분은 native query를 사용한다. V2.2도 같은 스타일을 따른다.
+현재 repository의 단순 동적 조건은 Querydsl custom repository가 담당하고, Ranking의 `ROW_NUMBER()`처럼 DB window 기능이 필요한 부분은 native query를 사용한다. V2.2는 query-specific `GrowthReadRepository`에서 MySQL native lightweight projection을 사용한다. Growth Record query는 event-filtered history index `idx_record_user_event_created_at_id`를 `FORCE INDEX`로 지정한다. 같은 user의 legacy 또는 future event row가 섞여도 user/event range와 ordering을 같은 index에서 처리한다.
 
-- recent 24: Spring Data/Querydsl lightweight projection + page limit
-- count/min/max와 simple range count: Querydsl aggregate projection
-- daily/period median과 PB progression: MySQL 8 native query + interface/record projection
+- recent 24와 completed comparison range: native lightweight Record projection
+- current PB와 count/min/max activity: native projection/aggregate
+- daily median과 PB progression: MySQL 8 native window query
 - metric policy: repository SQL에 흩뿌리지 않고 pure Java calculator와 domain fixture로 검증
 - entity list 전체 반환 또는 frontend raw history aggregate: 사용하지 않음
 
@@ -604,10 +450,11 @@ Build와 CI success는 production request 성공을 뜻하지 않는다. main me
 
 ### PR B — Growth read API와 query
 
+- status: implemented
 - scope: summary/trend/progression controller, service, projection, native query, REST Docs
 - dependency: PR A
 - acceptance: private WCA_333 contract, bounded payload, progression parity, no migration/Redis
-- tests: service/repository MySQL integration, REST Docs, query-plan evidence
+- tests: service/repository MySQL integration, REST Docs, [10,000-record query-plan evidence](../06-quality/performance/growth-read-api-10k.md)
 - rollback risk: additive GET endpoint 제거. DB rollback 없음
 
 ### PR C — My Growth dashboard

--- a/docs/06-quality/performance/README.md
+++ b/docs/06-quality/performance/README.md
@@ -9,6 +9,7 @@ tags: []
 related:
   - docs/06-quality/performance/ranking-baseline.md
   - docs/06-quality/performance/mypage-baseline.md
+  - docs/06-quality/performance/growth-read-api-10k.md
 ---
 # Performance Evidence
 
@@ -18,6 +19,7 @@ related:
 
 - [Ranking baseline](ranking-baseline.md): 2026-04-20~21 MySQL V1과 Redis V2 비교
 - [MyPage baseline](mypage-baseline.md): 2026-04-22 사용자당 10,000 records 비교
+- [Growth read API 10k query plan](growth-read-api-10k.md): MySQL 8 `EXPLAIN ANALYZE` snapshot
 - [Legacy benchmark runbook](benchmarks/legacy-runbook.md): 당시 실행 절차 원문
 
 raw JSON, generated Markdown·HTML, Grafana screenshot은 benchmarks와 docs/assets/screenshots/performance에 보존한다.

--- a/docs/06-quality/performance/growth-read-api-10k.md
+++ b/docs/06-quality/performance/growth-read-api-10k.md
@@ -1,0 +1,39 @@
+---
+doc_type: quality
+status: active
+created: 2026-08-12
+updated: 2026-08-12
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/03-architecture/growth-architecture.md
+  - docs/06-quality/performance/README.md
+  - backend/src/main/java/com/cubinghub/domain/growth/repository/GrowthReadRepository.java
+  - backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
+---
+# Growth Read API Query Plan Evidence (10k)
+
+## Fixture
+
+격리된 MySQL 8.0.46 container에서 WCA_333 한 user/event의 `records` 10,000건을 만들고 `ANALYZE TABLE records`를 실행했다. Growth query는 V3 `idx_record_user_event_created_at_id (user_id, event_type, created_at, id)`를 `FORCE INDEX`로 사용했다. production data, schema, index는 사용하지 않았다.
+
+`GrowthQueryPlanIntegrationTest`는 같은 MySQL 8 query를 CI에서 다시 실행한다. 아래 숫자는 local snapshot이며 production latency나 capacity를 뜻하지 않는다.
+
+## EXPLAIN ANALYZE
+
+| Query | Chosen access | Rows examined | Returned rows | Execution time |
+| --- | --- | ---: | ---: | ---: |
+| latest 24 Record | `idx_record_user_event_created_at_id` reverse index lookup | 24 | 24 | 0.701–0.706ms |
+| 30-day daily trend | `idx_record_user_event_created_at_id` range scan, 9,412 rankable rows in median window | 10,000 | 8 date aggregate rows | 27.0ms |
+| PB progression | `idx_record_user_event_created_at_id` lookup, 9,412 rankable rows materialized | 10,000 | 2 PB points | 25.1ms |
+
+Daily trend는 10,000-row range에서 daily count와 rankable median을 함께 계산한다. 10,000-row snapshot에서 27.0ms로 끝나며 새 covering index나 generated effective column을 추가할 근거는 없다.
+
+PB progression은 inclusive running minimum 뒤 `LAG`로 이전 minimum을 비교한다. 10,000-row snapshot은 25.1ms로 끝났다. tie와 strict improvement semantics는 unchanged다.
+
+## 범위
+
+- latest, trend, progression은 모두 current retained Record만 읽는다.
+- response는 latest 24, fixed 30 points, progression page 50으로 각각 제한한다.
+- 100,000-record progression stress와 production request latency는 이 snapshot의 범위가 아니다.

--- a/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
+++ b/docs/08-decisions/adr-0010-current-record-growth-read-contract.md
@@ -77,9 +77,9 @@ Option C를 V2.2 Growth read contract로 채택한다.
 
 ## Implementation status
 
-PR A는 current Record projection을 입력으로 받는 pure metric calculator와 canonical fixture를 구현한다. effective result, Ao5/Ao12, median, period comparison, IQR, PB progression과 Asia/Seoul time window는 해당 calculator가 기준이다.
+PR A는 current Record projection을 입력으로 받는 pure metric calculator와 canonical fixture를 구현했다. effective result, Ao5/Ao12, median, period comparison, IQR, PB progression과 Asia/Seoul time window는 해당 calculator가 기준이다.
 
-Dedicated read API, repository projection, MySQL 8 aggregate/window query와 My Growth frontend는 후속 PR에서 구현한다. 이 ADR의 accepted status는 API와 UI의 구현 완료를 뜻하지 않는다.
+PR B는 dedicated private read API, lightweight repository projection, MySQL 8 daily aggregate/window query와 REST Docs를 구현했다. My Growth frontend는 후속 PR 범위다. 이 ADR의 accepted status는 UI와 release의 구현 완료를 뜻하지 않는다.
 
 ## Consequences
 


### PR DESCRIPTION
## Goal

Add private, bounded Growth read APIs on top of the accepted calculator and current MySQL Record/PB projections.

## Endpoints

- `GET /api/users/me/growth`
- `GET /api/users/me/growth/trend?period=30D`
- `GET /api/users/me/growth/pb-progression`

## Query strategy

Use lightweight Record projections, `user_pbs`, MySQL 8 window queries, and the existing event-filtered history index. No schema, Redis, or cache is added.

## Contract

Owner-only WCA_333 access, Asia/Seoul calendar boundaries, explicit metric statuses, fixed 30-point trend, and current-record-state PB progression.

## MySQL evidence

Record 10k `EXPLAIN ANALYZE` evidence covers latest rows, daily trend, and PB progression.

## REST Docs

Summary, trend, progression, error, empty, insufficient, DNF, and pagination snippets are included.

## Tests

- Growth calculator and read-service regression
- MySQL repository/controller integration and REST Docs tests
- 10k query-plan integration test

## Out of scope

My Growth frontend, UI redesign, Flyway/index changes, Redis/cache, public Profile, and future V2.2 work.

## Rollback

Remove the additive GET endpoints and Growth read classes. No database rollback is required.