### PR TITLE
fix: correct previous seven-day activity window

### DIFF
--- a/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthTimeWindows.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/metric/GrowthTimeWindows.java
@@ -28,6 +28,22 @@ public final class GrowthTimeWindows {
         return new ActivityWindow(asOfDate, calendarWindow(fromDate, asOfDate.plusDays(1)));
     }
 
+    public static ActivityComparisonWindow activityComparisonWindow(Clock clock, int days) {
+        Objects.requireNonNull(clock, "clock은 필수입니다.");
+        return activityComparisonWindow(clock.instant(), days);
+    }
+
+    public static ActivityComparisonWindow activityComparisonWindow(Instant generatedAt, int days) {
+        ActivityWindow current = activityWindow(generatedAt, days);
+        LocalDate previousToDateExclusive = current.range().fromDate();
+        CalendarWindow previous = calendarWindow(
+                previousToDateExclusive.minusDays(days),
+                previousToDateExclusive
+        );
+
+        return new ActivityComparisonWindow(current.asOfDate(), current.range(), previous);
+    }
+
     public static PerformanceComparisonWindow performanceComparisonWindow(Clock clock) {
         Objects.requireNonNull(clock, "clock은 필수입니다.");
         return performanceComparisonWindow(clock.instant());
@@ -58,6 +74,22 @@ public final class GrowthTimeWindows {
         public ActivityWindow {
             Objects.requireNonNull(asOfDate, "asOfDate는 필수입니다.");
             Objects.requireNonNull(range, "range는 필수입니다.");
+        }
+    }
+
+    public record ActivityComparisonWindow(
+            LocalDate asOfDate,
+            CalendarWindow currentPeriod,
+            CalendarWindow previousPeriod
+    ) {
+
+        public ActivityComparisonWindow {
+            Objects.requireNonNull(asOfDate, "asOfDate는 필수입니다.");
+            Objects.requireNonNull(currentPeriod, "currentPeriod는 필수입니다.");
+            Objects.requireNonNull(previousPeriod, "previousPeriod는 필수입니다.");
+            if (!previousPeriod.toDateExclusive().equals(currentPeriod.fromDate())) {
+                throw new IllegalArgumentException("activity period는 gap이나 overlap 없이 이어져야 합니다.");
+            }
         }
     }
 

--- a/backend/src/main/java/com/cubinghub/domain/growth/service/GrowthReadService.java
+++ b/backend/src/main/java/com/cubinghub/domain/growth/service/GrowthReadService.java
@@ -63,7 +63,7 @@ public class GrowthReadService {
         User user = findUser(email);
         Instant generatedAt = clock.instant();
 
-        GrowthTimeWindows.ActivityWindow last7Days = GrowthTimeWindows.activityWindow(
+        GrowthTimeWindows.ActivityComparisonWindow activity7Days = GrowthTimeWindows.activityComparisonWindow(
                 generatedAt,
                 ACTIVITY_LAST_7_DAYS
         );
@@ -88,10 +88,10 @@ public class GrowthReadService {
         ActivitySummary activity = growthReadRepository.findActivitySummary(
                 user.getId(),
                 eventType,
-                last7Days.range().fromInclusive(),
-                last7Days.range().toExclusive(),
-                comparisonWindow.previousPeriod().fromInclusive(),
-                comparisonWindow.previousPeriod().toExclusive(),
+                activity7Days.currentPeriod().fromInclusive(),
+                activity7Days.currentPeriod().toExclusive(),
+                activity7Days.previousPeriod().fromInclusive(),
+                activity7Days.previousPeriod().toExclusive(),
                 last30Days.range().fromInclusive(),
                 last30Days.range().toExclusive()
         );

--- a/backend/src/test/java/com/cubinghub/domain/growth/GrowthReadApiIntegrationTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/GrowthReadApiIntegrationTest.java
@@ -119,6 +119,28 @@ class GrowthReadApiIntegrationTest extends JpaIntegrationTest {
     }
 
     @Test
+    @DisplayName("summary activity는 오늘 포함 7일과 바로 앞 7일을 KST boundary로 집계한다")
+    void should_count_consecutive_current_and_previous_activity_windows_at_kst_boundaries() throws Exception {
+        saveRecord(owner, 24000, Penalty.NONE, Instant.parse("2026-07-29T14:59:59Z"));
+        saveRecord(owner, 23000, Penalty.NONE, Instant.parse("2026-07-29T15:00:00Z"));
+        saveRecord(owner, 22000, Penalty.NONE, Instant.parse("2026-08-04T15:00:00Z"));
+        saveRecord(owner, 21000, Penalty.NONE, Instant.parse("2026-08-05T14:59:59Z"));
+        saveRecord(owner, 20000, Penalty.NONE, Instant.parse("2026-08-05T15:00:00Z"));
+        saveRecord(owner, 19000, Penalty.NONE, Instant.parse("2026-08-11T15:00:30Z"));
+
+        mockMvc.perform(get("/api/users/me/growth")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .param("eventType", EventType.WCA_333.name())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.asOfDate").value("2026-08-12"))
+                .andExpect(jsonPath("$.data.activity.totalSolveCount").value(6))
+                .andExpect(jsonPath("$.data.activity.last7DaysSolveCount").value(2))
+                .andExpect(jsonPath("$.data.activity.previous7DaysSolveCount").value(3))
+                .andExpect(jsonPath("$.data.activity.last30DaysSolveCount").value(6));
+    }
+
+    @Test
     @DisplayName("trend는 30개의 KST date point에서 missing day와 DNF-only day를 구분한다")
     void should_return_fixed_trend_points_when_days_are_missing_or_dnf_only() throws Exception {
         saveRecord(owner, 10000, Penalty.NONE, Instant.parse("2026-08-09T15:30:00Z"));

--- a/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthTimeWindowsTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/metric/GrowthTimeWindowsTest.java
@@ -29,6 +29,26 @@ class GrowthTimeWindowsTest {
     }
 
     @Test
+    @DisplayName("activity comparison은 오늘 포함 7일과 바로 앞 7일을 gap 없이 만든다")
+    void should_create_consecutive_current_and_previous_activity_ranges() {
+        GrowthTimeWindows.ActivityComparisonWindow window = GrowthTimeWindows.activityComparisonWindow(
+                AS_OF_AUGUST_12_KST,
+                7
+        );
+
+        assertThat(window.asOfDate()).hasToString("2026-08-12");
+        assertThat(window.currentPeriod().fromDate()).hasToString("2026-08-06");
+        assertThat(window.currentPeriod().toDateExclusive()).hasToString("2026-08-13");
+        assertThat(window.currentPeriod().fromInclusive()).isEqualTo(Instant.parse("2026-08-05T15:00:00Z"));
+        assertThat(window.currentPeriod().toExclusive()).isEqualTo(Instant.parse("2026-08-12T15:00:00Z"));
+        assertThat(window.previousPeriod().fromDate()).hasToString("2026-07-30");
+        assertThat(window.previousPeriod().toDateExclusive()).hasToString("2026-08-06");
+        assertThat(window.previousPeriod().fromInclusive()).isEqualTo(Instant.parse("2026-07-29T15:00:00Z"));
+        assertThat(window.previousPeriod().toExclusive()).isEqualTo(Instant.parse("2026-08-05T15:00:00Z"));
+        assertThat(window.previousPeriod().toExclusive()).isEqualTo(window.currentPeriod().fromInclusive());
+    }
+
+    @Test
     @DisplayName("performance comparison은 partial today를 제외한 recent와 previous 7-day range를 만든다")
     void should_create_completed_recent_and_previous_seven_day_ranges() {
         GrowthTimeWindows.PerformanceComparisonWindow window = GrowthTimeWindows.performanceComparisonWindow(

--- a/backend/src/test/java/com/cubinghub/domain/growth/service/GrowthReadServiceTest.java
+++ b/backend/src/test/java/com/cubinghub/domain/growth/service/GrowthReadServiceTest.java
@@ -101,6 +101,16 @@ class GrowthReadServiceTest {
         assertThat(response.asOfDate()).hasToString("2026-08-12");
         assertThat(response.currentPb().recordId()).isEqualTo(1L);
         verify(clock, times(1)).instant();
+        verify(growthReadRepository).findActivitySummary(
+                1L,
+                EventType.WCA_333,
+                Instant.parse("2026-08-05T15:00:00Z"),
+                Instant.parse("2026-08-12T15:00:00Z"),
+                Instant.parse("2026-07-29T15:00:00Z"),
+                Instant.parse("2026-08-05T15:00:00Z"),
+                Instant.parse("2026-07-13T15:00:00Z"),
+                Instant.parse("2026-08-12T15:00:00Z")
+        );
     }
 
     @Test

--- a/docs/01-domain/growth-metrics.md
+++ b/docs/01-domain/growth-metrics.md
@@ -2,7 +2,7 @@
 doc_type: domain
 status: active
 created: 2026-08-11
-updated: 2026-08-12
+updated: 2026-08-14
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -99,7 +99,13 @@ Median은 이름이 지정된 population의 rankable effective value를 오름�
 - `asOfDate`는 response 생성 시점의 Asia/Seoul 날짜다.
 - 30-day chart/activity window는 `asOfDate - 29일` 00:00 inclusive부터 `asOfDate + 1일` 00:00 exclusive까지다. 오늘은 진행 중인 partial day임을 UI에 표시한다.
 - `last7DaysSolveCount`는 오늘을 포함한 7개 calendar date, `last30DaysSolveCount`는 오늘을 포함한 30개 calendar date다.
+- `previous7DaysSolveCount`는 `last7DaysSolveCount` 구간 바로 전의 연속 7개 calendar date다. 두 activity 구간 사이에는 gap이나 overlap이 없다.
 - performance 비교는 partial day 편향을 피하기 위해 오늘을 제외한 완료 calendar day를 사용한다.
+
+```text
+current activity 7 days  = [asOfDate - 6일 00:00, asOfDate + 1일 00:00)
+previous activity 7 days = [asOfDate - 13일 00:00, asOfDate - 6일 00:00)
+```
 
 ```text
 recent period   = [asOfDate - 7일 00:00, asOfDate 00:00)


### PR DESCRIPTION
## Problem

`previous7DaysSolveCount`가 activity 이전 7일이 아니라 performance comparison 이전 구간을 재사용해 하루 앞당겨지는 문제 수정

## Expected

`asOfDate=2026-08-12` 기준 구간:

- `last7`: 8월 6일~12일
- `previous7`: 7월 30일~8월 5일

## Fix

오늘 포함 최근 7일과 바로 앞 7일을 gap·overlap 없이 만드는 activity 전용 window 추가 및 performance comparison window와 계산 흐름 분리

## Regression

- `GrowthTimeWindows` KST calendar/UTC instant 경계 검증 추가
- `GrowthReadService` repository 전달 인자 exact 검증 추가
- API boundary fixture의 직전/최근 7일 count 검증 추가
- partial today를 제외하는 기존 performance comparison 계약 유지

로컬 Mac mini에는 Java runtime이 없어 Gradle 검증은 실행하지 못했으며 Java 25 GitHub Validate에서 확인 예정

## Out of Scope

- API shape 변경
- DB/schema 변경
- MySQL maintenance/release workflow 변경