### PR TITLE
ci: add post-maintenance runtime baseline reconciliation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
       packages: write
     outputs:
       data_service_maintenance_required: ${{ steps.data-service-maintenance.outputs.required }}
+      runtime_baseline_digest: ${{ steps.runtime-baseline.outputs.digest }}
+      runtime_baseline_revision: ${{ steps.runtime-baseline.outputs.revision }}
+      runtime_baseline_source: ${{ steps.runtime-baseline.outputs.source }}
       runtime_config_mode: ${{ steps.runtime-config-mode.outputs.mode }}
       runtime_config_digest: ${{ steps.publish-runtime-config.outputs.digest }}
       runtime_config_revision: ${{ steps.data-service-maintenance.outputs.runtime_config_revision }}
@@ -57,80 +60,67 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Resolve last successful production revision
-        id: deployed-base
+      - name: Resolve verified runtime config baseline
+        id: runtime-baseline
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          deployment_page=1
-          deployment_page_size=100
-          saw_production_deployment=false
-          deployed_sha=0000000000000000000000000000000000000000
-          while :; do
-            deployments="$(
-              curl \
-                --fail \
-                --retry 3 \
-                --silent \
-                --show-error \
-                --header "Authorization: Bearer ${GH_TOKEN}" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments?environment=production&per_page=${deployment_page_size}&page=${deployment_page}"
-            )"
-            if ! jq -e 'type == "array"' <<<"${deployments}" >/dev/null; then
-              printf 'Production deployment history response is invalid\n' >&2
-              exit 1
-            fi
-            deployment_count="$(jq -r 'length' <<<"${deployments}")"
-            if [[ "${deployment_count}" -eq 0 ]]; then
-              if [[ "${saw_production_deployment}" == false ]]; then
-                break
-              fi
-              printf 'Production deployments exist, but no successful revision was found\n' >&2
-              exit 1
-            fi
-            saw_production_deployment=true
-            while IFS=$'\t' read -r deployment_id deployment_candidate_sha; do
-              state="$(
-                curl \
-                  --fail \
-                  --retry 3 \
-                  --silent \
-                  --show-error \
-                  --header "Authorization: Bearer ${GH_TOKEN}" \
-                  --header "X-GitHub-Api-Version: 2022-11-28" \
-                  "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses?per_page=1" \
-                  | jq -r '.[0].state // empty'
-              )"
-              if [[ "${state}" == success ]]; then
-                deployed_sha="${deployment_candidate_sha}"
-                break
-              fi
-            done < <(jq -r '.[] | [.id, .sha] | @tsv' <<<"${deployments}")
-            if [[ "${deployed_sha}" != 0000000000000000000000000000000000000000 ]]; then
-              break
-            fi
-            if [[ "${deployment_count}" -lt "${deployment_page_size}" ]]; then
-              printf 'Production deployments exist, but no successful revision was found\n' >&2
-              exit 1
-            fi
-            deployment_page="$((deployment_page + 1))"
-          done
-          if [[ ! "${deployed_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            printf 'Last successful deployment revision has an unexpected format\n' >&2
+          baseline="$(
+            /bin/bash ./homeserver/scripts/resolve-runtime-config-baseline.sh
+          )"
+          keys="$(
+            printf '%s\n' "${baseline}" \
+              | awk -F= 'NF >= 2 { print $1 }' \
+              | LC_ALL=C sort
+          )"
+          if [[ "${keys}" != $'digest\nrevision\nsource' ]]; then
+            printf 'Runtime baseline resolver output is invalid\n' >&2
+            exit 1
+          fi
+          runtime_baseline_digest="$(
+            sed -n 's/^digest=//p' <<<"${baseline}" | tail -n 1
+          )"
+          runtime_baseline_revision="$(
+            sed -n 's/^revision=//p' <<<"${baseline}" | tail -n 1
+          )"
+          runtime_baseline_source="$(
+            sed -n 's/^source=//p' <<<"${baseline}" | tail -n 1
+          )"
+          if [[ ! "${runtime_baseline_revision}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'Runtime baseline revision has an unexpected format\n' >&2
             exit 64
           fi
-          printf 'sha=%s\n' "${deployed_sha}" >>"${GITHUB_OUTPUT}"
+          if [[ ! "${runtime_baseline_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            printf 'Runtime baseline digest has an unexpected format\n' >&2
+            exit 64
+          fi
+          if [[ "${runtime_baseline_revision}" != 0000000000000000000000000000000000000000 ]] \
+            && ! git cat-file -e "${runtime_baseline_revision}^{commit}" 2>/dev/null
+          then
+            printf 'Runtime baseline revision is unavailable in repository history\n' >&2
+            exit 1
+          fi
+          case "${runtime_baseline_source}" in
+            runtime|legacy-bootstrap|new-install-bootstrap)
+              ;;
+            *)
+              printf 'Runtime baseline source is invalid\n' >&2
+              exit 64
+              ;;
+          esac
+          printf 'digest=%s\n' "${runtime_baseline_digest}" >>"${GITHUB_OUTPUT}"
+          printf 'revision=%s\n' "${runtime_baseline_revision}" >>"${GITHUB_OUTPUT}"
+          printf 'source=%s\n' "${runtime_baseline_source}" >>"${GITHUB_OUTPUT}"
 
       - name: Detect runtime config changes
         id: runtime-config-mode
         env:
-          DEPLOYED_SHA: ${{ steps.deployed-base.outputs.sha }}
+          RUNTIME_BASELINE_SHA: ${{ steps.runtime-baseline.outputs.revision }}
           FORCE_SYNC: ${{ inputs.sync_runtime_config || false }}
         run: |
           mode="$(
             /bin/bash ./homeserver/scripts/detect-runtime-config-change.sh \
-              "${DEPLOYED_SHA}" \
+              "${RUNTIME_BASELINE_SHA}" \
               "${GITHUB_SHA}" \
               "${FORCE_SYNC}"
           )"
@@ -139,12 +129,12 @@ jobs:
       - name: Detect data-service maintenance
         id: data-service-maintenance
         env:
-          DEPLOYED_SHA: ${{ steps.deployed-base.outputs.sha }}
+          RUNTIME_BASELINE_SHA: ${{ steps.runtime-baseline.outputs.revision }}
           RUNTIME_CONFIG_MODE: ${{ steps.runtime-config-mode.outputs.mode }}
         run: |
           required="$(
             /bin/bash ./homeserver/scripts/detect-data-service-maintenance.sh \
-              "${DEPLOYED_SHA}" \
+              "${RUNTIME_BASELINE_SHA}" \
               "${GITHUB_SHA}"
           )"
           case "${required}" in
@@ -239,6 +229,9 @@ jobs:
         env:
           API_IMAGE_DIGEST: ${{ steps.publish-api.outputs.digest }}
           DATA_SERVICE_MAINTENANCE_REQUIRED: ${{ steps.data-service-maintenance.outputs.required }}
+          RUNTIME_BASELINE_DIGEST: ${{ steps.runtime-baseline.outputs.digest }}
+          RUNTIME_BASELINE_REVISION: ${{ steps.runtime-baseline.outputs.revision }}
+          RUNTIME_BASELINE_SOURCE: ${{ steps.runtime-baseline.outputs.source }}
           WEB_IMAGE_DIGEST: ${{ steps.publish-web.outputs.digest }}
           RUNTIME_CONFIG_DIGEST: ${{ steps.publish-runtime-config.outputs.digest }}
           RUNTIME_CONFIG_MODE: ${{ steps.runtime-config-mode.outputs.mode }}
@@ -252,6 +245,12 @@ jobs:
             printf -- "  - Digest: \`%s\`\n" "${WEB_IMAGE_DIGEST}"
             printf -- "- Runtime config mode: \`%s\`\n" \
               "${RUNTIME_CONFIG_MODE}"
+            printf -- "- Runtime baseline source: \`%s\`\n" \
+              "${RUNTIME_BASELINE_SOURCE}"
+            printf -- "- Runtime baseline revision: \`%s\`\n" \
+              "${RUNTIME_BASELINE_REVISION}"
+            printf -- "- Runtime baseline digest: \`%s\`\n" \
+              "${RUNTIME_BASELINE_DIGEST}"
             if [[ "${RUNTIME_CONFIG_MODE}" == update ]]; then
               printf -- "- Runtime config revision: \`%s\`\n" \
                 "${RUNTIME_CONFIG_REVISION}"
@@ -263,9 +262,15 @@ jobs:
             if [[ "${DATA_SERVICE_MAINTENANCE_REQUIRED}" == true ]]; then
               printf -- "- Data-service maintenance: \`required\`\n"
               printf -- "- Production deploy: \`skipped\`\n"
+              printf -- "- Runtime baseline: \`unchanged\`\n"
             else
               printf -- "- Data-service maintenance: \`not required\`\n"
               printf -- "- Production deploy: \`allowed\`\n"
+              if [[ "${RUNTIME_CONFIG_MODE}" == update ]]; then
+                printf -- "- Runtime baseline: deploy 성공 후 기록\n"
+              else
+                printf -- "- Runtime baseline: \`unchanged\`\n"
+              fi
             fi
           } >>"${GITHUB_STEP_SUMMARY}"
 
@@ -344,3 +349,55 @@ jobs:
                 -o StrictHostKeyChecking=yes \
                 homeserver@home-mini \
                 "${deploy_command}"
+
+  record-runtime-baseline:
+    name: Record runtime config baseline
+    if: >-
+      always()
+      && github.ref == 'refs/heads/main'
+      && vars.MAC_MINI_DEPLOY_ENABLED == 'true'
+      && needs.publish.result == 'success'
+      && needs.deploy.result == 'success'
+      && needs.publish.outputs.runtime_config_mode == 'update'
+      && needs.publish.outputs.data_service_maintenance_required == 'false'
+    needs:
+      - publish
+      - deploy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Record verified runtime config baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_CONFIG_DIGEST: ${{ needs.publish.outputs.runtime_config_digest }}
+          RUNTIME_CONFIG_REVISION: ${{ needs.publish.outputs.runtime_config_revision }}
+        run: |
+          result="$(
+            /bin/bash ./homeserver/scripts/record-runtime-config-baseline.sh \
+              normal-update \
+              "${GITHUB_SHA}" \
+              "${RUNTIME_CONFIG_REVISION}" \
+              "${RUNTIME_CONFIG_DIGEST}" \
+              - \
+              - \
+              -
+          )"
+          deployment_id="$(
+            sed -n 's/^deployment_id=//p' <<<"${result}" | tail -n 1
+          )"
+          [[ "${deployment_id}" =~ ^[0-9]+$ ]]
+          {
+            printf '## Runtime config baseline\n\n'
+            printf -- '- Operation: `normal-update`\n'
+            printf -- '- Application revision: `%s`\n' "${GITHUB_SHA}"
+            printf -- '- Runtime revision: `%s`\n' "${RUNTIME_CONFIG_REVISION}"
+            printf -- '- Runtime digest: `%s`\n' "${RUNTIME_CONFIG_DIGEST}"
+            printf -- '- Deployment ID: `%s`\n' "${deployment_id}"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/reconcile-runtime-baseline.yml
+++ b/.github/workflows/reconcile-runtime-baseline.yml
@@ -1,0 +1,179 @@
+name: Reconcile Production Runtime Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_application_revision:
+        description: Current production API/Web application revision
+        required: true
+        type: string
+      expected_runtime_config_revision:
+        description: Applied production runtime config revision
+        required: true
+        type: string
+      expected_runtime_config_digest:
+        description: Applied production runtime config sha256 digest
+        required: true
+        type: string
+      expected_db_image:
+        description: Exact production MySQL image tag@digest
+        required: true
+        type: string
+      expected_db_volume:
+        description: Exact production MySQL volume name
+        required: true
+        type: string
+      expected_mysql_version:
+        description: Exact running MySQL patch version
+        required: true
+        default: 8.4.11
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cubing-hub-production
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Verify and record runtime config baseline
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: production-runtime-config
+      deployment: false
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+
+    steps:
+      - name: Check out repository history
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate reconciliation intent
+        env:
+          EXPECTED_APPLICATION_REVISION: ${{ inputs.expected_application_revision }}
+          EXPECTED_RUNTIME_CONFIG_REVISION: ${{ inputs.expected_runtime_config_revision }}
+          EXPECTED_RUNTIME_CONFIG_DIGEST: ${{ inputs.expected_runtime_config_digest }}
+          EXPECTED_DB_IMAGE: ${{ inputs.expected_db_image }}
+          EXPECTED_DB_VOLUME: ${{ inputs.expected_db_volume }}
+          EXPECTED_MYSQL_VERSION: ${{ inputs.expected_mysql_version }}
+        run: |
+          set -Eeuo pipefail
+
+          [[ "${EXPECTED_APPLICATION_REVISION}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${EXPECTED_RUNTIME_CONFIG_REVISION}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${EXPECTED_RUNTIME_CONFIG_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${EXPECTED_DB_IMAGE}" =~ ^mysql:[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$ ]]
+          [[ "${EXPECTED_DB_VOLUME}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]
+          [[ "${EXPECTED_MYSQL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+
+          expected_image_version="${EXPECTED_DB_IMAGE#mysql:}"
+          expected_image_version="${expected_image_version%@sha256:*}"
+          [[ "${expected_image_version}" == "${EXPECTED_MYSQL_VERSION}" ]]
+
+          git cat-file -e "${EXPECTED_APPLICATION_REVISION}^{commit}"
+          git cat-file -e "${EXPECTED_RUNTIME_CONFIG_REVISION}^{commit}"
+          git merge-base --is-ancestor "${EXPECTED_APPLICATION_REVISION}" "${GITHUB_SHA}"
+          git merge-base --is-ancestor "${EXPECTED_RUNTIME_CONFIG_REVISION}" "${GITHUB_SHA}"
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          hostname: cubing-hub-runtime-reconcile-${{ github.run_id }}-${{ github.run_attempt }}
+          ping: home-mini
+
+      - name: Configure restricted SSH identity
+        env:
+          HOME_MINI_SSH_KEY: ${{ secrets.HOME_MINI_SSH_KEY }}
+          HOME_MINI_KNOWN_HOSTS: ${{ secrets.HOME_MINI_KNOWN_HOSTS }}
+        run: |
+          test -n "${HOME_MINI_SSH_KEY}"
+          test -n "${HOME_MINI_KNOWN_HOSTS}"
+
+          umask 077
+          mkdir -p "${HOME}/.ssh"
+          printf '%s\n' "${HOME_MINI_SSH_KEY}" >"${HOME}/.ssh/id_ed25519_home_mini_ci"
+          printf '%s\n' "${HOME_MINI_KNOWN_HOSTS}" >"${HOME}/.ssh/known_hosts"
+
+          ssh-keygen -y -f "${HOME}/.ssh/id_ed25519_home_mini_ci" >/dev/null
+          ssh-keygen -lf "${HOME}/.ssh/known_hosts" >/dev/null
+
+      - name: Inspect verified production runtime
+        env:
+          EXPECTED_APPLICATION_REVISION: ${{ inputs.expected_application_revision }}
+          EXPECTED_RUNTIME_CONFIG_REVISION: ${{ inputs.expected_runtime_config_revision }}
+          EXPECTED_RUNTIME_CONFIG_DIGEST: ${{ inputs.expected_runtime_config_digest }}
+          EXPECTED_DB_IMAGE: ${{ inputs.expected_db_image }}
+          EXPECTED_DB_VOLUME: ${{ inputs.expected_db_volume }}
+          EXPECTED_MYSQL_VERSION: ${{ inputs.expected_mysql_version }}
+        run: |
+          set -Eeuo pipefail
+
+          inspection_command="inspect-cubing-hub-runtime ${EXPECTED_APPLICATION_REVISION} ${EXPECTED_RUNTIME_CONFIG_REVISION} ${EXPECTED_RUNTIME_CONFIG_DIGEST} ${EXPECTED_DB_IMAGE} ${EXPECTED_DB_VOLUME} ${EXPECTED_MYSQL_VERSION}"
+          inspection_file="${RUNNER_TEMP}/cubing-hub-runtime-inspection"
+          umask 077
+          ssh \
+            -F /dev/null \
+            -i "${HOME}/.ssh/id_ed25519_home_mini_ci" \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            homeserver@home-mini \
+            "${inspection_command}" \
+            >"${inspection_file}"
+
+          test -f "${inspection_file}"
+          test ! -L "${inspection_file}"
+          /bin/bash ./homeserver/scripts/verify-runtime-baseline-inspection.sh \
+            "${EXPECTED_APPLICATION_REVISION}" \
+            "${EXPECTED_RUNTIME_CONFIG_REVISION}" \
+            "${EXPECTED_RUNTIME_CONFIG_DIGEST}" \
+            "${EXPECTED_DB_IMAGE}" \
+            "${EXPECTED_DB_VOLUME}" \
+            "${EXPECTED_MYSQL_VERSION}" \
+            <"${inspection_file}"
+
+      - name: Record reconciled runtime config baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_APPLICATION_REVISION: ${{ inputs.expected_application_revision }}
+          EXPECTED_RUNTIME_CONFIG_REVISION: ${{ inputs.expected_runtime_config_revision }}
+          EXPECTED_RUNTIME_CONFIG_DIGEST: ${{ inputs.expected_runtime_config_digest }}
+          EXPECTED_DB_IMAGE: ${{ inputs.expected_db_image }}
+          EXPECTED_DB_VOLUME: ${{ inputs.expected_db_volume }}
+          EXPECTED_MYSQL_VERSION: ${{ inputs.expected_mysql_version }}
+        run: |
+          result="$(
+            /bin/bash ./homeserver/scripts/record-runtime-config-baseline.sh \
+              maintenance-reconcile \
+              "${EXPECTED_APPLICATION_REVISION}" \
+              "${EXPECTED_RUNTIME_CONFIG_REVISION}" \
+              "${EXPECTED_RUNTIME_CONFIG_DIGEST}" \
+              "${EXPECTED_DB_IMAGE}" \
+              "${EXPECTED_DB_VOLUME}" \
+              "${EXPECTED_MYSQL_VERSION}"
+          )"
+          deployment_id="$(
+            sed -n 's/^deployment_id=//p' <<<"${result}" | tail -n 1
+          )"
+          [[ "${deployment_id}" =~ ^[0-9]+$ ]]
+          {
+            printf '## Production runtime config reconciliation\n\n'
+            printf -- '- Application revision: `%s`\n' "${EXPECTED_APPLICATION_REVISION}"
+            printf -- '- Runtime revision: `%s`\n' "${EXPECTED_RUNTIME_CONFIG_REVISION}"
+            printf -- '- Runtime digest: `%s`\n' "${EXPECTED_RUNTIME_CONFIG_DIGEST}"
+            printf -- '- DB image: `%s`\n' "${EXPECTED_DB_IMAGE}"
+            printf -- '- DB volume: `%s`\n' "${EXPECTED_DB_VOLUME}"
+            printf -- '- MySQL: `%s`\n' "${EXPECTED_MYSQL_VERSION}"
+            printf -- '- Runtime baseline deployment ID: `%s`\n' "${deployment_id}"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -126,13 +126,19 @@ jobs:
             homeserver/scripts/deploy-home-server.sh \
             homeserver/scripts/fixtures/mock-cubing-hub-curl.sh \
             homeserver/scripts/fixtures/mock-cubing-hub-docker.sh \
+            homeserver/scripts/fixtures/mock-github-deployments-curl.sh \
             homeserver/scripts/mysql-maintenance-home-server.sh \
+            homeserver/scripts/record-runtime-config-baseline.sh \
+            homeserver/scripts/resolve-runtime-config-baseline.sh \
             homeserver/scripts/test-backup-home-server.sh \
             homeserver/scripts/test-detect-data-service-maintenance.sh \
             homeserver/scripts/test-detect-runtime-config-change.sh \
             homeserver/scripts/test-deploy-home-server.sh \
             homeserver/scripts/test-mysql-maintenance-home-server.sh \
-            homeserver/scripts/test-runtime-script-bootstrap.sh
+            homeserver/scripts/test-runtime-baseline-inspection.sh \
+            homeserver/scripts/test-runtime-config-baseline.sh \
+            homeserver/scripts/test-runtime-script-bootstrap.sh \
+            homeserver/scripts/verify-runtime-baseline-inspection.sh
 
       - name: Verify runtime config change detection
         if: needs.changes.result == 'success' && needs.changes.outputs.infrastructure == 'true'
@@ -152,6 +158,8 @@ jobs:
           )" = update
           /bin/bash ./homeserver/scripts/test-detect-data-service-maintenance.sh
           /bin/bash ./homeserver/scripts/test-detect-runtime-config-change.sh
+          /bin/bash ./homeserver/scripts/test-runtime-config-baseline.sh
+          /bin/bash ./homeserver/scripts/test-runtime-baseline-inspection.sh
           /bin/bash ./homeserver/scripts/test-runtime-script-bootstrap.sh
 
       - name: Test deploy v2 state transitions

--- a/docs/03-architecture/deployment-architecture.md
+++ b/docs/03-architecture/deployment-architecture.md
@@ -24,13 +24,24 @@ Runtime configuration publication과 production deploy는 다음 release mode를
 - DB binding이 그대로인 runtime configuration update는 immutable artifact를 발행하고 정상 deploy로 동기화한다.
 - DB image 또는 MySQL volume binding이 바뀌는 release는 immutable artifact를 발행하지만 production deploy job을 시작하지 않는다. Dedicated data-service maintenance가 필요하다.
 
-Data-service 판정은 runtime 파일의 변경 여부가 아니라 마지막 정상 production deployment와 candidate revision의 Compose를 render한 effective DB image·volume name 비교를 사용한다. Production deployment 이력이 실제로 없을 때만 최초 bootstrap으로 처리한다. 이력은 있으나 성공 revision을 찾지 못하면 release를 중단한다. Runtime configuration 강제 동기화는 이 판정을 우회하지 않는다.
+Data-service 판정은 runtime 파일의 변경 여부가 아니라 마지막 정상 production runtime-config baseline과 candidate revision의 Compose를 render한 effective DB image·volume name 비교를 사용한다. Runtime configuration 강제 동기화는 이 판정을 우회하지 않는다.
 
 ## Deployment unit
 
 - API image와 Web image는 같은 40자리 application commit SHA를 사용한다.
 - runtime configuration은 exact sha256 digest와 revision label로 검증한다.
 - 정상 상태는 application SHA와 runtime configuration digest의 pair로 기록한다.
+
+## Production baseline
+
+GitHub deployment history는 production 상태의 두 축을 분리한다.
+
+- `production`은 API·Web application 배포 이력이다.
+- `production-runtime-config`는 production에 실제 적용하고 검증한 runtime-config revision·digest 이력이다.
+
+Release detector는 `production-runtime-config`의 마지막 success revision을 runtime 비교 기준으로 사용한다. Runtime baseline 이력이 아직 한 건도 없는 최초 전환에만 기존 `production` success를 bootstrap 기준으로 사용한다. Runtime baseline deployment가 존재하지만 success가 없으면 legacy 이력으로 fallback하지 않고 release를 중단한다. 두 environment 모두 이력이 없는 신규 설치는 zero revision에서 시작한다.
+
+Application-only release는 runtime baseline을 갱신하지 않는다. 안전한 runtime update는 production deploy와 health 검증이 성공한 뒤에만 candidate runtime revision을 success로 기록한다. Artifact publication만으로 baseline을 전진시키지 않는다.
 
 ## Migration
 
@@ -58,6 +69,8 @@ Maintenance도 deploy·backup과 같은 operation lock과 canonical `runtime-con
 
 Main release가 data-service maintenance를 요구하면 GitHub Actions는 runtime-config revision과 digest를 기록한 뒤 production environment, Tailscale, SSH 단계 전에 deploy job을 skip한다. Host deploy worker의 drift guard도 독립된 방어선으로 유지한다.
 
-Maintenance 완료는 일반 GitHub production deployment success가 아니다. Release detector의 기준인 마지막 정상 production deployment SHA는 그대로 남을 수 있으므로, 다음 normal deploy 전에 host의 적용 runtime과 GitHub deployment baseline을 맞추는 explicit post-maintenance 절차가 필요하다. 이 reconciliation이 끝나기 전 release는 maintenance-required로 계속 차단될 수 있다.
+Maintenance 완료는 일반 GitHub production application deployment success가 아니다. Host에서는 기존 application revision과 새 runtime-config revision이 함께 정상 상태를 이룰 수 있다.
+
+Post-maintenance reconciliation은 operator가 기대한 application revision, runtime revision·digest, DB image·volume, MySQL patch를 명시하고 production host를 read-only로 검사한다. Inspector는 verified `state`·`current`·release content, pending 부재, 실제 image·volume, MySQL version과 전체 service health가 모두 일치할 때만 성공한다. 그 뒤에만 `production-runtime-config` environment에 runtime baseline success를 기록한다. Reconciliation 전에는 normal production deploy를 재개하지 않는다.
 
 command-level 절차와 실제 target path는 [deployment runbook gateway](../07-operations/deployment-runbook.md)에서 canonical homeserver runbook으로 연결한다.

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -280,6 +280,7 @@ test "$(/usr/bin/shasum -a 256 "${source_script}" | /usr/bin/awk '{print $1}')" 
 - `/Users/homeserver/Server/apps/cubing-hub/runtime-config/pending` 부재
 - `.cubing-hub-operation.lock`을 사용하는 deploy·backup·maintenance 미실행
 - maintenance worker source/install SHA-256 일치
+- post-maintenance inspection을 지원하는 approved stable deploy wrapper 설치와 SHA-256 검증
 
 ### Immutable upgrade candidate
 
@@ -340,12 +341,42 @@ API·Web image drift, Redis·network·DB command drift, target image digest 불�
 10. users, records, user_pbs, posts/comments 수와 PB·Penalty 분포, Record ID·timestamp 범위를 pre-upgrade evidence와 대조한다.
 11. API health, auth, Record create/PATCH/delete, Ranking, Growth summary/trend/progression, Community와 image read smoke를 수행한다.
 12. 모든 gate가 끝난 뒤에만 write를 재개한다.
+13. MySQL 8.4.11 상태에서 post-upgrade backup을 생성하고 manifest·checksum을 검증한다.
+14. 아래 post-maintenance runtime baseline reconciliation을 성공시킨 뒤 normal production deploy를 재개한다.
 
 `apply`가 target DB startup 뒤 state/current 확정 전에 중단됐다면 normal deploy `recover`가 아니라 dedicated maintenance recovery를 사용한다. Recovery는 target DB identity와 health를 먼저 확인하고 `SELECT VERSION()`으로 candidate operation의 exact target patch를 다시 검증한 뒤 API·Web을 candidate binding으로 기동한다. 전체 service가 healthy인 경우에만 partial state를 확정한다.
 
 ```bash
 /Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh recover
 ```
+
+### Post-maintenance runtime baseline reconciliation
+
+MySQL maintenance 후 production state는 서로 다른 revision을 정상적으로 가질 수 있다.
+
+```text
+APPLICATION_REVISION=<기존 production application SHA>
+RUNTIME_CONFIG_REVISION=<MySQL 8.4.11 runtime release SHA>
+```
+
+Upgrade smoke와 post-upgrade backup까지 성공한 뒤 GitHub Actions의
+`Reconcile Production Runtime Baseline` workflow를 `main`에서 실행한다.
+`expected_application_revision`, `expected_runtime_config_revision`,
+`expected_runtime_config_digest`, exact `expected_db_image`,
+`expected_db_volume`, `expected_mysql_version=8.4.11`을 maintenance evidence와
+일치하게 입력한다.
+
+Workflow의 restricted SSH inspector는 production을 변경하지 않는다. Verified
+runtime state·current pointer·release content, pending 부재, 실제 DB image·volume,
+`SELECT VERSION()`, API/Web/DB/Redis health를 확인하고 operator 입력과 다시
+대조한다. 성공한 경우에만 별도 `production-runtime-config` deployment history에
+runtime revision·digest를 기록한다. 기존 `production` application deployment
+baseline은 유지한다.
+
+Runtime baseline success를 확인하기 전에는 normal production deploy를 재개하지
+않는다. Artifact publication이나 maintenance worker 성공만으로 GitHub baseline을
+갱신하지 않는다. Reconciliation 실패는 host runtime을 rollback하지 않으며,
+expected identity나 inspector 설치 상태를 고친 뒤 workflow를 다시 실행한다.
 
 ### Rollback
 

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -40,6 +40,7 @@ GitHub Actions는 GHCR token을 stdin으로 전달하고 forced-command SSH에�
 deploy-cubing-hub <40자리 commit SHA> <registry user>
 deploy-cubing-hub-v2 <40자리 commit SHA> keep <registry user>
 deploy-cubing-hub-v2 <40자리 commit SHA> update <config digest> <registry user>
+inspect-cubing-hub-runtime <application SHA> <runtime SHA> <runtime digest> <DB image tag@digest> <DB volume> <MySQL version>
 ```
 
 현재 운영 서버에서 v2 workflow를 `main`에 병합하기 전에는 아래 두 stable
@@ -65,7 +66,14 @@ pre-v2 또는 기존 2파일 release의 recovery fallback으로만 보존한다.
 함께 staging하며, 이후 worker 변경도 runtime-config 변경으로 감지해
 자동 동기화한다.
 
-마지막 성공 production deployment 이후 `homeserver/docker-compose.yml`,
+`inspect-cubing-hub-runtime`은 stable deploy wrapper에 포함되는 read-only
+forced command다. Post-maintenance reconciliation 전에 approved repository
+revision의 `deploy-home-server-ci.sh`를 기존 stable wrapper 설치 절차와 별도
+production 승인으로 반영하고 source/install SHA-256, mode `700`,
+`/bin/bash -n`을 다시 확인한다. 기존 설치본이 다르면 자동으로 덮어쓰지
+않는다.
+
+마지막 성공 production runtime-config baseline 이후 `homeserver/docker-compose.yml`,
 pinned Cloudflare real-IP 설정, 허용된 deploy/backup script,
 `.dockerignore`의 runtime artifact 입력 또는
 `homeserver/runtime-config.Dockerfile`이 변경된 배포만 immutable
@@ -93,9 +101,26 @@ DB image 또는 MySQL volume binding 변경
 → dedicated maintenance worker
 ```
 
-DB maintenance 판정은 마지막 정상 production deployment와 candidate revision의 Compose를 같은 project contract로 render하고 effective DB image와 MySQL volume name을 비교한다. Release workflow는 production deployment 이력을 pagination해 마지막 success를 찾는다. 이력이 실제로 없을 때만 최초 bootstrap을 허용하고, 이력은 있으나 success를 찾지 못하면 fail closed한다. `workflow_dispatch.sync_runtime_config=true`는 runtime-config publication을 강제할 뿐 이 판정을 우회하지 않는다.
+DB maintenance 판정은 마지막 정상 `production-runtime-config` baseline과 candidate revision의 Compose를 같은 project contract로 render하고 effective DB image와 MySQL volume name을 비교한다. Resolver는 runtime baseline 이력을 100개 단위로 끝까지 확인한다. Runtime baseline 이력이 전혀 없는 최초 전환에만 기존 `production` success를 bootstrap 기준으로 사용한다. Runtime 이력은 있으나 success가 없으면 fail closed하며 legacy production 이력으로 돌아가지 않는다. 두 environment 모두 이력이 없는 신규 설치는 zero revision에서 시작한다. `workflow_dispatch.sync_runtime_config=true`는 runtime-config publication을 강제할 뿐 이 판정을 우회하지 않는다.
 
 `MAC_MINI_DEPLOY_ENABLED=true`는 현재 publish job과 production deploy job을 모두 enable한다. Data-service maintenance가 필요하면 publish job은 API·Web과 runtime-config artifact를 발행하고, deploy job은 `data_service_maintenance_required` output으로 GitHub Actions에서 skip된다. Tailscale 연결과 SSH command는 실행되지 않는다. Workflow summary에는 runtime mode, runtime revision·digest, maintenance 필요 여부와 deploy skip 상태를 기록한다.
+
+GitHub deployment environment는 application과 runtime baseline을 분리한다.
+
+```text
+production
+→ 현재 API/Web application deployment history
+
+production-runtime-config
+→ production에 실제 적용하고 검증한 runtime-config history
+```
+
+Application-only `keep`은 runtime baseline을 갱신하지 않는다. Safe
+runtime-config `update`는 production deploy가 성공한 뒤 별도 job에서 runtime
+baseline success를 기록한다. Maintenance-required release는 artifact만
+발행하고 production deploy와 runtime baseline 기록을 모두 skip한다. Baseline
+recording이 실패하면 release는 실패 상태로 남고, 다음 release는 마지막으로
+확인된 success를 계속 사용한다.
 
 runtime-config image에는 아래 네 파일만 들어간다.
 
@@ -161,7 +186,38 @@ MySQL engine image·volume binding은 일반 deploy worker의 예외로 허용�
 
 Command별 exact 절차, fresh rollback volume 준비, dedicated recovery는 [DB와 이미지 백업·복구](db-backup-restore.md)를 따른다.
 
-Maintenance가 target runtime을 적용해도 GitHub의 마지막 정상 production deployment SHA는 이전 release를 가리킬 수 있다. 다음 application release는 같은 DB binding 변경을 다시 감지해 자동 deploy를 계속 차단할 수 있다. Host current runtime과 GitHub deployment baseline을 맞추는 post-maintenance release 절차를 별도로 확정하기 전에는 normal deploy를 재개하지 않는다.
+Maintenance가 target runtime을 적용하면 `APPLICATION_REVISION`은 기존
+application SHA를 유지하고 `RUNTIME_CONFIG_REVISION`만 maintenance release
+SHA로 바뀔 수 있다. 두 revision이 다른 것은 정상이다. MySQL upgrade smoke와
+post-upgrade backup이 끝나면 `Reconcile Production Runtime Baseline` workflow를
+`main`에서 수동 실행한다.
+
+입력은 아래 expected identity를 모두 명시한다.
+
+```text
+expected_application_revision
+expected_runtime_config_revision
+expected_runtime_config_digest
+expected_db_image
+expected_db_volume
+expected_mysql_version
+```
+
+Workflow는 `production-runtime-config` environment의 approval boundary 안에서
+Tailscale과 restricted SSH를 사용한다. Forced command는 operation lock을
+non-blocking으로 확인한 뒤 `state`, `current`, release content hash, pending
+부재, `.env`와 effective Compose binding, 실제 API/Web·DB image, DB volume,
+`SELECT VERSION()`, API/Web/DB/Redis health를 read-only로 검증한다. Host state는
+수정하지 않으며 exact expected value가 하나라도 다르면 GitHub baseline을
+기록하지 않는다.
+
+검증이 성공하면 `production-runtime-config`에 `maintenance-reconcile` success를
+기록한다. `production` application deployment 이력은 바꾸지 않는다. GitHub
+environment에 필요한 reviewer·secret은 repository 밖 운영 prerequisite다.
+Workflow job은 environment approval을 적용하되 별도 자동 deployment record는
+만들지 않도록 구성되어 있다. Custom deployment protection rule을 함께 쓰는
+경우 이 설정과 호환되지 않으므로 사전에 확인한다. Reconciliation success 전에는
+normal production deploy를 재개하지 않는다.
 
 첫 배포는 기존 image SHA가 없으므로 다음 순서로 진행한다.
 

--- a/homeserver/scripts/deploy-home-server-ci.sh
+++ b/homeserver/scripts/deploy-home-server-ci.sh
@@ -6,6 +6,7 @@ readonly DOCKER_BIN=/usr/local/bin/docker
 readonly LOCKF_BIN=/usr/bin/lockf
 readonly PYTHON_BIN=/usr/bin/python3
 readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub
+readonly ENV_FILE="${APP_DIR}/.env"
 readonly LEGACY_DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh
 readonly RUNTIME_CONFIG_ROOT="${APP_DIR}/runtime-config"
 readonly RUNTIME_CONFIG_RELEASES="${RUNTIME_CONFIG_ROOT}/releases"
@@ -14,6 +15,7 @@ readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
 readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
 readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
 readonly OPERATION_LOCK="${APP_DIR}/.cubing-hub-operation.lock"
+readonly PROJECT_NAME=cubing-hub
 readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
 readonly ZERO_SHA=0000000000000000000000000000000000000000
 readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
@@ -54,6 +56,43 @@ acquire_operation_lock() {
   exec 9>&-
   if [[ "${lock_status}" -eq 75 ]]; then
     printf 'Another Cubing Hub deploy or backup operation is already running\n' >&2
+    exit 75
+  fi
+  fail "operation lock validation failed"
+}
+
+acquire_inspection_lock() {
+  local lock_status
+
+  if [[ ! -x "${PYTHON_BIN}" ]]; then
+    fail "Python is not executable: ${PYTHON_BIN}"
+  fi
+  if [[ ! -x "${LOCKF_BIN}" ]]; then
+    fail "lockf is not executable: ${LOCKF_BIN}"
+  fi
+  if [[ ! -f "${OPERATION_LOCK}" || -L "${OPERATION_LOCK}" ]]; then
+    fail "operation lock must already be a regular non-symlink file"
+  fi
+  if ! "${PYTHON_BIN}" -c \
+    'import os, stat, sys; raise SystemExit(0 if stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o600 else 1)' \
+    "${OPERATION_LOCK}"
+  then
+    fail "operation lock mode must be 600"
+  fi
+  if ! exec 9<>"${OPERATION_LOCK}"; then
+    fail "operation lock file could not be opened"
+  fi
+
+  if "${LOCKF_BIN}" -s -t 0 9
+  then
+    return
+  else
+    lock_status="$?"
+  fi
+
+  exec 9>&-
+  if [[ "${lock_status}" -eq 75 ]]; then
+    printf 'Another Cubing Hub operation is already running\n' >&2
     exit 75
   fi
   fail "operation lock validation failed"
@@ -246,6 +285,309 @@ validate_verified_state() {
   printf '%s' "${release_dir}"
 }
 
+read_env_value() {
+  local key="$1"
+
+  "${PYTHON_BIN}" - "${ENV_FILE}" "${key}" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+key = sys.argv[2]
+if not path.is_file() or path.is_symlink():
+    raise SystemExit("production environment file is missing or unsafe")
+values = []
+for line in path.read_text(encoding="utf-8").splitlines():
+    candidate, separator, value = line.partition("=")
+    if separator and candidate == key:
+        values.append(value)
+if len(values) != 1 or not values[0]:
+    raise SystemExit(f"{key} must appear exactly once and be non-empty")
+print(values[0], end="")
+PY
+}
+
+inspection_compose() {
+  local api_image="$2"
+  local db_image="$4"
+  local db_volume="$5"
+  local release_dir="$1"
+  local web_image="$3"
+  shift 5
+
+  API_IMAGE="${api_image}" \
+  WEB_IMAGE="${web_image}" \
+  DB_IMAGE="${db_image}" \
+  DB_VOLUME_NAME="${db_volume}" \
+    "${DOCKER_BIN}" compose \
+      --project-name "${PROJECT_NAME}" \
+      --project-directory "${release_dir}" \
+      --env-file "${ENV_FILE}" \
+      --file "${release_dir}/compose.yaml" \
+      "$@"
+}
+
+validate_inspection_service_image() {
+  local actual_image_id
+  local actual_project
+  local actual_service
+  local container_id
+  local expected_image="$2"
+  local expected_image_id
+  local expected_image_revision
+  local expected_revision="$4"
+  local release_dir="$1"
+  local service="$3"
+
+  container_id="$(
+    inspection_compose \
+      "${release_dir}" \
+      "${inspection_api_image}" \
+      "${inspection_web_image}" \
+      "${inspection_db_image}" \
+      "${inspection_db_volume}" \
+      ps -q "${service}"
+  )"
+  [[ "${container_id}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] \
+    || fail "${service} container identity is missing or invalid"
+  expected_image_id="$("${DOCKER_BIN}" image inspect --format '{{.Id}}' "${expected_image}")"
+  expected_image_revision="$(
+    "${DOCKER_BIN}" image inspect \
+      --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+      "${expected_image}"
+  )"
+  actual_image_id="$("${DOCKER_BIN}" container inspect --format '{{.Image}}' "${container_id}")"
+  actual_project="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.project" }}' \
+      "${container_id}"
+  )"
+  actual_service="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.service" }}' \
+      "${container_id}"
+  )"
+  [[ "${expected_image_id}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    && [[ "${actual_image_id}" == "${expected_image_id}" ]] \
+    || fail "${service} container image does not match the committed application"
+  [[ "${expected_image_revision}" == "${expected_revision}" ]] \
+    || fail "${service} image revision label does not match the committed application"
+  [[ "${actual_project}" == "${PROJECT_NAME}" && "${actual_service}" == "${service}" ]] \
+    || fail "${service} container does not belong to the expected Compose service"
+}
+
+validate_inspection_service_set() {
+  local rendered="$1"
+
+  printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("no service status was returned")
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
+entries = value if isinstance(value, list) else [value]
+required = {"api", "db", "redis", "web"}
+seen = set()
+for entry in entries:
+    service = entry.get("Service")
+    if service not in required or str(entry.get("State", "")).lower() != "running":
+        raise SystemExit("production service set is not running")
+    seen.add(service)
+    health = str(entry.get("Health", "")).lower()
+    if service in {"db", "redis", "web"} and health != "healthy":
+        raise SystemExit("production service health is not ready")
+    if health and health != "healthy":
+        raise SystemExit("production service health is invalid")
+if seen != required:
+    raise SystemExit("production service set is incomplete")
+'
+}
+
+inspect_verified_runtime() {
+  local actual_db_health
+  local actual_db_image_id
+  local actual_db_project
+  local actual_db_service
+  local actual_db_volume
+  local actual_mysql_version
+  local current_pointer
+  local db_container_id
+  local effective_db_contract
+  local expected_application_revision="$1"
+  local expected_db_image="$4"
+  local expected_db_volume="$5"
+  local expected_mysql_version="$6"
+  local expected_runtime_digest="$3"
+  local expected_runtime_revision="$2"
+  local expected_db_image_id
+  local inspection_api_image
+  local inspection_db_image
+  local inspection_db_volume
+  local inspection_web_image
+  local release_dir
+  local service_status
+  local volume_users
+
+  if [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+    fail "runtime config transaction is pending"
+  fi
+  release_dir="$(validate_verified_state)"
+  [[ -n "${release_dir}" ]] || fail "verified runtime config state is unavailable"
+  [[ "$(validate_release "${release_dir}")" == synced ]] \
+    || fail "runtime inspection requires a script-enabled release"
+
+  [[ "$(read_state_value APPLICATION_REVISION)" == "${expected_application_revision}" ]] \
+    || fail "application revision does not match inspection intent"
+  [[ "$(read_state_value RUNTIME_CONFIG_REVISION)" == "${expected_runtime_revision}" ]] \
+    || fail "runtime config revision does not match inspection intent"
+  [[ "$(read_state_value RUNTIME_CONFIG_DIGEST)" == "${expected_runtime_digest}" ]] \
+    || fail "runtime config digest does not match inspection intent"
+
+  inspection_api_image="$(read_env_value API_IMAGE)"
+  inspection_web_image="$(read_env_value WEB_IMAGE)"
+  inspection_db_image="$(read_env_value DB_IMAGE)"
+  inspection_db_volume="$(read_env_value DB_VOLUME_NAME)"
+  [[ "${inspection_api_image}" == "ghcr.io/xxh3898/cubing-hub-api:${expected_application_revision}" ]] \
+    || fail "API image does not match the committed application revision"
+  [[ "${inspection_web_image}" == "ghcr.io/xxh3898/cubing-hub-web:${expected_application_revision}" ]] \
+    || fail "Web image does not match the committed application revision"
+  [[ "${inspection_db_image}" == "${expected_db_image}" ]] \
+    || fail "DB image does not match inspection intent"
+  [[ "${inspection_db_volume}" == "${expected_db_volume}" ]] \
+    || fail "DB volume does not match inspection intent"
+
+  effective_db_contract="$(
+    inspection_compose \
+      "${release_dir}" \
+      "${inspection_api_image}" \
+      "${inspection_web_image}" \
+      "${inspection_db_image}" \
+      "${inspection_db_volume}" \
+      config --format json \
+      | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+config = json.load(sys.stdin)
+db = config.get("services", {}).get("db", {})
+volume = config.get("volumes", {}).get("mysql-data", {})
+mounts = [
+    item for item in db.get("volumes", [])
+    if isinstance(item, dict) and item.get("target") == "/var/lib/mysql"
+]
+if (
+    len(mounts) != 1
+    or mounts[0].get("type") != "volume"
+    or mounts[0].get("source") != "mysql-data"
+):
+    raise SystemExit("effective MySQL mount is invalid")
+print("{}\t{}".format(db.get("image", ""), volume.get("name", "")), end="")
+'
+  )" || fail "effective DB binding could not be rendered"
+  [[ "${effective_db_contract}" == "${expected_db_image}"$'\t'"${expected_db_volume}" ]] \
+    || fail "effective DB binding does not match inspection intent"
+
+  validate_inspection_service_image \
+    "${release_dir}" "${inspection_api_image}" api \
+    "${expected_application_revision}"
+  validate_inspection_service_image \
+    "${release_dir}" "${inspection_web_image}" web \
+    "${expected_application_revision}"
+
+  db_container_id="$(
+    inspection_compose \
+      "${release_dir}" \
+      "${inspection_api_image}" \
+      "${inspection_web_image}" \
+      "${inspection_db_image}" \
+      "${inspection_db_volume}" \
+      ps -q db
+  )"
+  [[ "${db_container_id}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] \
+    || fail "DB container identity is missing or invalid"
+  expected_db_image_id="$("${DOCKER_BIN}" image inspect --format '{{.Id}}' "${expected_db_image}")"
+  actual_db_image_id="$("${DOCKER_BIN}" container inspect --format '{{.Image}}' "${db_container_id}")"
+  actual_db_volume="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{range .Mounts}}{{if eq .Destination "/var/lib/mysql"}}{{.Name}}{{end}}{{end}}' \
+      "${db_container_id}"
+  )"
+  actual_db_project="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.project" }}' \
+      "${db_container_id}"
+  )"
+  actual_db_service="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.service" }}' \
+      "${db_container_id}"
+  )"
+  actual_db_health="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+      "${db_container_id}"
+  )"
+  volume_users="$(
+    "${DOCKER_BIN}" ps -a --no-trunc \
+      --filter "volume=${expected_db_volume}" \
+      --format '{{.ID}}'
+  )"
+  [[ "${expected_db_image_id}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    && [[ "${actual_db_image_id}" == "${expected_db_image_id}" ]] \
+    || fail "actual DB image does not match inspection intent"
+  [[ "${actual_db_volume}" == "${expected_db_volume}" ]] \
+    || fail "actual DB volume does not match inspection intent"
+  [[ "${actual_db_project}" == "${PROJECT_NAME}" && "${actual_db_service}" == db ]] \
+    || fail "actual DB container does not belong to the production Compose service"
+  [[ "${actual_db_health}" == healthy && "${volume_users}" == "${db_container_id}" ]] \
+    || fail "actual DB health or exclusive volume attachment is invalid"
+
+  actual_mysql_version="$(
+    "${DOCKER_BIN}" exec --env MAINTENANCE_QUERY=running-version \
+      "${db_container_id}" /bin/sh -ceu '
+        export MYSQL_PWD="${MYSQL_ROOT_PASSWORD}"
+        exec mysql --user=root --batch --skip-column-names "${MYSQL_DATABASE}" \
+          --execute "SELECT VERSION()"
+      '
+  )" || fail "running MySQL version query failed"
+  if [[ "${actual_mysql_version}" != "${expected_mysql_version}" ]] \
+    && [[ "${actual_mysql_version}" != "${expected_mysql_version}"-* ]] \
+    && [[ "${actual_mysql_version}" != "${expected_mysql_version}"+* ]]
+  then
+    fail "running MySQL version does not match inspection intent"
+  fi
+
+  service_status="$(
+    inspection_compose \
+      "${release_dir}" \
+      "${inspection_api_image}" \
+      "${inspection_web_image}" \
+      "${inspection_db_image}" \
+      "${inspection_db_volume}" \
+      ps --format json
+  )"
+  validate_inspection_service_set "${service_status}" \
+    || fail "production service set is unhealthy"
+
+  current_pointer="$(/usr/bin/readlink "${RUNTIME_CONFIG_CURRENT}")"
+  printf 'APPLICATION_REVISION=%s\n' "${expected_application_revision}"
+  printf 'RUNTIME_CONFIG_REVISION=%s\n' "${expected_runtime_revision}"
+  printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${expected_runtime_digest}"
+  printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' \
+    "$(read_state_value RUNTIME_CONFIG_CONTENT_SHA256)"
+  printf 'CURRENT_POINTER=%s\n' "${current_pointer}"
+  printf 'PENDING=none\n'
+  printf 'DB_IMAGE=%s\n' "${expected_db_image}"
+  printf 'DB_VOLUME_NAME=%s\n' "${expected_db_volume}"
+  printf 'MYSQL_VERSION=%s\n' "${actual_mysql_version}"
+  printf 'SERVICE_SET=healthy\n'
+}
+
 validated_recovery_release() {
   local expected_content_sha
   local release_dir
@@ -293,6 +635,32 @@ if [[ "$#" -ne 0 ]]; then
 fi
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
+if [[ "${original_command}" =~ ^inspect-cubing-hub-runtime[[:space:]]([0-9a-f]{40})[[:space:]]([0-9a-f]{40})[[:space:]](sha256:[0-9a-f]{64})[[:space:]](mysql:[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64})[[:space:]]([A-Za-z0-9][A-Za-z0-9_.-]{0,127})[[:space:]]([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  expected_application_revision="${BASH_REMATCH[1]}"
+  expected_runtime_revision="${BASH_REMATCH[2]}"
+  expected_runtime_digest="${BASH_REMATCH[3]}"
+  expected_db_image="${BASH_REMATCH[4]}"
+  expected_db_volume="${BASH_REMATCH[5]}"
+  expected_mysql_version="${BASH_REMATCH[6]}"
+  expected_image_version="${expected_db_image#mysql:}"
+  expected_image_version="${expected_image_version%@sha256:*}"
+  [[ "${expected_image_version}" == "${expected_mysql_version}" ]] \
+    || fail "expected DB image and MySQL version are inconsistent"
+  acquire_inspection_lock
+  [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]] \
+    || fail "runtime config transaction is pending"
+  if [[ ! -x "${DOCKER_BIN}" ]]; then
+    fail "Docker CLI is not executable: ${DOCKER_BIN}"
+  fi
+  inspect_verified_runtime \
+    "${expected_application_revision}" \
+    "${expected_runtime_revision}" \
+    "${expected_runtime_digest}" \
+    "${expected_db_image}" \
+    "${expected_db_volume}" \
+    "${expected_mysql_version}"
+  exit 0
+fi
 if [[ "${original_command}" =~ ^deploy-cubing-hub[[:space:]]([0-9a-fA-F]{40})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
   acquire_operation_lock
   exec "${LEGACY_DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
@@ -314,7 +682,7 @@ elif [[ "${original_command}" =~ ^deploy-cubing-hub-v2[[:space:]]([0-9a-f]{40})[
   registry_user="${BASH_REMATCH[3]}"
 else
   printf '%s\n' \
-    'Only deploy-cubing-hub or strictly formatted deploy-cubing-hub-v2 commands are allowed' \
+    'Only deploy-cubing-hub, deploy-cubing-hub-v2, or inspect-cubing-hub-runtime commands are allowed' \
     >&2
   exit 64
 fi

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -121,7 +121,11 @@ case "${command_name}" in
     format="$1"
     container_id="$2"
     if [[ "${format}" == '{{.Image}}' ]]; then
-      if [[ "${container_id}" == "${FAKE_RESTORE_CONTAINER:-mock-restore-db}" ]] \
+      if [[ "${container_id}" == "${FAKE_API_CONTAINER_ID:-mock-api-container}" ]]; then
+        printf '%s\n' "${FAKE_ACTUAL_API_IMAGE_ID:-${FAKE_DEFAULT_IMAGE_ID:-sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd}}"
+      elif [[ "${container_id}" == "${FAKE_WEB_CONTAINER_ID:-mock-web-container}" ]]; then
+        printf '%s\n' "${FAKE_ACTUAL_WEB_IMAGE_ID:-${FAKE_DEFAULT_IMAGE_ID:-sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd}}"
+      elif [[ "${container_id}" == "${FAKE_RESTORE_CONTAINER:-mock-restore-db}" ]] \
         || [[ "${container_id}" == cubing-hub-mysql-rollback-validation-* ]]
       then
         printf '%s\n' "${FAKE_RESTORE_IMAGE_ID:-${FAKE_MYSQL_80_IMAGE_ID:-sha256:8080808080808080808080808080808080808080808080808080808080808080}}"
@@ -143,7 +147,11 @@ case "${command_name}" in
     elif [[ "${format}" == *com.docker.compose.project* ]]; then
       printf '%s\n' "${FAKE_ACTUAL_DB_PROJECT:-cubing-hub}"
     elif [[ "${format}" == *com.docker.compose.service* ]]; then
-      printf '%s\n' "${FAKE_ACTUAL_DB_SERVICE:-db}"
+      case "${container_id}" in
+        "${FAKE_API_CONTAINER_ID:-mock-api-container}") printf 'api\n' ;;
+        "${FAKE_WEB_CONTAINER_ID:-mock-web-container}") printf 'web\n' ;;
+        *) printf '%s\n' "${FAKE_ACTUAL_DB_SERVICE:-db}" ;;
+      esac
     elif [[ "${format}" == *io.chochiho.cubing-hub.mysql-restore-backup* ]]; then
       printf '%s\n' "${FAKE_RESTORE_BACKUP_ID:-cubing-hub-production-20260813T000000Z}"
     elif [[ "${format}" == '{{.State.Status}}' ]]; then
@@ -307,6 +315,10 @@ users}"
       else
         printf '%s\n' "${FAKE_DB_CONTAINER_ID:-mock-db-container}"
       fi
+    elif [[ "${arguments}" == *" ps -q api "* ]]; then
+      printf '%s\n' "${FAKE_API_CONTAINER_ID:-mock-api-container}"
+    elif [[ "${arguments}" == *" ps -q web "* ]]; then
+      printf '%s\n' "${FAKE_WEB_CONTAINER_ID:-mock-web-container}"
     elif [[ "${arguments}" == *" ps --format json "* ]]; then
       service_health="${FAKE_SERVICE_HEALTH:-healthy}"
       api_health="${FAKE_API_HEALTH:-}"

--- a/homeserver/scripts/fixtures/mock-github-deployments-curl.sh
+++ b/homeserver/scripts/fixtures/mock-github-deployments-curl.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+method=GET
+data=
+url=
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --request)
+      method="$2"
+      shift 2
+      ;;
+    --data)
+      data="$2"
+      shift 2
+      ;;
+    --header|--retry)
+      shift 2
+      ;;
+    --fail|--silent|--show-error)
+      shift
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      printf 'Unexpected mock curl argument: %s\n' "$1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+[[ -n "${url}" ]] || exit 64
+[[ -d "${FAKE_GITHUB_API_FIXTURE_DIR:-}" ]] || exit 64
+
+if [[ -n "${FAKE_GITHUB_API_LOG:-}" ]]; then
+  jq -cn \
+    --arg method "${method}" \
+    --arg url "${url}" \
+    --argjson data "${data:-null}" \
+    '{method: $method, url: $url, data: $data}' \
+    >>"${FAKE_GITHUB_API_LOG}"
+fi
+
+case "${method} ${url}" in
+  "GET "*'/deployments?'*)
+    environment="$(
+      /usr/bin/sed -E 's#.*[?&]environment=([^&]+).*#\1#' <<<"${url}"
+    )"
+    page="$(/usr/bin/sed -E 's#.*[?&]page=([0-9]+).*#\1#' <<<"${url}")"
+    fixture="${FAKE_GITHUB_API_FIXTURE_DIR}/${environment}-deployments-page-${page}.json"
+    ;;
+  "GET "*'/deployments/'*'/statuses?'*)
+    deployment_id="$(
+      /usr/bin/sed -E 's#^.*/deployments/([0-9]+)/statuses.*#\1#' <<<"${url}"
+    )"
+    fixture="${FAKE_GITHUB_API_FIXTURE_DIR}/deployment-${deployment_id}-statuses.json"
+    ;;
+  "POST "*'/deployments/'*'/statuses')
+    [[ "${FAKE_GITHUB_STATUS_FAIL:-false}" != true ]] || exit 22
+    deployment_id="$(
+      /usr/bin/sed -E 's#^.*/deployments/([0-9]+)/statuses$#\1#' <<<"${url}"
+    )"
+    state="${FAKE_GITHUB_STATUS_STATE:-success}"
+    environment="$(jq -r '.environment' <<<"${data}")"
+    jq -cn \
+      --argjson id "${deployment_id}" \
+      --arg state "${state}" \
+      --arg environment "${environment}" \
+      '{id: $id, state: $state, environment: $environment}'
+    exit 0
+    ;;
+  "POST "*'/deployments')
+    [[ "${FAKE_GITHUB_DEPLOYMENT_FAIL:-false}" != true ]] || exit 22
+    deployment_id="${FAKE_GITHUB_DEPLOYMENT_ID:-900}"
+    revision="$(jq -r '.ref' <<<"${data}")"
+    environment="$(jq -r '.environment' <<<"${data}")"
+    jq -cn \
+      --argjson id "${deployment_id}" \
+      --arg sha "${revision}" \
+      --arg environment "${environment}" \
+      '{id: $id, sha: $sha, environment: $environment}'
+    exit 0
+    ;;
+  *)
+    printf 'Unexpected mock GitHub API request: %s %s\n' "${method}" "${url}" >&2
+    exit 64
+    ;;
+esac
+
+[[ -f "${fixture}" ]] || exit 22
+/bin/cat "${fixture}"

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -129,6 +129,22 @@ test("should_allowOnlyRestrictedDeployCommand_when_ciConnectsOverSsh", () => {
     restrictedWrapper,
     /deploy-cubing-hub-v2[\s\S]*keep[\s\S]*deploy-cubing-hub-v2[\s\S]*update/,
   );
+  assert.match(
+    restrictedWrapper,
+    /inspect-cubing-hub-runtime\[\[:space:\]\]\(\[0-9a-f\]\{40\}\)/,
+  );
+  assert.match(
+    restrictedWrapper,
+    /inspect_verified_runtime[\s\S]*SELECT VERSION\(\)[\s\S]*SERVICE_SET=healthy/,
+  );
+  const inspector = restrictedWrapper.slice(
+    restrictedWrapper.indexOf("inspect_verified_runtime()"),
+    restrictedWrapper.indexOf("validated_recovery_release()"),
+  );
+  assert.doesNotMatch(
+    inspector,
+    /compose[\s\S]*(?:\bup\b|\bdown\b)|write_state|write_env|ln -s|volume rm/,
+  );
   assert.doesNotMatch(restrictedWrapper, /eval|bash -c|sh -c/);
   assert.match(
     restrictedWrapper,

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -145,7 +145,20 @@ test("should_allowOnlyRestrictedDeployCommand_when_ciConnectsOverSsh", () => {
     inspector,
     /compose[\s\S]*(?:\bup\b|\bdown\b)|write_state|write_env|ln -s|volume rm/,
   );
-  assert.doesNotMatch(restrictedWrapper, /eval|bash -c|sh -c/);
+  const forcedCommandStart = restrictedWrapper.indexOf(
+    'original_command="${SSH_ORIGINAL_COMMAND:-}"',
+  );
+  const forcedCommandEnd = restrictedWrapper.indexOf(
+    'registry_token="$(/bin/cat)"',
+    forcedCommandStart,
+  );
+  assert.ok(forcedCommandStart >= 0);
+  assert.ok(forcedCommandEnd > forcedCommandStart);
+  const forcedCommandDispatch = restrictedWrapper.slice(
+    forcedCommandStart,
+    forcedCommandEnd,
+  );
+  assert.doesNotMatch(forcedCommandDispatch, /eval|bash -c|sh -c/);
   assert.match(
     restrictedWrapper,
     /\/Users\/homeserver\/Server\/scripts\/deploy\/deploy-cubing-hub\.sh/,

--- a/homeserver/scripts/record-runtime-config-baseline.sh
+++ b/homeserver/scripts/record-runtime-config-baseline.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly CURL_BIN="${CURL_BIN:-curl}"
+readonly JQ_BIN="${JQ_BIN:-jq}"
+readonly RUNTIME_ENVIRONMENT=production-runtime-config
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+fail() {
+  printf 'Runtime config baseline recording failed: %s\n' "$1" >&2
+  exit 1
+}
+
+if [[ "$#" -ne 7 ]]; then
+  printf '%s\n' \
+    'Usage: record-runtime-config-baseline.sh <operation> <application-revision> <runtime-revision> <runtime-digest> <db-image|-> <db-volume|-> <mysql-version|->' \
+    >&2
+  exit 64
+fi
+
+operation="$1"
+application_revision="$2"
+runtime_revision="$3"
+runtime_digest="$4"
+db_image="$5"
+db_volume="$6"
+mysql_version="$7"
+db_image_version=
+
+case "${operation}" in
+  normal-update|maintenance-reconcile)
+    ;;
+  *)
+    printf 'Runtime baseline operation is invalid\n' >&2
+    exit 64
+    ;;
+esac
+if [[ ! "${application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "${runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "${runtime_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || [[ "${application_revision}" == "${ZERO_SHA}" ]] \
+  || [[ "${runtime_revision}" == "${ZERO_SHA}" ]] \
+  || [[ "${runtime_digest}" == "${ZERO_DIGEST}" ]]
+then
+  printf 'Runtime baseline identity is invalid\n' >&2
+  exit 64
+fi
+if [[ "${db_image}" == - && "${db_volume}" == - && "${mysql_version}" == - ]]; then
+  if [[ "${operation}" == maintenance-reconcile ]]; then
+    printf 'Maintenance reconciliation requires an exact DB binding\n' >&2
+    exit 64
+  fi
+elif [[ "${db_image}" =~ ^mysql:[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$ ]] \
+  && [[ "${db_volume}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]] \
+  && [[ "${mysql_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+then
+  db_image_version="${db_image#mysql:}"
+  db_image_version="${db_image_version%@sha256:*}"
+  if [[ "${db_image_version}" != "${mysql_version}" ]]; then
+    printf 'Runtime baseline DB version is inconsistent\n' >&2
+    exit 64
+  fi
+else
+  printf 'Runtime baseline DB identity is invalid\n' >&2
+  exit 64
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]] \
+  || [[ -z "${GITHUB_API_URL:-}" ]] \
+  || [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+then
+  printf 'GitHub API context is incomplete\n' >&2
+  exit 64
+fi
+if ! command -v "${CURL_BIN}" >/dev/null 2>&1 \
+  || ! command -v "${JQ_BIN}" >/dev/null 2>&1
+then
+  fail "curl or jq is unavailable"
+fi
+
+payload="$({
+  "${JQ_BIN}" -n \
+    --arg operation "${operation}" \
+    --arg application_revision "${application_revision}" \
+    --arg runtime_revision "${runtime_revision}" \
+    --arg runtime_digest "${runtime_digest}" \
+    --arg db_image "${db_image}" \
+    --arg db_volume "${db_volume}" \
+    --arg mysql_version "${mysql_version}" '
+      {
+        operation: $operation,
+        applicationRevision: $application_revision,
+        runtimeConfigRevision: $runtime_revision,
+        runtimeConfigDigest: $runtime_digest
+      }
+      + if $db_image == "-" then {}
+        else {
+          dbImage: $db_image,
+          dbVolume: $db_volume,
+          mysqlVersion: $mysql_version
+        }
+        end
+    '
+})"
+
+deployment_request="$({
+  "${JQ_BIN}" -n \
+    --arg ref "${runtime_revision}" \
+    --arg environment "${RUNTIME_ENVIRONMENT}" \
+    --arg description "Verified production runtime config (${operation})" \
+    --argjson payload "${payload}" '
+      {
+        ref: $ref,
+        task: "runtime-config:baseline",
+        auto_merge: false,
+        required_contexts: [],
+        payload: $payload,
+        environment: $environment,
+        description: $description,
+        transient_environment: false,
+        production_environment: true
+      }
+    '
+})"
+
+deployment_response="$(
+  "${CURL_BIN}" \
+    --fail \
+    --retry 3 \
+    --silent \
+    --show-error \
+    --request POST \
+    --header 'Accept: application/vnd.github+json' \
+    --header "Authorization: Bearer ${GH_TOKEN}" \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header 'Content-Type: application/json' \
+    --data "${deployment_request}" \
+    "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments"
+)" || fail "deployment creation request failed"
+
+if ! "${JQ_BIN}" -e \
+  --arg revision "${runtime_revision}" \
+  --arg environment "${RUNTIME_ENVIRONMENT}" '
+    (.id | type == "number") and
+    .sha == $revision and
+    .environment == $environment
+  ' <<<"${deployment_response}" >/dev/null
+then
+  fail "deployment creation response is invalid"
+fi
+deployment_id="$("${JQ_BIN}" -r '.id' <<<"${deployment_response}")"
+
+status_request="$({
+  "${JQ_BIN}" -n \
+    --arg environment "${RUNTIME_ENVIRONMENT}" \
+    --arg description 'Production runtime config verified' '
+      {
+        state: "success",
+        environment: $environment,
+        description: $description,
+        auto_inactive: false
+      }
+    '
+})"
+
+status_response="$(
+  "${CURL_BIN}" \
+    --fail \
+    --retry 3 \
+    --silent \
+    --show-error \
+    --request POST \
+    --header 'Accept: application/vnd.github+json' \
+    --header "Authorization: Bearer ${GH_TOKEN}" \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header 'Content-Type: application/json' \
+    --data "${status_request}" \
+    "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses"
+)" || fail "deployment success status request failed"
+
+if ! "${JQ_BIN}" -e \
+  --arg environment "${RUNTIME_ENVIRONMENT}" '
+    (.id | type == "number") and
+    .state == "success" and
+    .environment == $environment
+  ' <<<"${status_response}" >/dev/null
+then
+  fail "deployment success status response is invalid"
+fi
+
+printf 'deployment_id=%s\n' "${deployment_id}"

--- a/homeserver/scripts/resolve-runtime-config-baseline.sh
+++ b/homeserver/scripts/resolve-runtime-config-baseline.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly CURL_BIN="${CURL_BIN:-curl}"
+readonly JQ_BIN="${JQ_BIN:-jq}"
+readonly RUNTIME_ENVIRONMENT=production-runtime-config
+readonly LEGACY_ENVIRONMENT=production
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+readonly PAGE_SIZE=100
+
+fail() {
+  printf 'Runtime config baseline resolution failed: %s\n' "$1" >&2
+  exit 1
+}
+
+if [[ "$#" -ne 0 ]]; then
+  printf 'Usage: resolve-runtime-config-baseline.sh\n' >&2
+  exit 64
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]] \
+  || [[ -z "${GITHUB_API_URL:-}" ]] \
+  || [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+then
+  printf 'GitHub API context is incomplete\n' >&2
+  exit 64
+fi
+if ! command -v "${CURL_BIN}" >/dev/null 2>&1 \
+  || ! command -v "${JQ_BIN}" >/dev/null 2>&1
+then
+  fail "curl or jq is unavailable"
+fi
+
+api_get() {
+  "${CURL_BIN}" \
+    --fail \
+    --retry 3 \
+    --silent \
+    --show-error \
+    --header 'Accept: application/vnd.github+json' \
+    --header "Authorization: Bearer ${GH_TOKEN}" \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    "$1"
+}
+
+resolved_sha=
+resolved_digest=
+resolution_state=
+
+resolve_environment() {
+  local deployment_count
+  local deployment_id
+  local deployment_digest
+  local deployment_sha
+  local deployments
+  local environment="$1"
+  local history_kind="$2"
+  local page=1
+  local saw_deployment=false
+  local state
+  local statuses
+
+  resolved_sha=
+  resolved_digest=
+  resolution_state=
+  while :; do
+    deployments="$(
+      api_get \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments?environment=${environment}&per_page=${PAGE_SIZE}&page=${page}"
+    )" || fail "${environment} deployment history request failed"
+    if ! "${JQ_BIN}" -e \
+      --arg environment "${environment}" \
+      --arg history_kind "${history_kind}" \
+      --arg zero_digest "${ZERO_DIGEST}" \
+      --arg zero_sha "${ZERO_SHA}" \
+      'type == "array" and all(.[];
+        (.id | type == "number") and
+        (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+        .sha != $zero_sha and
+        .environment == $environment and
+        ($history_kind != "runtime" or (
+          .task == "runtime-config:baseline" and
+          (.payload | type == "object") and
+          (.payload.operation == "normal-update" or
+           .payload.operation == "maintenance-reconcile") and
+          (.payload.applicationRevision |
+            type == "string" and test("^[0-9a-f]{40}$")) and
+          .payload.applicationRevision != $zero_sha and
+          .payload.runtimeConfigRevision == .sha and
+          (.payload.runtimeConfigDigest |
+            type == "string" and test("^sha256:[0-9a-f]{64}$")) and
+          .payload.runtimeConfigDigest != $zero_digest and
+          (.payload.operation != "maintenance-reconcile" or (
+            (.payload.dbImage |
+              type == "string" and
+              test("^mysql:[0-9]+\\.[0-9]+\\.[0-9]+@sha256:[0-9a-f]{64}$")) and
+            (.payload.dbVolume |
+              type == "string" and
+              test("^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")) and
+            (.payload.mysqlVersion |
+              type == "string" and
+              test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+            (.payload.dbImage |
+              capture("^mysql:(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)@sha256:").version) ==
+              .payload.mysqlVersion
+          ))
+        ))
+      )' \
+      <<<"${deployments}" >/dev/null
+    then
+      fail "${environment} deployment history response is invalid"
+    fi
+    deployment_count="$("${JQ_BIN}" -r 'length' <<<"${deployments}")"
+    if [[ "${deployment_count}" -eq 0 ]]; then
+      if [[ "${saw_deployment}" == false ]]; then
+        resolution_state=empty
+      else
+        resolution_state=no-success
+      fi
+      return
+    fi
+    saw_deployment=true
+
+    while IFS=$'\t' read -r \
+      deployment_id deployment_sha deployment_digest
+    do
+      statuses="$(
+        api_get \
+          "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses?per_page=1"
+      )" || fail "${environment} deployment status request failed"
+      if ! "${JQ_BIN}" -e \
+        'type == "array" and all(.[];
+          (.state | type == "string") and
+          (.state == "error" or
+           .state == "failure" or
+           .state == "inactive" or
+           .state == "in_progress" or
+           .state == "queued" or
+           .state == "pending" or
+           .state == "success")
+        )' \
+        <<<"${statuses}" >/dev/null
+      then
+        fail "${environment} deployment status response is invalid"
+      fi
+      state="$("${JQ_BIN}" -r '.[0].state // empty' <<<"${statuses}")"
+      if [[ "${state}" == success ]]; then
+        resolved_sha="${deployment_sha}"
+        resolved_digest="${deployment_digest}"
+        resolution_state=success
+        return
+      fi
+    done < <(
+      "${JQ_BIN}" -r \
+        '.[] | [.id, .sha, (.payload.runtimeConfigDigest // "-")] | @tsv' \
+        <<<"${deployments}"
+    )
+
+    if [[ "${deployment_count}" -lt "${PAGE_SIZE}" ]]; then
+      resolution_state=no-success
+      return
+    fi
+    page="$((page + 1))"
+  done
+}
+
+resolve_environment "${RUNTIME_ENVIRONMENT}" runtime
+case "${resolution_state}" in
+  success)
+    baseline_revision="${resolved_sha}"
+    baseline_digest="${resolved_digest}"
+    baseline_source=runtime
+    ;;
+  empty)
+    resolve_environment "${LEGACY_ENVIRONMENT}" legacy
+    case "${resolution_state}" in
+      success)
+        baseline_revision="${resolved_sha}"
+        baseline_digest="${ZERO_DIGEST}"
+        baseline_source=legacy-bootstrap
+        ;;
+      empty)
+        baseline_revision="${ZERO_SHA}"
+        baseline_digest="${ZERO_DIGEST}"
+        baseline_source=new-install-bootstrap
+        ;;
+      no-success)
+        fail "legacy production deployments exist without a successful revision"
+        ;;
+      *)
+        fail "legacy production baseline state is invalid"
+        ;;
+    esac
+    ;;
+  no-success)
+    fail "runtime config deployments exist without a successful baseline"
+    ;;
+  *)
+    fail "runtime config baseline state is invalid"
+    ;;
+esac
+
+[[ "${baseline_revision}" =~ ^[0-9a-f]{40}$ ]] \
+  || fail "resolved revision has an unexpected format"
+[[ "${baseline_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || fail "resolved digest has an unexpected format"
+if [[ "${baseline_source}" == runtime && "${baseline_digest}" == "${ZERO_DIGEST}" ]]; then
+  fail "verified runtime baseline digest must not be zero"
+fi
+
+printf 'digest=%s\n' "${baseline_digest}"
+printf 'revision=%s\n' "${baseline_revision}"
+printf 'source=%s\n' "${baseline_source}"

--- a/homeserver/scripts/test-detect-data-service-maintenance.sh
+++ b/homeserver/scripts/test-detect-data-service-maintenance.sh
@@ -6,6 +6,7 @@ readonly PROJECT_ROOT="$(
   CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
 )"
 readonly DETECTOR="${PROJECT_ROOT}/homeserver/scripts/detect-data-service-maintenance.sh"
+readonly RUNTIME_DETECTOR="${PROJECT_ROOT}/homeserver/scripts/detect-runtime-config-change.sh"
 
 test_root="$(
   /usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-data-service-detector-test.XXXXXX"
@@ -202,5 +203,70 @@ if (
   printf 'Missing candidate revision was accepted\n' >&2
   exit 1
 fi
+
+# A legacy application/runtime baseline must keep detecting the 8.4 binding as
+# maintenance until reconciliation advances only the runtime baseline to M.
+flow_dir="${test_root}/post-maintenance-flow"
+/bin/mkdir -p "${flow_dir}/homeserver" "${flow_dir}/frontend"
+git -C "${flow_dir}" init --quiet
+git -C "${flow_dir}" config user.email test@example.invalid
+git -C "${flow_dir}" config user.name "Runtime Baseline Flow Test"
+write_compose \
+  "${flow_dir}/homeserver/docker-compose.yml" \
+  mysql:8.0.46 \
+  cubing-hub_mysql-data \
+  baseline-a
+printf 'application A\n' >"${flow_dir}/frontend/app.txt"
+git -C "${flow_dir}" add homeserver/docker-compose.yml frontend/app.txt
+git -C "${flow_dir}" commit --quiet -m A
+application_a="$(git -C "${flow_dir}" rev-parse HEAD)"
+
+write_compose \
+  "${flow_dir}/homeserver/docker-compose.yml" \
+  mysql:8.4.11 \
+  cubing-hub_mysql-data \
+  maintenance-m
+git -C "${flow_dir}" add homeserver/docker-compose.yml
+git -C "${flow_dir}" commit --quiet -m M
+maintenance_m="$(git -C "${flow_dir}" rev-parse HEAD)"
+
+printf 'application N\n' >"${flow_dir}/frontend/app.txt"
+git -C "${flow_dir}" add frontend/app.txt
+git -C "${flow_dir}" commit --quiet -m N
+application_n="$(git -C "${flow_dir}" rev-parse HEAD)"
+
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${DETECTOR}" "${application_a}" "${maintenance_m}"
+)" = true
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${DETECTOR}" "${application_a}" "${application_n}"
+)" = true
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${DETECTOR}" "${maintenance_m}" "${application_n}"
+)" = false
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${RUNTIME_DETECTOR}" "${maintenance_m}" "${application_n}" false
+)" = keep
+
+write_compose \
+  "${flow_dir}/homeserver/docker-compose.yml" \
+  mysql:8.4.11 \
+  cubing-hub_mysql-data \
+  safe-runtime-r
+git -C "${flow_dir}" add homeserver/docker-compose.yml
+git -C "${flow_dir}" commit --quiet -m R
+safe_runtime_r="$(git -C "${flow_dir}" rev-parse HEAD)"
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${RUNTIME_DETECTOR}" "${application_n}" "${safe_runtime_r}" false
+)" = update
+test "$(
+  cd "${flow_dir}"
+  /bin/bash "${DETECTOR}" "${application_n}" "${safe_runtime_r}"
+)" = false
 
 printf 'Cubing Hub data-service maintenance detector tests passed\n'

--- a/homeserver/scripts/test-runtime-baseline-inspection.sh
+++ b/homeserver/scripts/test-runtime-baseline-inspection.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly PROJECT_ROOT="$(
+  CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
+)"
+readonly WRAPPER_SOURCE="${PROJECT_ROOT}/homeserver/scripts/deploy-home-server-ci.sh"
+readonly VERIFIER="${PROJECT_ROOT}/homeserver/scripts/verify-runtime-baseline-inspection.sh"
+readonly MOCK_DOCKER="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh"
+readonly MOCK_LOCKF="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-cubing-hub-lockf.py"
+readonly APPLICATION_REVISION=1111111111111111111111111111111111111111
+readonly OTHER_APPLICATION_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly RUNTIME_REVISION=2222222222222222222222222222222222222222
+readonly OTHER_RUNTIME_REVISION=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+readonly RUNTIME_DIGEST=sha256:3333333333333333333333333333333333333333333333333333333333333333
+readonly OTHER_RUNTIME_DIGEST=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+readonly DB_IMAGE=mysql:8.4.11@sha256:8484848484848484848484848484848484848484848484848484848484848484
+readonly DB_VOLUME=cubing-hub_mysql-data
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-runtime-inspection-test.XXXXXX")"
+
+cleanup() {
+  if [[ -n "${lock_holder_pid:-}" ]]; then
+    /bin/kill "${lock_holder_pid}" >/dev/null 2>&1 || true
+    wait "${lock_holder_pid}" >/dev/null 2>&1 || true
+  fi
+  if [[ "$(/usr/bin/basename "${test_root}")" == cubing-runtime-inspection-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+app_dir="${test_root}/app"
+release_dir="${app_dir}/runtime-config/releases/${RUNTIME_DIGEST#sha256:}"
+wrapper="${test_root}/deploy-cubing-hub-ci.sh"
+legacy_worker="${test_root}/legacy-deploy.sh"
+operation_lock="${app_dir}/.cubing-hub-operation.lock"
+
+/bin/mkdir -p "${release_dir}/nginx" "${release_dir}/scripts"
+printf 'name: cubing-hub\nservices: {}\n' >"${release_dir}/compose.yaml"
+printf 'set_real_ip_from 192.0.2.0/24;\n' \
+  >"${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+printf '#!/bin/bash\nset -Eeuo pipefail\n' \
+  >"${release_dir}/scripts/deploy-cubing-hub.sh"
+printf '#!/bin/bash\nset -Eeuo pipefail\n' \
+  >"${release_dir}/scripts/backup-cubing-hub.sh"
+/bin/chmod 700 \
+  "${release_dir}/scripts/deploy-cubing-hub.sh" \
+  "${release_dir}/scripts/backup-cubing-hub.sh"
+
+content_sha="$({
+  /usr/bin/shasum -a 256 "${release_dir}/compose.yaml"
+  /usr/bin/shasum -a 256 \
+    "${release_dir}/nginx/cloudflare-edge-real-ip.conf"
+  /usr/bin/shasum -a 256 \
+    "${release_dir}/scripts/backup-cubing-hub.sh"
+  /usr/bin/shasum -a 256 \
+    "${release_dir}/scripts/deploy-cubing-hub.sh"
+} | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}')"
+
+{
+  printf 'APPLICATION_REVISION=%s\n' "${APPLICATION_REVISION}"
+  printf 'PREVIOUS_APPLICATION_REVISION=%s\n' "${APPLICATION_REVISION}"
+  printf 'PREVIOUS_RUNTIME_CONFIG_DIGEST=%s\n' "${RUNTIME_DIGEST}"
+  printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' "${content_sha}"
+  printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${RUNTIME_DIGEST}"
+  printf 'RUNTIME_CONFIG_REVISION=%s\n' "${RUNTIME_REVISION}"
+} >"${app_dir}/runtime-config/state"
+/bin/chmod 600 "${app_dir}/runtime-config/state"
+/bin/ln -s \
+  "releases/${RUNTIME_DIGEST#sha256:}" \
+  "${app_dir}/runtime-config/current"
+printf 'RUNTIME_CONFIG_V2=initialized\n' \
+  >"${app_dir}/.runtime-config-v2-initialized"
+/bin/chmod 400 "${app_dir}/.runtime-config-v2-initialized"
+{
+  printf 'API_IMAGE=ghcr.io/xxh3898/cubing-hub-api:%s\n' "${APPLICATION_REVISION}"
+  printf 'WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:%s\n' "${APPLICATION_REVISION}"
+  printf 'DB_IMAGE=%s\n' "${DB_IMAGE}"
+  printf 'DB_VOLUME_NAME=%s\n' "${DB_VOLUME}"
+  printf 'DB_NAME=cubing_hub\n'
+  printf 'DB_USERNAME=cubing_hub\n'
+  printf 'DB_PASSWORD=fixture-secret\n'
+  printf 'MYSQL_ROOT_PASSWORD=fixture-root-secret\n'
+  printf 'JWT_SECRET=fixture-jwt-secret\n'
+  printf 'POST_IMAGES_HOST_DIR=%s/post-images\n' "${test_root}"
+} >"${app_dir}/.env"
+/bin/chmod 600 "${app_dir}/.env"
+: >"${operation_lock}"
+/bin/chmod 600 "${operation_lock}"
+printf '#!/bin/bash\nexit 0\n' >"${legacy_worker}"
+/bin/chmod 700 "${legacy_worker}" "${MOCK_DOCKER}" "${MOCK_LOCKF}"
+
+/usr/bin/sed \
+  -e "s#readonly DOCKER_BIN=/usr/local/bin/docker#readonly DOCKER_BIN=${MOCK_DOCKER}#" \
+  -e "s#readonly LOCKF_BIN=/usr/bin/lockf#readonly LOCKF_BIN=${MOCK_LOCKF}#" \
+  -e "s#readonly APP_DIR=/Users/homeserver/Server/apps/cubing-hub#readonly APP_DIR=${app_dir}#" \
+  -e "s#readonly LEGACY_DEPLOY_SCRIPT=/Users/homeserver/Server/scripts/deploy/deploy-cubing-hub.sh#readonly LEGACY_DEPLOY_SCRIPT=${legacy_worker}#" \
+  "${WRAPPER_SOURCE}" >"${wrapper}"
+/bin/chmod 700 "${wrapper}"
+
+inspect_command() {
+  local application_revision="${1:-${APPLICATION_REVISION}}"
+  local runtime_revision="${2:-${RUNTIME_REVISION}}"
+  local runtime_digest="${3:-${RUNTIME_DIGEST}}"
+  local db_image="${4:-${DB_IMAGE}}"
+  local db_volume="${5:-${DB_VOLUME}}"
+  local mysql_version="${6:-8.4.11}"
+
+  /usr/bin/env \
+    SSH_ORIGINAL_COMMAND="inspect-cubing-hub-runtime ${application_revision} ${runtime_revision} ${runtime_digest} ${db_image} ${db_volume} ${mysql_version}" \
+    FAKE_RUNNING_DB_VERSION_OVERRIDE="${FAKE_RUNNING_DB_VERSION_OVERRIDE:-8.4.11}" \
+    FAKE_ACTUAL_DB_VOLUME="${FAKE_ACTUAL_DB_VOLUME:-${DB_VOLUME}}" \
+    FAKE_REVISION_ONE="${FAKE_APPLICATION_IMAGE_REVISION_OVERRIDE:-${APPLICATION_REVISION}}" \
+    FAKE_SERVICE_HEALTH="${FAKE_SERVICE_HEALTH:-healthy}" \
+    /bin/bash "${wrapper}"
+}
+
+state_sha_before="$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')"
+env_sha_before="$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')"
+current_before="$(/usr/bin/readlink "${app_dir}/runtime-config/current")"
+inspection="$(inspect_command)"
+printf '%s\n' "${inspection}" | /bin/bash "${VERIFIER}" \
+  "${APPLICATION_REVISION}" \
+  "${RUNTIME_REVISION}" \
+  "${RUNTIME_DIGEST}" \
+  "${DB_IMAGE}" \
+  "${DB_VOLUME}" \
+  8.4.11 \
+  >/dev/null
+/usr/bin/grep -Fxq "APPLICATION_REVISION=${APPLICATION_REVISION}" <<<"${inspection}"
+/usr/bin/grep -Fxq "RUNTIME_CONFIG_REVISION=${RUNTIME_REVISION}" <<<"${inspection}"
+test "${APPLICATION_REVISION}" != "${RUNTIME_REVISION}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" = "${state_sha_before}"
+test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_sha_before}"
+test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
+
+expect_inspection_failure() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf '%s must fail closed\n' "${label}" >&2
+    exit 1
+  fi
+  test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" = "${state_sha_before}"
+  test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_sha_before}"
+  test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
+}
+
+expect_inspection_failure application-revision-mismatch \
+  inspect_command "${OTHER_APPLICATION_REVISION}"
+expect_inspection_failure runtime-revision-mismatch \
+  inspect_command "${APPLICATION_REVISION}" "${OTHER_RUNTIME_REVISION}"
+expect_inspection_failure runtime-digest-mismatch \
+  inspect_command "${APPLICATION_REVISION}" "${RUNTIME_REVISION}" "${OTHER_RUNTIME_DIGEST}"
+FAKE_RUNNING_DB_VERSION_OVERRIDE=8.4.10 \
+  expect_inspection_failure mysql-version-mismatch inspect_command
+FAKE_ACTUAL_DB_VOLUME=cubing-hub_mysql-other \
+  expect_inspection_failure db-volume-mismatch inspect_command
+FAKE_ACTUAL_DB_IMAGE_ID=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd \
+  expect_inspection_failure db-image-mismatch inspect_command
+FAKE_APPLICATION_IMAGE_REVISION_OVERRIDE="${OTHER_APPLICATION_REVISION}" \
+  expect_inspection_failure application-image-label-mismatch inspect_command
+FAKE_SERVICE_HEALTH=unhealthy \
+  expect_inspection_failure service-health-mismatch inspect_command
+
+lock_ready="${test_root}/operation-lock-held"
+/usr/bin/python3 - "${operation_lock}" "${lock_ready}" <<'PY' &
+import fcntl
+import pathlib
+import sys
+import time
+
+with open(sys.argv[1], "r+") as lock_file:
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    pathlib.Path(sys.argv[2]).write_text("ready\n", encoding="utf-8")
+    time.sleep(30)
+PY
+lock_holder_pid="$!"
+/bin/sleep 1
+test -f "${lock_ready}"
+expect_inspection_failure operation-lock-collision inspect_command
+/bin/kill "${lock_holder_pid}"
+wait "${lock_holder_pid}" >/dev/null 2>&1 || true
+lock_holder_pid=
+
+printf 'TRANSACTION_TYPE=MYSQL_MAINTENANCE\n' \
+  >"${app_dir}/runtime-config/pending"
+/bin/chmod 600 "${app_dir}/runtime-config/pending"
+expect_inspection_failure pending-runtime-transaction inspect_command
+/bin/rm -f -- "${app_dir}/runtime-config/pending"
+
+if printf '%s\nEXTRA=value\n' "${inspection}" \
+  | /bin/bash "${VERIFIER}" \
+      "${APPLICATION_REVISION}" \
+      "${RUNTIME_REVISION}" \
+      "${RUNTIME_DIGEST}" \
+      "${DB_IMAGE}" \
+      "${DB_VOLUME}" \
+      8.4.11 \
+      >/dev/null 2>&1
+then
+  printf 'Inspection output with an unexpected key must fail closed\n' >&2
+  exit 1
+fi
+
+if SSH_ORIGINAL_COMMAND="inspect-cubing-hub-runtime ${APPLICATION_REVISION} ${RUNTIME_REVISION}; touch ${test_root}/injected" \
+  /bin/bash "${wrapper}" >/dev/null 2>&1
+then
+  printf 'Inspection command injection must fail closed\n' >&2
+  exit 1
+fi
+test ! -e "${test_root}/injected"
+
+printf 'Cubing Hub runtime baseline inspection tests passed\n'

--- a/homeserver/scripts/test-runtime-config-baseline.sh
+++ b/homeserver/scripts/test-runtime-config-baseline.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+readonly PROJECT_ROOT="$(
+  CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd
+)"
+readonly RESOLVER="${PROJECT_ROOT}/homeserver/scripts/resolve-runtime-config-baseline.sh"
+readonly RECORDER="${PROJECT_ROOT}/homeserver/scripts/record-runtime-config-baseline.sh"
+readonly MOCK_CURL="${PROJECT_ROOT}/homeserver/scripts/fixtures/mock-github-deployments-curl.sh"
+readonly APPLICATION_REVISION=1111111111111111111111111111111111111111
+readonly RUNTIME_REVISION=2222222222222222222222222222222222222222
+readonly LEGACY_REVISION=3333333333333333333333333333333333333333
+readonly RUNTIME_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly DB_IMAGE=mysql:8.4.11@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+readonly DB_VOLUME=cubing-hub_mysql-data
+readonly ZERO_SHA=0000000000000000000000000000000000000000
+readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-runtime-baseline-test.XXXXXX")"
+
+cleanup() {
+  if [[ "$(/usr/bin/basename "${test_root}")" == cubing-runtime-baseline-test.* ]]; then
+    /bin/rm -rf -- "${test_root}"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+new_fixture() {
+  fixture_dir="${test_root}/$1"
+  /bin/mkdir -p "${fixture_dir}"
+}
+
+write_deployments() {
+  local environment="$1"
+  local page="$2"
+  local target="$3"
+  shift 3
+
+  printf '%s\n' "$@" | jq -Rn \
+    --arg application "${APPLICATION_REVISION}" \
+    --arg digest "${RUNTIME_DIGEST}" \
+    --arg environment "${environment}" '
+      [inputs | select(length > 0) | split("\t") |
+        {id: (.[0] | tonumber), sha: .[1], environment: $environment} |
+        if $environment == "production-runtime-config" then
+          . + {
+            task: "runtime-config:baseline",
+            payload: {
+              operation: "normal-update",
+              applicationRevision: $application,
+              runtimeConfigRevision: .sha,
+              runtimeConfigDigest: $digest
+            }
+          }
+        else . end
+      ]
+    ' >"${target}/${environment}-deployments-page-${page}.json"
+}
+
+write_status() {
+  local deployment_id="$1"
+  local state="$2"
+
+  jq -cn --arg state "${state}" '[{state: $state}]' \
+    >"${fixture_dir}/deployment-${deployment_id}-statuses.json"
+}
+
+write_full_failure_page() {
+  local environment="$1"
+  local page="$2"
+
+  "${PYTHON_BIN:-/usr/bin/python3}" - \
+    "${fixture_dir}/${environment}-deployments-page-${page}.json" \
+    "${environment}" \
+    "${APPLICATION_REVISION}" \
+    "${RUNTIME_DIGEST}" <<'PY'
+import json
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text(
+    json.dumps([
+        ({
+            "id": index,
+            "sha": f"{index:040x}",
+            "environment": sys.argv[2],
+        } | ({
+            "task": "runtime-config:baseline",
+            "payload": {
+                "operation": "normal-update",
+                "applicationRevision": sys.argv[3],
+                "runtimeConfigRevision": f"{index:040x}",
+                "runtimeConfigDigest": sys.argv[4],
+            },
+        } if sys.argv[2] == "production-runtime-config" else {}))
+        for index in range(1, 101)
+    ]),
+    encoding="utf-8",
+)
+PY
+  for deployment_id in $(/usr/bin/jot 100 1 100 2>/dev/null || /usr/bin/seq 1 100); do
+    write_status "${deployment_id}" failure
+  done
+}
+
+run_resolver() {
+  /usr/bin/env \
+    CURL_BIN="${MOCK_CURL}" \
+    FAKE_GITHUB_API_FIXTURE_DIR="${fixture_dir}" \
+    GH_TOKEN=test-token \
+    GITHUB_API_URL=https://api.github.test \
+    GITHUB_REPOSITORY=xxh3898/cubing-hub \
+    /bin/bash "${RESOLVER}"
+}
+
+new_fixture runtime-success
+write_deployments production-runtime-config 1 "${fixture_dir}" \
+  $'10\t'"${RUNTIME_REVISION}"
+write_status 10 success
+result="$(run_resolver)"
+/usr/bin/grep -Fxq "revision=${RUNTIME_REVISION}" <<<"${result}"
+/usr/bin/grep -Fxq "digest=${RUNTIME_DIGEST}" <<<"${result}"
+/usr/bin/grep -Fxq 'source=runtime' <<<"${result}"
+
+new_fixture paginated-runtime-success
+write_full_failure_page production-runtime-config 1
+write_deployments production-runtime-config 2 "${fixture_dir}" \
+  $'101\t'"${RUNTIME_REVISION}"
+write_status 101 success
+result="$(run_resolver)"
+/usr/bin/grep -Fxq "revision=${RUNTIME_REVISION}" <<<"${result}"
+/usr/bin/grep -Fxq "digest=${RUNTIME_DIGEST}" <<<"${result}"
+/usr/bin/grep -Fxq 'source=runtime' <<<"${result}"
+
+new_fixture pagination-failure
+write_full_failure_page production-runtime-config 1
+if run_resolver >/dev/null 2>&1; then
+  printf 'A failed runtime deployment history page request must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture legacy-bootstrap
+printf '[]\n' >"${fixture_dir}/production-runtime-config-deployments-page-1.json"
+write_deployments production 1 "${fixture_dir}" $'20\t'"${LEGACY_REVISION}"
+write_status 20 success
+result="$(run_resolver)"
+/usr/bin/grep -Fxq "revision=${LEGACY_REVISION}" <<<"${result}"
+/usr/bin/grep -Fxq "digest=${ZERO_DIGEST}" <<<"${result}"
+/usr/bin/grep -Fxq 'source=legacy-bootstrap' <<<"${result}"
+
+new_fixture new-install-bootstrap
+printf '[]\n' >"${fixture_dir}/production-runtime-config-deployments-page-1.json"
+printf '[]\n' >"${fixture_dir}/production-deployments-page-1.json"
+result="$(run_resolver)"
+/usr/bin/grep -Fxq "revision=${ZERO_SHA}" <<<"${result}"
+/usr/bin/grep -Fxq "digest=${ZERO_DIGEST}" <<<"${result}"
+/usr/bin/grep -Fxq 'source=new-install-bootstrap' <<<"${result}"
+
+new_fixture runtime-history-without-success
+write_deployments production-runtime-config 1 "${fixture_dir}" \
+  $'30\t'"${RUNTIME_REVISION}"
+write_status 30 failure
+if run_resolver >/dev/null 2>&1; then
+  printf 'Runtime history without success must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture invalid-runtime-response
+printf '{invalid\n' >"${fixture_dir}/production-runtime-config-deployments-page-1.json"
+if run_resolver >/dev/null 2>&1; then
+  printf 'Invalid runtime history response must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture invalid-runtime-payload
+jq -cn \
+  --arg revision "${RUNTIME_REVISION}" \
+  '[{id: 40, sha: $revision, environment: "production-runtime-config"}]' \
+  >"${fixture_dir}/production-runtime-config-deployments-page-1.json"
+write_status 40 success
+if run_resolver >/dev/null 2>&1; then
+  printf 'A runtime baseline without verified payload metadata must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture record-success
+api_log="${fixture_dir}/api.log"
+result="$(
+  /usr/bin/env \
+    CURL_BIN="${MOCK_CURL}" \
+    FAKE_GITHUB_API_FIXTURE_DIR="${fixture_dir}" \
+    FAKE_GITHUB_API_LOG="${api_log}" \
+    GH_TOKEN=test-token \
+    GITHUB_API_URL=https://api.github.test \
+    GITHUB_REPOSITORY=xxh3898/cubing-hub \
+    /bin/bash "${RECORDER}" \
+      maintenance-reconcile \
+      "${APPLICATION_REVISION}" \
+      "${RUNTIME_REVISION}" \
+      "${RUNTIME_DIGEST}" \
+      "${DB_IMAGE}" \
+      "${DB_VOLUME}" \
+      8.4.11
+)"
+/usr/bin/grep -Fxq 'deployment_id=900' <<<"${result}"
+deployment_request="$(/usr/bin/sed -n '1p' "${api_log}")"
+status_request="$(/usr/bin/sed -n '2p' "${api_log}")"
+jq -e \
+  --arg application "${APPLICATION_REVISION}" \
+  --arg runtime "${RUNTIME_REVISION}" \
+  --arg digest "${RUNTIME_DIGEST}" \
+  --arg image "${DB_IMAGE}" \
+  --arg volume "${DB_VOLUME}" '
+    .method == "POST" and
+    .data.ref == $runtime and
+    .data.environment == "production-runtime-config" and
+    .data.auto_merge == false and
+    .data.required_contexts == [] and
+    .data.payload.operation == "maintenance-reconcile" and
+    .data.payload.applicationRevision == $application and
+    .data.payload.runtimeConfigRevision == $runtime and
+    .data.payload.runtimeConfigDigest == $digest and
+    .data.payload.dbImage == $image and
+    .data.payload.dbVolume == $volume and
+    .data.payload.mysqlVersion == "8.4.11"
+  ' <<<"${deployment_request}" >/dev/null
+jq -e \
+  '.method == "POST" and
+   .data.state == "success" and
+   .data.environment == "production-runtime-config" and
+   .data.auto_inactive == false' \
+  <<<"${status_request}" >/dev/null
+! /usr/bin/grep -Fq test-token "${api_log}"
+
+new_fixture record-status-failure
+if /usr/bin/env \
+  CURL_BIN="${MOCK_CURL}" \
+  FAKE_GITHUB_API_FIXTURE_DIR="${fixture_dir}" \
+  FAKE_GITHUB_STATUS_STATE=failure \
+  GH_TOKEN=test-token \
+  GITHUB_API_URL=https://api.github.test \
+  GITHUB_REPOSITORY=xxh3898/cubing-hub \
+  /bin/bash "${RECORDER}" \
+    normal-update \
+    "${APPLICATION_REVISION}" \
+    "${RUNTIME_REVISION}" \
+    "${RUNTIME_DIGEST}" \
+    - - - \
+    >/dev/null 2>&1
+then
+  printf 'A non-success deployment status must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture record-deployment-request-failure
+if /usr/bin/env \
+  CURL_BIN="${MOCK_CURL}" \
+  FAKE_GITHUB_API_FIXTURE_DIR="${fixture_dir}" \
+  FAKE_GITHUB_DEPLOYMENT_FAIL=true \
+  GH_TOKEN=test-token \
+  GITHUB_API_URL=https://api.github.test \
+  GITHUB_REPOSITORY=xxh3898/cubing-hub \
+  /bin/bash "${RECORDER}" \
+    normal-update \
+    "${APPLICATION_REVISION}" \
+    "${RUNTIME_REVISION}" \
+    "${RUNTIME_DIGEST}" \
+    - - - \
+    >/dev/null 2>&1
+then
+  printf 'A failed deployment creation request must fail closed\n' >&2
+  exit 1
+fi
+
+new_fixture record-status-request-failure
+if /usr/bin/env \
+  CURL_BIN="${MOCK_CURL}" \
+  FAKE_GITHUB_API_FIXTURE_DIR="${fixture_dir}" \
+  FAKE_GITHUB_STATUS_FAIL=true \
+  GH_TOKEN=test-token \
+  GITHUB_API_URL=https://api.github.test \
+  GITHUB_REPOSITORY=xxh3898/cubing-hub \
+  /bin/bash "${RECORDER}" \
+    normal-update \
+    "${APPLICATION_REVISION}" \
+    "${RUNTIME_REVISION}" \
+    "${RUNTIME_DIGEST}" \
+    - - - \
+    >/dev/null 2>&1
+then
+  printf 'A failed deployment status request must fail closed\n' >&2
+  exit 1
+fi
+
+printf 'Cubing Hub runtime config baseline tests passed\n'

--- a/homeserver/scripts/verify-runtime-baseline-inspection.sh
+++ b/homeserver/scripts/verify-runtime-baseline-inspection.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+if [[ "$#" -ne 6 ]]; then
+  printf '%s\n' \
+    'Usage: verify-runtime-baseline-inspection.sh <application-revision> <runtime-revision> <runtime-digest> <db-image> <db-volume> <mysql-version>' \
+    >&2
+  exit 64
+fi
+
+expected_application_revision="$1"
+expected_runtime_revision="$2"
+expected_runtime_digest="$3"
+expected_db_image="$4"
+expected_db_volume="$5"
+expected_mysql_version="$6"
+expected_db_image_version="${expected_db_image#mysql:}"
+expected_db_image_version="${expected_db_image_version%@sha256:*}"
+
+if [[ ! "${expected_application_revision}" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "${expected_runtime_revision}" =~ ^[0-9a-f]{40}$ ]] \
+  || [[ ! "${expected_runtime_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || [[ ! "${expected_db_image}" =~ ^mysql:[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$ ]] \
+  || [[ ! "${expected_db_volume}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]] \
+  || [[ ! "${expected_mysql_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || [[ "${expected_db_image_version}" != "${expected_mysql_version}" ]]
+then
+  printf 'Expected runtime inspection identity is invalid\n' >&2
+  exit 64
+fi
+
+inspection="$(/bin/cat)"
+keys="$(
+  printf '%s\n' "${inspection}" \
+    | /usr/bin/awk -F= 'NF >= 2 { print $1 }' \
+    | LC_ALL=C /usr/bin/sort
+)"
+if [[ "${keys}" != $'APPLICATION_REVISION\nCURRENT_POINTER\nDB_IMAGE\nDB_VOLUME_NAME\nMYSQL_VERSION\nPENDING\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION\nSERVICE_SET' ]]; then
+  printf 'Runtime inspection keys are invalid\n' >&2
+  exit 1
+fi
+
+read_value() {
+  /usr/bin/sed -n "s/^$1=//p" <<<"${inspection}" | /usr/bin/tail -n 1
+}
+
+actual_application_revision="$(read_value APPLICATION_REVISION)"
+actual_runtime_revision="$(read_value RUNTIME_CONFIG_REVISION)"
+actual_runtime_digest="$(read_value RUNTIME_CONFIG_DIGEST)"
+actual_content_sha="$(read_value RUNTIME_CONFIG_CONTENT_SHA256)"
+actual_current_pointer="$(read_value CURRENT_POINTER)"
+actual_pending="$(read_value PENDING)"
+actual_db_image="$(read_value DB_IMAGE)"
+actual_db_volume="$(read_value DB_VOLUME_NAME)"
+actual_mysql_version="$(read_value MYSQL_VERSION)"
+actual_service_set="$(read_value SERVICE_SET)"
+
+[[ "${actual_application_revision}" == "${expected_application_revision}" ]] \
+  || { printf 'Application revision does not match the reconciliation intent\n' >&2; exit 1; }
+[[ "${actual_runtime_revision}" == "${expected_runtime_revision}" ]] \
+  || { printf 'Runtime revision does not match the reconciliation intent\n' >&2; exit 1; }
+[[ "${actual_runtime_digest}" == "${expected_runtime_digest}" ]] \
+  || { printf 'Runtime digest does not match the reconciliation intent\n' >&2; exit 1; }
+[[ "${actual_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+  || { printf 'Runtime content digest is invalid\n' >&2; exit 1; }
+[[ "${actual_current_pointer}" == "releases/${expected_runtime_digest#sha256:}" ]] \
+  || { printf 'Runtime current pointer does not match the verified digest\n' >&2; exit 1; }
+[[ "${actual_pending}" == none ]] \
+  || { printf 'A production runtime transaction is pending\n' >&2; exit 1; }
+[[ "${actual_db_image}" == "${expected_db_image}" ]] \
+  || { printf 'DB image does not match the reconciliation intent\n' >&2; exit 1; }
+[[ "${actual_db_volume}" == "${expected_db_volume}" ]] \
+  || { printf 'DB volume does not match the reconciliation intent\n' >&2; exit 1; }
+if [[ "${actual_mysql_version}" != "${expected_mysql_version}" ]] \
+  && [[ "${actual_mysql_version}" != "${expected_mysql_version}"-* ]] \
+  && [[ "${actual_mysql_version}" != "${expected_mysql_version}"+* ]]
+then
+  printf 'MySQL version does not match the reconciliation intent\n' >&2
+  exit 1
+fi
+[[ "${actual_service_set}" == healthy ]] \
+  || { printf 'Production service set is unhealthy\n' >&2; exit 1; }
+
+printf 'Runtime baseline inspection verified\n'

--- a/homeserver/scripts/workflow-config.test.mjs
+++ b/homeserver/scripts/workflow-config.test.mjs
@@ -6,14 +6,22 @@ import test from "node:test";
 const [
   validateWorkflow,
   deployWorkflow,
+  reconcileWorkflow,
   benchmarkWorkflow,
   pathClassifier,
+  runtimeBaselineResolver,
+  runtimeBaselineRecorder,
+  runtimeInspectionVerifier,
 ] =
   await Promise.all([
     read("../../.github/workflows/validate.yml"),
     read("../../.github/workflows/deploy.yml"),
+    read("../../.github/workflows/reconcile-runtime-baseline.yml"),
     read("../../.github/workflows/performance-benchmark.yml"),
     read("../../scripts/classify-ci-paths.sh"),
+    read("./resolve-runtime-config-baseline.sh"),
+    read("./record-runtime-config-baseline.sh"),
+    read("./verify-runtime-baseline-inspection.sh"),
   ]);
 
 test("should_validateDevPushAndDevAndMainPullRequestsBeforeRelease", () => {
@@ -317,7 +325,14 @@ test("should_publishOnlyFullShaArm64ImagesToGhcr", () => {
   );
   assert.match(
     deployWorkflow,
-    /deployments\?environment=production[\s\S]*steps\.deployed-base\.outputs\.sha/,
+    /resolve-runtime-config-baseline\.sh[\s\S]*steps\.runtime-baseline\.outputs\.revision/,
+  );
+  assert.match(runtimeBaselineResolver, /RUNTIME_ENVIRONMENT=production-runtime-config/);
+  assert.match(runtimeBaselineResolver, /LEGACY_ENVIRONMENT=production/);
+  assert.match(runtimeBaselineResolver, /task == "runtime-config:baseline"/);
+  assert.match(
+    runtimeBaselineResolver,
+    /payload\.runtimeConfigDigest[\s\S]*sha256:\[0-9a-f\]\{64\}/,
   );
   assert.doesNotMatch(deployWorkflow, /:latest|:main/);
   assert.doesNotMatch(deployWorkflow, /Docker Hub|DOCKERHUB|setup-qemu/);
@@ -347,7 +362,7 @@ test("should_publishMaintenanceRuntimeConfigWithoutStartingProductionDeploy", ()
 
   assert.match(
     publish,
-    /- name: Detect data-service maintenance\n        id: data-service-maintenance[\s\S]*detect-data-service-maintenance\.sh \\\n+\s+"\$\{DEPLOYED_SHA\}" \\\n+\s+"\$\{GITHUB_SHA\}"/,
+    /- name: Detect data-service maintenance\n        id: data-service-maintenance[\s\S]*detect-data-service-maintenance\.sh \\\n+\s+"\$\{RUNTIME_BASELINE_SHA\}" \\\n+\s+"\$\{GITHUB_SHA\}"/,
   );
   assert.match(
     publish,
@@ -368,29 +383,25 @@ test("should_publishMaintenanceRuntimeConfigWithoutStartingProductionDeploy", ()
   assert.doesNotMatch(publish, /tailscale\/github-action|home-mini/);
 });
 
-test("should_failClosedWhenProductionHistoryHasNoSuccessfulDeployment", () => {
-  const publish = workflowJob(deployWorkflow, "publish");
-  const deployedBase = publish.slice(
-    publish.indexOf("- name: Resolve last successful production revision"),
-    publish.indexOf("- name: Detect runtime config changes"),
-  );
-
+test("should_resolveRuntimeBaselineWithExplicitLegacyBootstrapAndPagination", () => {
+  assert.match(runtimeBaselineResolver, /readonly PAGE_SIZE=100/);
   assert.match(
-    deployedBase,
-    /deployment_page=1[\s\S]*deployment_page_size=100[\s\S]*saw_production_deployment=false/,
+    runtimeBaselineResolver,
+    /deployments\?environment=\$\{environment\}&per_page=\$\{PAGE_SIZE\}&page=\$\{page\}/,
   );
   assert.match(
-    deployedBase,
-    /deployments\?environment=production&per_page=\$\{deployment_page_size\}&page=\$\{deployment_page\}/,
+    runtimeBaselineResolver,
+    /resolve_environment "\$\{RUNTIME_ENVIRONMENT\}"[\s\S]*success\)[\s\S]*baseline_source=runtime[\s\S]*empty\)[\s\S]*resolve_environment "\$\{LEGACY_ENVIRONMENT\}"/,
   );
   assert.match(
-    deployedBase,
-    /deployment_count="\$\(jq -r 'length'[\s\S]*if \[\[ "\$\{deployment_count\}" -eq 0 \]\]; then[\s\S]*if \[\[ "\$\{saw_production_deployment\}" == false \]\]; then[\s\S]*break[\s\S]*Production deployments exist, but no successful revision was found/,
+    runtimeBaselineResolver,
+    /no-success\)[\s\S]*runtime config deployments exist without a successful baseline/,
   );
   assert.match(
-    deployedBase,
-    /if \[\[ "\$\{deployment_count\}" -lt "\$\{deployment_page_size\}" \]\]; then[\s\S]*Production deployments exist, but no successful revision was found[\s\S]*deployment_page="\$\(\(deployment_page \+ 1\)\)"/,
+    runtimeBaselineResolver,
+    /baseline_source=legacy-bootstrap[\s\S]*baseline_source=new-install-bootstrap/,
   );
+  assert.match(runtimeBaselineResolver, /printf 'digest=%s\\n'/);
 });
 
 test("should_notLetForcedRuntimeSyncBypassDataServiceMaintenance", () => {
@@ -408,13 +419,15 @@ test("should_notLetForcedRuntimeSyncBypassDataServiceMaintenance", () => {
   assert.doesNotMatch(maintenanceDetection, /FORCE_SYNC|sync_runtime_config/);
   assert.match(
     maintenanceDetection,
-    /detect-data-service-maintenance\.sh[\s\S]*"\$\{DEPLOYED_SHA\}"[\s\S]*"\$\{GITHUB_SHA\}"/,
+    /detect-data-service-maintenance\.sh[\s\S]*"\$\{RUNTIME_BASELINE_SHA\}"[\s\S]*"\$\{GITHUB_SHA\}"/,
   );
 });
 
 test("should_applyLeastPrivilegePermissionsPerJob", () => {
   const publish = workflowJob(deployWorkflow, "publish");
   const deploy = workflowJob(deployWorkflow, "deploy");
+  const recordRuntime = workflowJob(deployWorkflow, "record-runtime-baseline");
+  const reconcile = workflowJob(reconcileWorkflow, "reconcile");
 
   assert.match(publish, /actions: read/);
   assert.match(publish, /contents: read/);
@@ -426,6 +439,19 @@ test("should_applyLeastPrivilegePermissionsPerJob", () => {
   assert.match(deploy, /id-token: write/);
   assert.doesNotMatch(deploy, /packages: write/);
   assert.match(deploy, /environment: production/);
+
+  assert.match(recordRuntime, /contents: read/);
+  assert.match(recordRuntime, /deployments: write/);
+  assert.doesNotMatch(recordRuntime, /id-token: write|packages: write/);
+
+  assert.match(reconcile, /contents: read/);
+  assert.match(reconcile, /deployments: write/);
+  assert.match(reconcile, /id-token: write/);
+  assert.doesNotMatch(reconcile, /contents: write|packages: write|actions: write/);
+  assert.match(
+    reconcile,
+    /environment:\n      name: production-runtime-config\n      deployment: false/,
+  );
 });
 
 test("should_useTailscaleOidcAndRestrictedSshForDeployment", () => {
@@ -443,6 +469,59 @@ test("should_useTailscaleOidcAndRestrictedSshForDeployment", () => {
   );
   assert.match(deployWorkflow, /StrictHostKeyChecking=yes/);
   assert.doesNotMatch(deployWorkflow, /ssh-keyscan|StrictHostKeyChecking=no/);
+  assert.match(reconcileWorkflow, /uses: tailscale\/github-action@[0-9a-f]{40}/);
+  assert.match(
+    reconcileWorkflow,
+    /inspection_command="inspect-cubing-hub-runtime \$\{EXPECTED_APPLICATION_REVISION\} \$\{EXPECTED_RUNTIME_CONFIG_REVISION\} \$\{EXPECTED_RUNTIME_CONFIG_DIGEST\} \$\{EXPECTED_DB_IMAGE\} \$\{EXPECTED_DB_VOLUME\} \$\{EXPECTED_MYSQL_VERSION\}"/,
+  );
+  assert.doesNotMatch(reconcileWorkflow, /ssh-keyscan|StrictHostKeyChecking=no/);
+});
+
+test("should_recordRuntimeBaselineOnlyAfterSafeRuntimeDeploySuccess", () => {
+  const recordRuntime = workflowJob(deployWorkflow, "record-runtime-baseline");
+
+  assert.match(recordRuntime, /always\(\)/);
+  assert.match(recordRuntime, /needs\.publish\.result == 'success'/);
+  assert.match(recordRuntime, /needs\.deploy\.result == 'success'/);
+  assert.match(recordRuntime, /runtime_config_mode == 'update'/);
+  assert.match(
+    recordRuntime,
+    /data_service_maintenance_required == 'false'/,
+  );
+  assert.match(
+    recordRuntime,
+    /record-runtime-config-baseline\.sh \\\n+\s+normal-update/,
+  );
+  assert.match(runtimeBaselineRecorder, /environment: \$environment/);
+  assert.match(runtimeBaselineRecorder, /required_contexts: \[\]/);
+  assert.match(runtimeBaselineRecorder, /auto_merge: false/);
+  assert.match(runtimeBaselineRecorder, /state: "success"/);
+  assert.doesNotMatch(
+    workflowJob(deployWorkflow, "publish"),
+    /record-runtime-config-baseline\.sh/,
+  );
+});
+
+test("should_reconcileOnlyExplicitVerifiedHostStateWithoutMutatingProduction", () => {
+  const reconcile = workflowJob(reconcileWorkflow, "reconcile");
+
+  assert.match(reconcileWorkflow, /^on:\n  workflow_dispatch:/m);
+  assert.doesNotMatch(reconcileWorkflow, /\n  push:|\n  pull_request:/);
+  assert.match(reconcile, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(reconcile, /git merge-base --is-ancestor/);
+  assert.match(reconcile, /verify-runtime-baseline-inspection\.sh/);
+  assert.match(
+    reconcile,
+    /record-runtime-config-baseline\.sh \\\n+\s+maintenance-reconcile/,
+  );
+  assert.match(runtimeInspectionVerifier, /APPLICATION_REVISION/);
+  assert.match(runtimeInspectionVerifier, /RUNTIME_CONFIG_REVISION/);
+  assert.match(runtimeInspectionVerifier, /PENDING/);
+  assert.match(runtimeInspectionVerifier, /SERVICE_SET/);
+  assert.doesNotMatch(
+    reconcileWorkflow,
+    /docker compose (?:up|down)|runtime-config\/state|runtime-config\/current|volume rm/,
+  );
 });
 
 test("should_pinEveryExternalActionToFullCommitSha", () => {
@@ -466,6 +545,7 @@ test("should_pinEveryExternalActionToFullCommitSha", () => {
   for (const workflow of [
     validateWorkflow,
     deployWorkflow,
+    reconcileWorkflow,
     benchmarkWorkflow,
   ]) {
     for (const action of actionReferences(workflow)) {


### PR DESCRIPTION
## Goal

- data-service maintenance 이후 GitHub release baseline 정합성 복구
- normal automated deployment의 안전한 재개 경계 확정

## Baseline model

- `production` application deployment 이력 유지
- `production-runtime-config` verified runtime revision·digest 이력 분리
- runtime baseline payload와 latest success pagination 검증 추가

## Application vs runtime revision

- `APPLICATION_REVISION`과 `RUNTIME_CONFIG_REVISION` 독립 검증
- maintenance 이후 서로 다른 revision을 정상 상태로 허용

## Runtime baseline

- runtime history 최초 도입 시 legacy production success bootstrap 추가
- runtime history 존재·success 부재와 GitHub API 오류의 fail-closed 처리
- safe runtime update의 production deploy 성공 후 baseline 기록 추가

## Normal deploy behavior

- application-only `keep`에서 기존 runtime baseline 유지
- safe runtime-config `update`에서 deploy 성공 뒤 baseline 갱신
- data-service detector의 runtime baseline revision 기준 전환

## Maintenance behavior

- maintenance-required release의 artifact publish 유지
- production deploy와 runtime baseline record skip 유지
- artifact publication만으로 baseline을 전진시키지 않는 경계 보강

## Reconciliation

- explicit expected application/runtime/digest/DB identity 입력 추가
- read-only production inspection 성공 후 runtime baseline 기록 추가
- `production` application deployment 이력 비변경

## Host verification

- restricted `inspect-cubing-hub-runtime` forced command 추가
- state/current/release content, pending, application image revision, DB image·volume·version, service health 검증 추가
- operation lock 충돌과 expected identity 불일치 차단

## Bootstrap

- runtime history 완전 부재 시 legacy `production` success bootstrap 추가
- runtime deployment 존재·success 부재 시 legacy fallback 차단
- 양쪽 history가 없는 신규 설치 zero revision bootstrap 유지

## Tests

- runtime baseline resolver·recorder pagination/API fixture 추가
- application/runtime revision 분리와 host inspection failure fixture 추가
- A→M→reconcile→N 및 safe runtime update detector fixture 추가
- deploy·backup·MySQL maintenance·runtime bootstrap 회귀 통과
- shell syntax, YAML syntax, Compose render, `git diff --check` 통과

## Operations

- `production-runtime-config` environment approval prerequisite 문서화
- approved stable deploy wrapper 설치와 SHA-256 검증 경계 문서화
- MySQL smoke·post-upgrade backup 뒤 reconciliation 절차 연결

## Out of Scope

- production workflow dispatch
- production SSH 또는 stable wrapper 설치
- runtime baseline 실제 생성
- MySQL upgrade·container·volume·runtime state 변경
- `dev` → `main` merge와 production deploy

## Rollback

- workflow·helper·runbook 변경의 별도 corrective revert
- 기존 GitHub deployment history의 audit evidence 보존
