### PR TITLE
ci: align performance benchmark with Java 25

### DIFF
--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Setup JDK 17
+      - name: Setup JDK 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: "temurin"
           cache: gradle
 

--- a/homeserver/scripts/workflow-config.test.mjs
+++ b/homeserver/scripts/workflow-config.test.mjs
@@ -8,6 +8,7 @@ const [
   deployWorkflow,
   reconcileWorkflow,
   benchmarkWorkflow,
+  backendBuild,
   pathClassifier,
   runtimeBaselineResolver,
   runtimeBaselineRecorder,
@@ -18,6 +19,7 @@ const [
     read("../../.github/workflows/deploy.yml"),
     read("../../.github/workflows/reconcile-runtime-baseline.yml"),
     read("../../.github/workflows/performance-benchmark.yml"),
+    read("../../backend/build.gradle"),
     read("../../scripts/classify-ci-paths.sh"),
     read("./resolve-runtime-config-baseline.sh"),
     read("./record-runtime-config-baseline.sh"),
@@ -284,6 +286,37 @@ test("should_buildBackendArtifactBeforeApiImage", () => {
     deployWorkflow,
     /name: backend-jar-\$\{\{ github\.sha \}\}/,
   );
+});
+
+test("should_alignJavaProvisioningWithBackendToolchain", () => {
+  const canonicalJavaVersion = javaToolchainVersion(backendBuild);
+  const workflowSetups = [
+    [
+      workflowJob(validateWorkflow, "backend"),
+      `Set up Java ${canonicalJavaVersion}`,
+    ],
+    [
+      workflowJob(benchmarkWorkflow, "benchmark"),
+      `Setup JDK ${canonicalJavaVersion}`,
+    ],
+  ];
+
+  assert.equal(canonicalJavaVersion, "25");
+
+  for (const [workflow, expectedStepName] of workflowSetups) {
+    const setupJavaStep = workflowActionStep(workflow, "actions/setup-java");
+
+    assert.match(
+      setupJavaStep,
+      new RegExp(`^      - name: ${expectedStepName}$`, "m"),
+    );
+    assert.match(
+      setupJavaStep,
+      new RegExp(`^          java-version: "${canonicalJavaVersion}"$`, "m"),
+    );
+    assert.match(setupJavaStep, /^          distribution: "?temurin"?$/m);
+    assert.match(setupJavaStep, /^          cache: gradle$/m);
+  }
 });
 
 test("should_publishOnlyFullShaArm64ImagesToGhcr", () => {
@@ -611,6 +644,41 @@ function workflowJob(workflow, jobId) {
   return nextJobOffset >= 0
     ? workflow.slice(start, bodyStart + nextJobOffset)
     : workflow.slice(start);
+}
+
+function workflowActionStep(workflow, actionName) {
+  const actionReferencesForName = actionReferences(workflow).filter(
+    (reference) => reference.startsWith(`${actionName}@`),
+  );
+
+  assert.equal(
+    actionReferencesForName.length,
+    1,
+    `Expected exactly one ${actionName} action`,
+  );
+
+  const actionOffset = workflow.indexOf(
+    `uses: ${actionReferencesForName[0]}`,
+  );
+  const stepStart = workflow.lastIndexOf("\n      - name: ", actionOffset);
+  const nextStepOffset = workflow.indexOf("\n      - name: ", actionOffset);
+
+  assert.ok(stepStart >= 0, `Missing step for ${actionName}`);
+
+  return workflow.slice(
+    stepStart + 1,
+    nextStepOffset >= 0 ? nextStepOffset : workflow.length,
+  );
+}
+
+function javaToolchainVersion(buildGradle) {
+  const versions = [
+    ...buildGradle.matchAll(/JavaLanguageVersion\.of\((\d+)\)/g),
+  ].map((match) => match[1]);
+
+  assert.equal(versions.length, 1, "Expected one Java toolchain version");
+
+  return versions[0];
 }
 
 function countMatches(value, pattern) {


### PR DESCRIPTION
## Problem

Backend Gradle toolchain은 Java 25인데 manual Performance Benchmark workflow는 Java 17을 provision해 `bootRun`이 toolchain을 찾지 못할 수 있다.

## Fix

- Performance Benchmark JDK 17 → 25 수정
- Validate의 Temurin·Gradle cache 설정과 정렬
- Gradle canonical Java major와 Validate·benchmark setup-java 계약을 비교하는 semantic regression 추가

## Validation

- Validate run `31797763289` 전체 성공
- Infrastructure checks에서 `workflow-config.test.mjs` 포함 workflow semantic tests 성공
- Workflow YAML parse 성공
- `git diff --check` 성공
- Backend·Frontend·API/Web ARM64 전체 검증 성공

## Manual Benchmark

Branch run `31798363112` 실행:

- Setup JDK 25 성공: Temurin `25.0.4+7`
- Gradle `compileJava`, `compileTestJava`, `test` 진입 및 Java toolchain resolution 오류 없음
- 전체 run은 `Recreate schema`의 120초 health wait 중 `bootRun → asciidoctor → test` chain이 아직 `:test`를 실행해 timeout
- Seed, backend benchmark startup, k6는 미실행

Java 25 provisioning fix는 확인됐으며 기존 bootRun startup timeout은 별도 범위다.

## Out of Scope

- Backend source 변경
- Dependency 변경
- Production 변경
- MySQL maintenance/release workflow 변경
- Benchmark bootRun dependency/health timeout 변경