### PR TITLE
chore: upgrade MySQL to 8.4 LTS

### DIFF
--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 90
     services:
       mysql:
-        image: mysql:8.0.46
+        image: mysql:8.4.11
         env:
           MYSQL_ROOT_PASSWORD: benchmark-pass
           MYSQL_DATABASE: cubing_hub

--- a/backend/src/test/java/com/cubinghub/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/cubinghub/TestcontainersConfiguration.java
@@ -13,7 +13,11 @@ public class TestcontainersConfiguration {
 	@Bean
 	@ServiceConnection
 	MySQLContainer<?> mysqlContainer() {
-		return new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
+		return new MySQLContainer<>(DockerImageName.parse("mysql:8.4.11"))
+				.withCommand(
+						"--character-set-server=utf8mb4",
+						"--collation-server=utf8mb4_0900_ai_ci"
+				);
 	}
 
 	@Bean

--- a/backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
@@ -40,6 +40,8 @@ class GrowthQueryPlanIntegrationTest extends JpaIntegrationTest {
     @Test
     @DisplayName("10,000-record user/event fixture에서 recent, trend, progression query를 EXPLAIN ANALYZE로 실행한다")
     void should_execute_growth_queries_with_mysql_explain_analyze_for_ten_thousand_records() {
+        assertThat(jdbcTemplate.queryForObject("SELECT VERSION()", String.class)).isEqualTo("8.4.11");
+
         User user = userRepository.save(User.builder()
                 .email("growth-plan@cubinghub.com")
                 .password("password")
@@ -73,6 +75,13 @@ class GrowthQueryPlanIntegrationTest extends JpaIntegrationTest {
         List<String> progressionPlan = explainAnalyze(
                 GrowthReadRepository.PB_PROGRESSION_POINTS_QUERY,
                 progressionParameters
+        );
+
+        System.out.printf("Growth recent plan on MySQL 8.4.11:%n%s%n", String.join("\n", latestPlan));
+        System.out.printf("Growth trend plan on MySQL 8.4.11:%n%s%n", String.join("\n", trendPlan));
+        System.out.printf(
+                "Growth PB progression plan on MySQL 8.4.11:%n%s%n",
+                String.join("\n", progressionPlan)
         );
 
         assertThat(String.join("\n", latestPlan)).contains("idx_record_user_event_created_at_id");

--- a/backend/src/test/java/com/cubinghub/domain/record/RecordFoundationMigrationIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/record/RecordFoundationMigrationIntegrationTest.java
@@ -62,6 +62,26 @@ class RecordFoundationMigrationIntegrationTest {
     }
 
     @Test
+    @DisplayName("MySQL 8.4.11에서 기존 Flyway history와 table collation을 유지한다")
+    void should_run_existing_migrations_on_mysql_8_4_11() {
+        String version = jdbcTemplate.queryForObject("SELECT VERSION()", String.class);
+        Integer migrationCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE success = 1",
+                Integer.class
+        );
+        String recordsCollation = jdbcTemplate.queryForObject("""
+                SELECT table_collation
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'records'
+                """, String.class);
+
+        assertThat(version).isEqualTo("8.4.11");
+        assertThat(migrationCount).isEqualTo(3);
+        assertThat(recordsCollation).isEqualTo("utf8mb4_unicode_ci");
+    }
+
+    @Test
     @DisplayName("V3 columns와 Record 조회 index는 합의한 type과 nullability를 가진다")
     void should_create_record_foundation_columns_and_indexes() {
         assertColumn("input_method", "varchar", 32L, "YES");
@@ -161,7 +181,10 @@ class RecordFoundationMigrationIntegrationTest {
             implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
         private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
-                DockerImageName.parse("mysql:8.0")
+                DockerImageName.parse("mysql:8.4.11")
+        ).withCommand(
+                "--character-set-server=utf8mb4",
+                "--collation-server=utf8mb4_0900_ai_ci"
         );
         private static final AtomicBoolean MIGRATED = new AtomicBoolean();
 

--- a/backend/src/test/java/com/cubinghub/integration/MySqlUpgradeCompatibilityIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/integration/MySqlUpgradeCompatibilityIntegrationTest.java
@@ -1,0 +1,277 @@
+package com.cubinghub.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@DisplayName("MySQL 8.4 logical upgrade 호환성 통합 테스트")
+class MySqlUpgradeCompatibilityIntegrationTest {
+
+    private static final String SOURCE_IMAGE = "mysql:8.0.46";
+    private static final String TARGET_IMAGE = "mysql:8.4.11";
+    private static final String DATABASE_NAME = "cubing_hub";
+    private static final String DATABASE_USER = "cubing_hub";
+    private static final String DATABASE_PASSWORD = "upgrade-fixture-password";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    @DisplayName("8.0 logical backup은 fresh 8.4.11과 fresh 8.0.46에 동일하게 복구된다")
+    void should_restore_mysql_8_0_backup_to_8_4_and_fresh_8_0_with_data_parity() throws Exception {
+        Path dumpFile = temporaryDirectory.resolve("pre-upgrade.sql");
+        DatabaseSnapshot sourceSnapshot;
+
+        try (MySQLContainer<?> source = mysql(SOURCE_IMAGE)) {
+            source.start();
+            migrate(source);
+            JdbcTemplate sourceDatabase = database(source);
+            seed(sourceDatabase);
+            sourceSnapshot = snapshot(sourceDatabase);
+
+            assertThat(sourceDatabase.queryForObject("SELECT VERSION()", String.class))
+                    .isEqualTo("8.0.46");
+
+            var dump = source.execInContainer(
+                    "/bin/sh",
+                    "-ceu",
+                    """
+                    export MYSQL_PWD="$MYSQL_ROOT_PASSWORD"
+                    exec mysqldump \
+                      --user=root \
+                      --default-character-set=utf8mb4 \
+                      --single-transaction \
+                      --quick \
+                      --complete-insert \
+                      --skip-extended-insert \
+                      --hex-blob \
+                      --routines \
+                      --triggers \
+                      "$MYSQL_DATABASE"
+                    """
+            );
+
+            assertThat(dump.getExitCode()).isZero();
+            assertThat(dump.getStdout())
+                    .contains("CREATE TABLE `records`")
+                    .contains("CREATE TABLE `flyway_schema_history`")
+                    .contains("-- Dump completed on");
+            Files.writeString(dumpFile, dump.getStdout(), StandardCharsets.UTF_8);
+        }
+
+        assertRestoredSnapshot(TARGET_IMAGE, "8.4.11", dumpFile, sourceSnapshot);
+        assertRestoredSnapshot(SOURCE_IMAGE, "8.0.46", dumpFile, sourceSnapshot);
+    }
+
+    private void assertRestoredSnapshot(
+            String image,
+            String expectedVersion,
+            Path dumpFile,
+            DatabaseSnapshot expected
+    ) throws Exception {
+        try (MySQLContainer<?> target = mysql(image)) {
+            target.start();
+            target.copyFileToContainer(MountableFile.forHostPath(dumpFile), "/tmp/pre-upgrade.sql");
+
+            var restore = target.execInContainer(
+                    "/bin/sh",
+                    "-ceu",
+                    """
+                    export MYSQL_PWD="$MYSQL_ROOT_PASSWORD"
+                    exec mysql --user=root "$MYSQL_DATABASE" < /tmp/pre-upgrade.sql
+                    """
+            );
+
+            assertThat(restore.getExitCode()).isZero();
+            JdbcTemplate restoredDatabase = database(target);
+            assertThat(restoredDatabase.queryForObject("SELECT VERSION()", String.class))
+                    .isEqualTo(expectedVersion);
+            assertThat(snapshot(restoredDatabase)).isEqualTo(expected);
+        }
+    }
+
+    private MySQLContainer<?> mysql(String image) {
+        return new MySQLContainer<>(DockerImageName.parse(image))
+                .withDatabaseName(DATABASE_NAME)
+                .withUsername(DATABASE_USER)
+                .withPassword(DATABASE_PASSWORD)
+                .withCommand(
+                        "--character-set-server=utf8mb4",
+                        "--collation-server=utf8mb4_0900_ai_ci"
+                );
+    }
+
+    private void migrate(MySQLContainer<?> source) {
+        Flyway.configure()
+                .dataSource(source.getJdbcUrl(), source.getUsername(), source.getPassword())
+                .locations("classpath:db/migration")
+                .load()
+                .migrate();
+    }
+
+    private JdbcTemplate database(MySQLContainer<?> container) {
+        return new JdbcTemplate(new DriverManagerDataSource(
+                container.getJdbcUrl(),
+                container.getUsername(),
+                container.getPassword()
+        ));
+    }
+
+    private void seed(JdbcTemplate database) {
+        database.update("""
+                INSERT INTO users (
+                    id, created_at, updated_at, main_event, nickname, email,
+                    password, role, status
+                ) VALUES (
+                    1, '2026-08-01 00:00:00.000000', '2026-08-01 00:00:00.000000',
+                    'WCA_333', 'UpgradeFixture', 'upgrade-fixture@cubinghub.com',
+                    'fixture-password-hash', 'ROLE_USER', 'ACTIVE'
+                )
+                """);
+        database.update("""
+                INSERT INTO records (
+                    id, time_ms, created_at, updated_at, user_id, scramble,
+                    event_type, penalty, input_method, client_submission_id,
+                    client_submission_payload_hash
+                ) VALUES
+                    (1, 12000, '2026-08-01 01:00:00.000001', '2026-08-01 01:00:00.000001',
+                     1, 'fixture-none', 'WCA_333', 'NONE', 'KEYBOARD',
+                     '11111111-1111-4111-8111-111111111111', UNHEX(REPEAT('11', 32))),
+                    (2, 11000, '2026-08-01 02:00:00.000002', '2026-08-01 02:00:00.000002',
+                     1, 'fixture-plus-two', 'WCA_333', 'PLUS_TWO', 'TOUCH',
+                     '22222222-2222-4222-8222-222222222222', UNHEX(REPEAT('22', 32))),
+                    (3, 10000, '2026-08-01 03:00:00.000003', '2026-08-01 03:00:00.000003',
+                     1, 'fixture-dnf', 'WCA_333', 'DNF', 'KEYBOARD',
+                     '33333333-3333-4333-8333-333333333333', UNHEX(REPEAT('33', 32)))
+                """);
+        database.update("""
+                INSERT INTO user_pbs (
+                    id, best_time_ms, created_at, updated_at, record_id, user_id, event_type
+                ) VALUES (
+                    1, 12000, '2026-08-01 01:00:00.000001', '2026-08-01 01:00:00.000001',
+                    1, 1, 'WCA_333'
+                )
+                """);
+        database.update("""
+                INSERT INTO posts (
+                    id, view_count, created_at, updated_at, user_id, title, content, category
+                ) VALUES (
+                    1, 3, '2026-08-01 04:00:00.000004', '2026-08-01 04:00:00.000004',
+                    1, 'Upgrade fixture post', 'Upgrade fixture content', 'FREE'
+                )
+                """);
+        database.update("""
+                INSERT INTO comments (
+                    id, created_at, updated_at, post_id, user_id, content
+                ) VALUES (
+                    1, '2026-08-01 05:00:00.000005', '2026-08-01 05:00:00.000005',
+                    1, 1, 'Upgrade fixture comment'
+                )
+                """);
+    }
+
+    private DatabaseSnapshot snapshot(JdbcTemplate database) {
+        int tableCount = requiredInteger(database, """
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_type = 'BASE TABLE'
+                """);
+        Map<String, Integer> rowCounts = Map.of(
+                "users", requiredInteger(database, "SELECT COUNT(*) FROM users"),
+                "records", requiredInteger(database, "SELECT COUNT(*) FROM records"),
+                "user_pbs", requiredInteger(database, "SELECT COUNT(*) FROM user_pbs"),
+                "posts", requiredInteger(database, "SELECT COUNT(*) FROM posts"),
+                "comments", requiredInteger(database, "SELECT COUNT(*) FROM comments"),
+                "flyway", requiredInteger(
+                        database,
+                        "SELECT COUNT(*) FROM flyway_schema_history WHERE success = 1"
+                )
+        );
+        List<String> penaltyDistribution = database.queryForList("""
+                SELECT CONCAT(penalty, ':', COUNT(*))
+                FROM records
+                GROUP BY penalty
+                ORDER BY penalty
+                """, String.class);
+        List<String> eventDistribution = database.queryForList("""
+                SELECT CONCAT(event_type, ':', COUNT(*))
+                FROM records
+                GROUP BY event_type
+                ORDER BY event_type
+                """, String.class);
+        List<String> personalBests = database.queryForList("""
+                SELECT CONCAT(user_id, ':', event_type, ':', best_time_ms, ':', record_id)
+                FROM user_pbs
+                ORDER BY user_id, event_type
+                """, String.class);
+        List<String> indexes = database.queryForList("""
+                SELECT CONCAT(table_name, ':', index_name, ':', seq_in_index, ':', column_name, ':', non_unique)
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                ORDER BY table_name, index_name, seq_in_index
+                """, String.class);
+        List<String> foreignKeys = database.queryForList("""
+                SELECT CONCAT(table_name, ':', constraint_name, ':', column_name, ':',
+                              referenced_table_name, ':', referenced_column_name)
+                FROM information_schema.key_column_usage
+                WHERE table_schema = DATABASE()
+                  AND referenced_table_name IS NOT NULL
+                ORDER BY table_name, constraint_name, ordinal_position
+                """, String.class);
+        Map<String, Object> recordRange = database.queryForMap("""
+                SELECT MIN(id) AS min_id, MAX(id) AS max_id,
+                       MIN(created_at) AS first_created_at,
+                       MAX(created_at) AS latest_created_at
+                FROM records
+                """);
+
+        return new DatabaseSnapshot(
+                tableCount,
+                rowCounts,
+                penaltyDistribution,
+                eventDistribution,
+                personalBests,
+                indexes,
+                foreignKeys,
+                String.valueOf(recordRange.get("min_id")),
+                String.valueOf(recordRange.get("max_id")),
+                String.valueOf(recordRange.get("first_created_at")),
+                String.valueOf(recordRange.get("latest_created_at"))
+        );
+    }
+
+    private int requiredInteger(JdbcTemplate database, String sql) {
+        Integer value = database.queryForObject(sql, Integer.class);
+        assertThat(value).isNotNull();
+        return value;
+    }
+
+    private record DatabaseSnapshot(
+            int tableCount,
+            Map<String, Integer> rowCounts,
+            List<String> penaltyDistribution,
+            List<String> eventDistribution,
+            List<String> personalBests,
+            List<String> indexes,
+            List<String> foreignKeys,
+            String minimumRecordId,
+            String maximumRecordId,
+            String firstRecordCreatedAt,
+            String latestRecordCreatedAt
+    ) {
+    }
+}

--- a/backend/src/test/java/com/cubinghub/integration/MySqlVersionIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/integration/MySqlVersionIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.cubinghub.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@DisplayName("MySQL runtime 통합 테스트")
+class MySqlVersionIntegrationTest extends JpaIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("통합 테스트는 MySQL 8.4.11과 production charset/collation을 사용한다")
+    void should_use_mysql_8_4_11_with_production_character_defaults() {
+        Map<String, Object> runtime = jdbcTemplate.queryForMap("""
+                SELECT
+                    VERSION() AS version,
+                    @@character_set_server AS character_set_server,
+                    @@collation_server AS collation_server
+                """);
+
+        assertThat(runtime.get("version")).isEqualTo("8.4.11");
+        assertThat(runtime.get("character_set_server")).isEqualTo("utf8mb4");
+        assertThat(runtime.get("collation_server")).isEqualTo("utf8mb4_0900_ai_ci");
+    }
+}

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:tc:mysql:8.0:///cubing_hub
+    url: jdbc:tc:mysql:8.4.11:///cubing_hub
     username: test
     password: test
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4.11
     container_name: cubing_hub_mysql
     ports:
       - "3306:3306"

--- a/docs/03-architecture/growth-architecture.md
+++ b/docs/03-architecture/growth-architecture.md
@@ -397,7 +397,7 @@ User timezone이 도입되면 historical day regrouping, profile setting, cache 
 - type-7 Q1/Q3 interpolation, rankable 8 gate, IQR direction
 - next Practice CTA fallback
 
-### Repository integration on MySQL 8
+### Repository integration on MySQL 8.4
 
 - same `created_at` + id ordering
 - KST 전후 UTC instant와 half-open range
@@ -407,7 +407,7 @@ User timezone이 도입되면 historical day regrouping, profile setting, cache 
 - unsupported event는 repository call 전 차단
 - 10,000-record fixture `EXPLAIN ANALYZE`와 returned row/payload count
 
-H2로 MySQL window/date behavior를 대신 증명하지 않는다. Current MySQL 8.0 runtime과 같은 major의 integration evidence를 사용한다.
+H2로 MySQL window/date behavior를 대신 증명하지 않는다. Current MySQL 8.4.11 runtime과 같은 engine patch의 integration evidence를 사용한다.
 
 ### REST Docs / API
 
@@ -507,6 +507,6 @@ Rollback은 additive endpoint와 frontend consumer를 이전 revision으로 되�
 
 참고:
 
-- [MySQL 8.0 Window Function Descriptions](https://dev.mysql.com/doc/refman/8.0/en/window-functions.html)
-- [MySQL Multiple-Column Indexes](https://dev.mysql.com/doc/refman/8.0/en/multiple-column-indexes.html)
-- [How MySQL Uses Indexes](https://dev.mysql.com/doc/refman/8.0/en/mysql-indexes.html)
+- [MySQL 8.4 Window Function Descriptions](https://dev.mysql.com/doc/refman/8.4/en/window-functions.html)
+- [MySQL Multiple-Column Indexes](https://dev.mysql.com/doc/refman/8.4/en/multiple-column-indexes.html)
+- [How MySQL Uses Indexes](https://dev.mysql.com/doc/refman/8.4/en/mysql-indexes.html)

--- a/docs/06-quality/mysql-8-4-upgrade-evidence.md
+++ b/docs/06-quality/mysql-8-4-upgrade-evidence.md
@@ -1,0 +1,73 @@
+---
+doc_type: quality
+status: active
+created: 2026-08-12
+updated: 2026-08-12
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/06-quality/quality-gates.md
+  - docs/06-quality/performance/growth-read-api-10k-mysql-8-4.md
+  - docs/07-operations/environments.md
+  - homeserver/docs/db-backup-restore.md
+  - backend/src/test/java/com/cubinghub/integration/MySqlUpgradeCompatibilityIntegrationTest.java
+  - backend/src/test/java/com/cubinghub/integration/MySqlVersionIntegrationTest.java
+---
+# MySQL 8.4 Upgrade Evidence
+
+## Version과 path
+
+- source: MySQL 8.0.46
+- target: [MySQL 8.4.11 LTS](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-11.html), exact Docker tag `mysql:8.4.11`
+- image manifest: `sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb`, linux/amd64와 linux/arm64 제공
+- upgrade path: MySQL 8.0에서 다음 LTS인 8.4로 upgrade 가능
+- rollback path: pre-upgrade logical backup을 fresh MySQL 8.0.46에 restore
+
+MySQL 8.4가 upgrade한 data directory를 MySQL 8.0 image로 다시 시작하지 않는다. MySQL의 [upgrade prerequisite](https://dev.mysql.com/doc/refman/8.4/en/upgrade-prerequisites.html), [8.4 changes](https://dev.mysql.com/doc/refman/8.4/en/upgrading-from-previous-series.html), [downgrade path](https://dev.mysql.com/doc/refman/8.4/en/downgrading.html)를 production gate로 사용한다.
+
+## Compatibility check
+
+격리된 MySQL 8.0.46 fixture에 existing Flyway V1~V3와 synthetic application data를 적용했다. MySQL Shell Upgrade Checker의 target을 8.4.11로 지정한 결과는 다음과 같다.
+
+| Result | Count | 해석 |
+| --- | ---: | --- |
+| Error | 0 | upgrade를 차단하는 schema·configuration 문제 없음 |
+| Warning | 24 | 8.4 server default 변경. repository가 명시적으로 설정하지 않는 InnoDB·replication 관련 default 포함 |
+| Notice | 2 | synthetic root account의 `SET_USER_ID` privilege 제거 안내 |
+
+Database base table 10개는 모두 `CHECK TABLE` status `OK`였다. Spatial index, replication configuration, obsolete SQL mode와 제거된 startup option은 repository runtime에 없다. App DB user는 8.0과 8.4에서 `caching_sha2_password`를 유지했다.
+
+MySQL 8.4.11 release-specific 변경 가운데 Cubing Hub에 영향을 줄 수 있는 범위도 확인했다.
+
+- InnoDB의 B-tree record size와 DDL validation 수정: existing V1~V3 fresh migration 성공
+- CTE와 `LEFT JOIN` optimizer 수정: Growth trend·PB progression query plan 재측정
+- replication variable deprecation: replication을 사용하지 않아 영향 없음
+- Enterprise Linux 7 packaging 제거: official container의 Oracle Linux 9 계열과 무관
+
+## Backup, restore와 first startup
+
+Production backup worker와 같은 주요 `mysqldump` option으로 8.0 fixture를 논리 백업했다. Fresh 8.4.11과 fresh 8.0.46에 같은 dump를 restore해 다음 parity를 확인했다.
+
+| Evidence | Source 8.0.46 | Target 8.4.11 | Rollback 8.0.46 |
+| --- | ---: | ---: | ---: |
+| database base table | 10 | 10 | 10 |
+| successful Flyway migration | 3 | 3 | 3 |
+| users / records / user_pbs | 1 / 3 / 1 | 1 / 3 / 1 | 1 / 3 / 1 |
+| posts / comments | 1 / 1 | 1 / 1 | 1 / 1 |
+| Penalty NONE / PLUS_TWO / DNF | 1 / 1 / 1 | 1 / 1 / 1 | 1 / 1 / 1 |
+| current PB | WCA_333 / 12000ms / Record 1 | 동일 | 동일 |
+
+Index와 FK inventory, Record min/max ID, first/latest microsecond timestamp, `records` table collation도 일치했다. Fresh 8.4.11 restore 뒤 current source로 build한 API image는 Hibernate schema validation과 health check를 통과했다.
+
+별도 isolated volume에서 MySQL 8.0.46을 정상 종료하고 같은 data directory를 MySQL 8.4.11로 처음 시작했다. Server log는 data dictionary `80023 → 80300`과 server `80046 → 80411` upgrade 완료를 기록했고, `SELECT VERSION()`은 `8.4.11`, application data와 Flyway history는 그대로였다.
+
+## Executable gate
+
+- `MySqlVersionIntegrationTest`: actual engine patch와 server charset/collation
+- `RecordFoundationMigrationIntegrationTest`: fresh V1~V3 migration과 table collation
+- `MySqlUpgradeCompatibilityIntegrationTest`: 8.0 logical backup을 fresh 8.4와 fresh 8.0에 restore한 parity
+- `GrowthQueryPlanIntegrationTest`: 10,000-record Growth query의 8.4.11 access path
+- backend full test와 REST Docs: application contract regression
+
+Production data와 volume은 이 evidence 생성에 사용하지 않았다. 실제 production upgrade는 [DB와 이미지 백업·복구](../../homeserver/docs/db-backup-restore.md)의 별도 승인과 maintenance gate를 따른다.

--- a/docs/06-quality/performance/README.md
+++ b/docs/06-quality/performance/README.md
@@ -2,7 +2,7 @@
 doc_type: quality
 status: active
 created: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -10,6 +10,7 @@ related:
   - docs/06-quality/performance/ranking-baseline.md
   - docs/06-quality/performance/mypage-baseline.md
   - docs/06-quality/performance/growth-read-api-10k.md
+  - docs/06-quality/performance/growth-read-api-10k-mysql-8-4.md
 ---
 # Performance Evidence
 
@@ -19,7 +20,8 @@ related:
 
 - [Ranking baseline](ranking-baseline.md): 2026-04-20~21 MySQL V1과 Redis V2 비교
 - [MyPage baseline](mypage-baseline.md): 2026-04-22 사용자당 10,000 records 비교
-- [Growth read API 10k query plan](growth-read-api-10k.md): MySQL 8 `EXPLAIN ANALYZE` snapshot
+- [Growth read API 10k query plan](growth-read-api-10k.md): MySQL 8.0.46 baseline
+- [Growth read API 10k MySQL 8.4 query plan](growth-read-api-10k-mysql-8-4.md): MySQL 8.4.11 비교 snapshot
 - [Legacy benchmark runbook](benchmarks/legacy-runbook.md): 당시 실행 절차 원문
 
 raw JSON, generated Markdown·HTML, Grafana screenshot은 benchmarks와 docs/assets/screenshots/performance에 보존한다.

--- a/docs/06-quality/performance/growth-read-api-10k-mysql-8-4.md
+++ b/docs/06-quality/performance/growth-read-api-10k-mysql-8-4.md
@@ -1,0 +1,38 @@
+---
+doc_type: quality
+status: active
+created: 2026-08-12
+updated: 2026-08-12
+owner: xxh3898
+project: cubing-hub
+tags: []
+related:
+  - docs/03-architecture/growth-architecture.md
+  - docs/06-quality/performance/README.md
+  - docs/06-quality/performance/growth-read-api-10k.md
+  - backend/src/main/java/com/cubinghub/domain/growth/repository/GrowthReadRepository.java
+  - backend/src/test/java/com/cubinghub/domain/growth/repository/GrowthQueryPlanIntegrationTest.java
+---
+# Growth Read API Query Plan Evidence — MySQL 8.4.11
+
+## Fixture
+
+격리된 `mysql:8.4.11` container에 기존 Flyway migration을 적용하고 WCA_333 한 user/event의 `records` 10,000건을 생성했다. PR B의 fixture와 SQL을 그대로 사용했으며 `ANALYZE TABLE records` 뒤 `EXPLAIN ANALYZE`를 실행했다. production data, schema, index는 사용하지 않았다.
+
+아래 숫자는 Mac mini Docker Desktop에서 얻은 local snapshot이다. CI의 `GrowthQueryPlanIntegrationTest`는 같은 engine patch와 query를 다시 검증하지만, local execution time을 production latency나 capacity로 해석하지 않는다.
+
+## MySQL 8.0.46 비교
+
+| Query | MySQL 8.0.46 baseline | MySQL 8.4.11 | MySQL 8.4.11 access |
+| --- | ---: | ---: | --- |
+| latest 24 Record | 0.701–0.706ms | 0.473ms | `idx_record_user_event_created_at_id` reverse index lookup, 24 rows 반환 |
+| 30-day daily trend | 27.0ms | 19.9ms | 같은 index의 range scan, 10,000 rows scan, 9,412 rankable rows window, 8 rows 반환 |
+| PB progression | 25.1ms | 16.7ms | 같은 index lookup, 10,000 rows scan, 9,412 rankable rows materialize, 2 PB points 반환 |
+
+세 query 모두 V3 `idx_record_user_event_created_at_id (user_id, event_type, created_at, id)`를 선택했다. Trend는 daily aggregate와 median 계산에 temporary table을 사용하고, PB progression은 running minimum과 `LAG`를 위해 sort/materialize 단계를 유지한다. MySQL 8.4.11에서 scan shape나 반환량이 악화되지 않았고 새 index나 Flyway migration은 추가하지 않는다.
+
+## 범위
+
+- latest, trend, progression SQL과 10,000-record seed는 MySQL 8.0.46 baseline과 같다.
+- 절대 실행 시간은 host 상태에 따라 달라질 수 있으므로 access path와 actual row shape를 우선 비교한다.
+- 100,000-record progression stress와 production request latency는 이 snapshot의 범위가 아니다.

--- a/docs/06-quality/quality-gates.md
+++ b/docs/06-quality/quality-gates.md
@@ -9,6 +9,7 @@ tags: []
 related:
   - .github/workflows/validate.yml
   - AGENTS.md
+  - docs/06-quality/mysql-8-4-upgrade-evidence.md
   - homeserver/docs/release-smoke-runbook.md
 ---
 # Quality Gates
@@ -31,6 +32,8 @@ CI는 Java 25에서 다음을 실행한다.
     SPRING_PROFILES_ACTIVE=test ./gradlew test jacocoTestReport build --no-daemon
 
 test, REST Docs generation, JaCoCo report, bootJar build가 연결된다. 현재 build 설정에는 수치형 coverage verification task가 없으므로 과거 100% 기록을 지속 보장되는 gate로 표현하지 않는다.
+
+MySQL integration test는 exact `mysql:8.4.11` image를 사용한다. `SELECT VERSION()`으로 engine patch를 확인하고, 기존 Flyway history, 8.0 logical backup의 8.4·8.0 restore parity, Growth 10,000-record query plan을 검증한다.
 
 ## Frontend gate
 

--- a/docs/07-operations/environments.md
+++ b/docs/07-operations/environments.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-08-10
-updated: 2026-08-11
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -30,7 +30,9 @@ local profile은 ddl-auto update와 Flyway disabled를 사용한다. production 
 
 ## Production configuration fact
 
-repository Compose에는 MySQL 8.0.46, Redis 7.2.14, API, Web이 정의돼 있다. DB·Redis는 internal application network, API는 별도 outbound, Web은 external edge network를 사용한다. image·secret은 env로 주입한다.
+repository Compose에는 MySQL 8.4.11 LTS, Redis 7.2.14, API, Web이 정의돼 있다. DB·Redis는 internal application network, API는 별도 outbound, Web은 external edge network를 사용한다. image·secret은 env로 주입한다.
+
+일반 application deploy는 실행 중인 data-service image와 candidate runtime config가 다르면 중단한다. MySQL 8.4.11 전환은 [DB와 이미지 백업·복구](../../homeserver/docs/db-backup-restore.md)의 별도 production migration gate를 통과한 뒤 실행한다.
 
 ## Tracked legacy configuration
 

--- a/docs/07-operations/local-development.md
+++ b/docs/07-operations/local-development.md
@@ -17,7 +17,7 @@ related:
 
 - backend: Java 25, Gradle 9.6.1 wrapper
 - frontend: Node.js 20, npm
-- data helper: root docker-compose.yml의 MySQL 8.0, Redis 7.2, Prometheus, Grafana
+- data helper: root docker-compose.yml의 MySQL 8.4.11, Redis 7.2, Prometheus, Grafana
 - backend local profile: application-local.yaml
 - frontend dev server: Vite
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@ related:
 - [Acceptance Criteria](06-quality/acceptance-criteria.md)
 - [Quality Gates](06-quality/quality-gates.md)
 - [Security Testing](06-quality/security-testing.md)
+- [MySQL 8.4 Upgrade Evidence](06-quality/mysql-8-4-upgrade-evidence.md)
 - [Performance Evidence](06-quality/performance/README.md)
 
 ### 07 Operations

--- a/homeserver/docker-compose.smoke.yml
+++ b/homeserver/docker-compose.smoke.yml
@@ -27,7 +27,7 @@ services:
       - build
 
   mysql:
-    image: mysql:8.0.46
+    image: mysql:8.4.11
     environment:
       MYSQL_DATABASE: ${SMOKE_DB_NAME:-cubing_hub_smoke}
       MYSQL_USER: ${SMOKE_DB_USERNAME:-cubing_hub_smoke}

--- a/homeserver/docker-compose.yml
+++ b/homeserver/docker-compose.yml
@@ -2,7 +2,7 @@ name: cubing-hub
 
 services:
   db:
-    image: mysql:8.0.46
+    image: mysql:8.4.11
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: ${DB_NAME:?DB_NAME must be set}

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-06-19
-updated: 2026-08-10
+updated: 2026-08-12
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -233,8 +233,49 @@ URL은 Git, 문서, 로그에 기록하지 않는다. 상세 계약과 복구 �
 5. 검증용 API를 `ddl-auto=validate`로 시작한다.
 6. 검증 결과를 기록한 뒤에만 운영 복구 여부를 별도로 승인한다.
 
+## MySQL 8.4.11 engine upgrade
+
+Repository runtime target은 MySQL 8.0.46에서 MySQL 8.4.11 LTS로 전환한다. 일반 application deploy worker는 실행 중인 DB image와 candidate runtime config가 다르면 `data-service image drift`로 중단한다. 따라서 main merge만으로 production DB container가 자동 교체되지 않으며, 아래 절차는 별도 production 변경 승인 뒤 수동으로 수행한다.
+
+### Preconditions
+
+- MySQL 8.0.46 instance에 대한 Upgrade Checker와 table check 성공
+- 최신 정상 backup 생성과 manifest·checksum 검증
+- 같은 backup의 fresh MySQL 8.4.11 restore rehearsal 성공
+- 같은 backup의 fresh MySQL 8.0.46 rollback restore rehearsal 성공
+- MySQL 8.4.11 fresh Flyway migration, backend regression, Growth query plan, CI 성공
+- maintenance window와 application write stop 승인
+- current application SHA, runtime config digest, DB volume, rollback target 확인
+
+### Upgrade
+
+1. application write를 중단하고 maintenance 상태를 확인한다.
+2. 운영 backup worker로 pre-upgrade logical backup과 게시글 image snapshot을 만든다.
+3. `SUCCESS`, manifest, dump·image checksum, engine/version, row count를 검증한다.
+4. 별도 fresh MySQL 8.4.11 환경에 backup을 restore하고 schema, FK, index, Flyway history, 핵심 row count를 확인한다.
+5. 기존 MySQL 8.0.46을 정상 종료한다. 운영 Compose와 volume의 exact identity를 다시 확인한다.
+6. 별도 data-service 절차로 exact `mysql:8.4.11` image를 적용한다. 첫 startup의 data dictionary·server upgrade log와 container health를 확인한다.
+7. `SELECT VERSION()`, charset/collation, application DB user의 `caching_sha2_password` 연결, Flyway validation을 확인한다.
+8. users, records, user_pbs, posts/comments 수와 PB·Penalty 분포, Record ID·timestamp 범위를 pre-upgrade evidence와 대조한다.
+9. API health, auth, Record create/PATCH/delete, Ranking, Growth summary/trend/progression, Community와 image read smoke를 수행한다.
+10. 모든 gate가 끝난 뒤에만 write를 재개한다.
+
+### Rollback
+
+다음은 rollback trigger다.
+
+- MySQL 8.4.11 first startup 또는 data dictionary upgrade 실패
+- schema·constraint·row count·PB parity 불일치
+- application DB login, Flyway validation, 핵심 smoke 실패
+- Growth query plan의 구조적 regression
+
+Rollback은 pre-upgrade logical backup을 fresh MySQL 8.0.46 environment에 restore하는 방식으로 수행한다. MySQL 8.4가 한 번이라도 upgrade한 data directory에 MySQL 8.0.46 image를 다시 연결하지 않는다. Fresh 8.0.46에서 schema, row count, image reference, application smoke를 확인한 뒤 exact 이전 application/runtime pair를 복구한다.
+
+Production upgrade와 rollback의 실제 command, secret, 운영 path 확인은 변경 시점의 별도 승인 범위에서 작성한다. Repository merge나 이 runbook만으로 production data 변경을 승인하지 않는다.
+
 ## 금지 사항
 
 - `docker compose down -v`를 backup이나 rollback 명령으로 사용하지 않는다.
 - 검증하지 않은 dump를 운영 volume에 바로 복구하지 않는다.
+- MySQL 8.4가 upgrade한 data directory를 MySQL 8.0 image로 시작하지 않는다.
 - secret, DB password, 실제 token을 manifest나 로그에 기록하지 않는다.

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -96,7 +96,7 @@ case "${command_name}" in
     arguments=" $* "
     if [[ "${arguments}" == *" config --images db redis "* ]]; then
       printf '%s\n' \
-        "${FAKE_RENDER_DB_IMAGE:-mysql:8.0.46}" \
+        "${FAKE_RENDER_DB_IMAGE:-mysql:8.4.11}" \
         "${FAKE_RENDER_REDIS_IMAGE:-redis:7.2.14-alpine}"
     elif [[ "${arguments}" == *" run "* ]] \
       && [[ "${arguments}" == *"com.cubinghub.ops.MigrationMain"* ]] \
@@ -153,7 +153,7 @@ case "${command_name}" in
       fi
       api_image="${FAKE_RENDER_API_IMAGE:-${API_IMAGE}}"
       web_image="${FAKE_RENDER_WEB_IMAGE:-${WEB_IMAGE}}"
-      db_image="${FAKE_RENDER_DB_IMAGE:-mysql:8.0.46}"
+      db_image="${FAKE_RENDER_DB_IMAGE:-mysql:8.4.11}"
       redis_image="${FAKE_RENDER_REDIS_IMAGE:-redis:7.2.14-alpine}"
       real_ip_source="$(
         /usr/bin/dirname "${compose_file}"

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -94,7 +94,7 @@ export MOCK_DUMP_FILE="${default_dump_file}"
     'elif [[ "$*" == *"BACKUP_QUERY=dump"* ]]; then' \
     '  /bin/cat "${MOCK_DUMP_FILE}"' \
     'elif [[ "$*" == *"BACKUP_QUERY=version"* ]]; then' \
-    '  printf "8.0.46\n"' \
+    '  printf "8.4.11\n"' \
     'elif [[ "$*" == *"BACKUP_QUERY=record-counts"* ]]; then' \
     '  printf "post_attachments\t0\nusers\t1\n"' \
     'elif [[ "$*" == *"BACKUP_QUERY=attachment-keys"* ]]; then' \
@@ -308,7 +308,7 @@ def write_valid(timestamp):
         "environment": "production",
         "database": {
             "engine": "mysql",
-            "version": "8.0.46",
+            "version": "8.4.11",
             "dumpFile": "database/dump",
             "bytes": len(dump),
             "sha256": hashlib.sha256(dump).hexdigest(),
@@ -519,7 +519,7 @@ assert manifest["trigger"] == trigger
 assert manifest["source"]["applicationSha"] == application_sha
 assert manifest["source"]["runtimeConfigDigest"] == config_digest
 assert manifest["database"]["engine"] == "mysql"
-assert manifest["database"]["version"] == "8.0.46"
+assert manifest["database"]["version"] == "8.4.11"
 assert manifest["database"]["recordCounts"] == {"post_attachments": 1, "users": 1}
 assert manifest["database"]["recordCountsSource"] == "database/dump"
 assert manifest["database"]["bytes"] == dump.stat().st_size

--- a/homeserver/scripts/test-deploy-home-server.sh
+++ b/homeserver/scripts/test-deploy-home-server.sh
@@ -1047,7 +1047,7 @@ expect_protected_failure() {
     "${app_dir}/.env"
 }
 
-FAKE_CANDIDATE_DB_IMAGE=mysql:8.4 \
+FAKE_CANDIDATE_DB_IMAGE=mysql:8.0.46 \
   expect_protected_failure "data-service image drift"
 FAKE_CANDIDATE_DB_ENTRYPOINT_JSON='["sh","-c","rm -rf /var/lib/mysql"]' \
   expect_protected_failure "database entrypoint drift"


### PR DESCRIPTION
## Goal

- MySQL 8.0.46에서 MySQL 8.4.11 LTS로 engine 전환
- runtime과 Testcontainers의 exact `mysql:8.4.11` pin
- schema·API 변경 없는 upgrade safety 검증

## Version

- Before: MySQL 8.0.46
- After: MySQL 8.4.11 LTS
- Docker manifest: linux/amd64, linux/arm64 제공

## Compatibility

- MySQL Shell Upgrade Checker error 0건
- 8.4 server default 변경 warning 24건과 synthetic root privilege notice 2건 검토
- 기존 table `CHECK TABLE` 성공
- existing Flyway V1~V3 fresh migration과 charset/collation 검증
- 격리 volume의 8.0.46 → 8.4.11 data dictionary·server first startup 확인

## Backup / Restore

- MySQL 8.0.46 synthetic fixture logical backup 생성
- fresh MySQL 8.4.11 restore와 schema·row·index·FK·PB·timestamp parity 확인
- 같은 pre-upgrade backup의 fresh MySQL 8.0.46 rollback restore 확인

## Rollback

- pre-upgrade logical backup을 fresh MySQL 8.0.46에 restore
- MySQL 8.4가 upgrade한 data directory에 MySQL 8.0 image 연결 금지

## Application Regression

- exact Testcontainers engine version assertion 추가
- restored MySQL 8.4.11에서 Hibernate schema validation과 API health 확인
- Auth, Record, Ranking, Growth, Community, REST Docs는 Backend checks에서 회귀 검증

## Query Plan

- PR B와 같은 10,000-record fixture와 SQL 사용
- recent 0.473ms, trend 19.9ms, PB progression 16.7ms local snapshot
- 기존 composite index와 scan shape 유지, 새 index 없음

## CI

- local compile·bootJar 성공
- deploy·backup fixture, infrastructure Node test, Compose render 성공
- Backend checks, API ARM64 image, Infrastructure checks 성공
- Frontend checks와 Web ARM64 image 포함 전체 Validate 성공

## Production Migration Gate

일반 deploy worker는 DB image drift를 거부한다. Production upgrade는 정상 backup, 8.4 restore, 8.0 rollback restore, CI, query plan과 maintenance 절차를 확인한 뒤 별도 승인으로 진행한다.

## Out of Scope

- production deploy와 DB 접근
- schema, Flyway migration, index
- PostgreSQL, Redis upgrade
- frontend, V2.2 PR C
