### PR TITLE
release: publish runtime reconciliation credential fix

### DIFF
--- a/.github/workflows/reconcile-runtime-baseline.yml
+++ b/.github/workflows/reconcile-runtime-baseline.yml
@@ -37,18 +37,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  reconcile:
-    name: Verify and record runtime config baseline
+  validate-intent:
+    name: Validate runtime reconciliation intent
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    environment:
-      name: production-runtime-config
-      deployment: false
+    timeout-minutes: 5
     permissions:
       contents: read
-      deployments: write
-      id-token: write
 
     steps:
       - name: Check out repository history
@@ -82,6 +77,40 @@ jobs:
           git cat-file -e "${EXPECTED_RUNTIME_CONFIG_REVISION}^{commit}"
           git merge-base --is-ancestor "${EXPECTED_APPLICATION_REVISION}" "${GITHUB_SHA}"
           git merge-base --is-ancestor "${EXPECTED_RUNTIME_CONFIG_REVISION}" "${GITHUB_SHA}"
+
+  authorize-runtime-reconcile:
+    name: Authorize runtime reconciliation
+    needs:
+      - validate-intent
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment:
+      name: production-runtime-config
+      deployment: false
+    permissions:
+      contents: read
+
+    steps:
+      - name: Acknowledge runtime reconciliation authorization
+        run: printf '%s\n' 'Runtime reconciliation authorization acknowledged'
+
+  inspect-and-record:
+    name: Inspect and record runtime config baseline
+    needs:
+      - authorize-runtime-reconcile
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: production
+      deployment: false
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3

--- a/docs/07-operations/environments.md
+++ b/docs/07-operations/environments.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-08-10
-updated: 2026-08-12
+updated: 2026-08-15
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -33,6 +33,24 @@ local profile은 ddl-auto update와 Flyway disabled를 사용한다. production 
 repository Compose에는 MySQL 8.4.11 LTS, Redis 7.2.14, API, Web이 정의돼 있다. DB·Redis는 internal application network, API는 별도 outbound, Web은 external edge network를 사용한다. image·secret은 env로 주입한다.
 
 일반 application deploy는 실행 중인 data-service image와 candidate runtime config가 다르면 중단한다. MySQL 8.4.11 전환은 [DB와 이미지 백업·복구](../../homeserver/docs/db-backup-restore.md)의 별도 production migration gate를 통과한 뒤 실행한다.
+
+### GitHub production environments
+
+GitHub deployment environment는 application deployment와 runtime-config
+baseline의 책임을 분리한다.
+
+| GitHub environment | 역할 | Reconciliation 책임 |
+| --- | --- | --- |
+| `production` | API/Web application deployment history와 기존 Tailscale·SSH credential scope | Approval 뒤 read-only inspection job이 `deployment: false`로 참조 |
+| `production-runtime-config` | Production에 실제 적용·검증한 runtime-config history와 maintenance reconciliation approval | Secret 없이 authorization job이 `deployment: false`로 참조하고, 성공한 recorder가 baseline을 명시 기록 |
+
+Reconciliation은 environment가 없는 intent validation,
+`production-runtime-config` reviewer authorization, `production` credential을
+사용하는 inspection/record 순서로만 진행한다. 두 environment job 모두
+`deployment: false`이므로 workflow environment reference 자체가 application 또는
+runtime deployment history를 갱신하지 않는다. Inspection이 성공한 뒤
+`record-runtime-config-baseline.sh`만 `production-runtime-config`에 verified
+baseline을 생성한다. `production` application deployment history는 유지한다.
 
 ## Tracked legacy configuration
 

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-06-19
-updated: 2026-08-14
+updated: 2026-08-15
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -366,12 +366,19 @@ Upgrade smoke와 post-upgrade backup까지 성공한 뒤 GitHub Actions의
 `expected_db_volume`, `expected_mysql_version=8.4.11`을 maintenance evidence와
 일치하게 입력한다.
 
-Workflow의 restricted SSH inspector는 production을 변경하지 않는다. Verified
-runtime state·current pointer·release content, pending 부재, 실제 DB image·volume,
+Workflow는 environment가 없는 intent validation 뒤
+`production-runtime-config`의 `deployment: false` authorization job에서 required
+reviewer approval을 받는다. 이 job은 secret을 사용하거나 production에 접속하지
+않는다. Approval success 뒤에만 `production` environment를 `deployment: false`로
+참조하는 inspection job이 기존 Tailscale·SSH secret을 사용한다.
+
+Restricted SSH inspector는 production을 변경하지 않는다. Verified runtime
+state·current pointer·release content, pending 부재, 실제 DB image·volume,
 `SELECT VERSION()`, API/Web/DB/Redis health를 확인하고 operator 입력과 다시
-대조한다. 성공한 경우에만 별도 `production-runtime-config` deployment history에
-runtime revision·digest를 기록한다. 기존 `production` application deployment
-baseline은 유지한다.
+대조한다. 두 environment reference는 automatic Deployment object를 만들지
+않는다. 성공한 경우 recorder가 별도 `production-runtime-config` deployment
+history에 runtime revision·digest를 명시적으로 기록한다. 기존 `production`
+application deployment baseline은 유지한다.
 
 Runtime baseline success를 확인하기 전에는 normal production deploy를 재개하지
 않는다. Artifact publication이나 maintenance worker 성공만으로 GitHub baseline을

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -2,7 +2,7 @@
 doc_type: operation
 status: active
 created: 2026-06-19
-updated: 2026-08-14
+updated: 2026-08-15
 owner: xxh3898
 project: cubing-hub
 tags: []
@@ -203,21 +203,30 @@ expected_db_volume
 expected_mysql_version
 ```
 
-Workflow는 `production-runtime-config` environment의 approval boundary 안에서
-Tailscale과 restricted SSH를 사용한다. Forced command는 operation lock을
+Workflow는 intent validation, approval과 credential access를 별도 job으로
+분리한다. Environment가 없는 validation job이 exact expected identity와 commit
+ancestry를 먼저 확인한다. 이어지는 authorization job만
+`production-runtime-config` environment를 `deployment: false`로 참조해 required
+reviewer approval을 받으며 secret이나 production connection을 사용하지 않는다.
+
+Inspection job은 authorization success를 `needs`로 요구하고 `production`
+environment를 `deployment: false`로 참조한다. 이 job에서만 기존 production
+Tailscale·restricted SSH secret에 접근한다. Forced command는 operation lock을
 non-blocking으로 확인한 뒤 `state`, `current`, release content hash, pending
 부재, `.env`와 effective Compose binding, 실제 API/Web·DB image, DB volume,
 `SELECT VERSION()`, API/Web/DB/Redis health를 read-only로 검증한다. Host state는
 수정하지 않으며 exact expected value가 하나라도 다르면 GitHub baseline을
 기록하지 않는다.
 
-검증이 성공하면 `production-runtime-config`에 `maintenance-reconcile` success를
-기록한다. `production` application deployment 이력은 바꾸지 않는다. GitHub
-environment에 필요한 reviewer·secret은 repository 밖 운영 prerequisite다.
-Workflow job은 environment approval을 적용하되 별도 자동 deployment record는
-만들지 않도록 구성되어 있다. Custom deployment protection rule을 함께 쓰는
-경우 이 설정과 호환되지 않으므로 사전에 확인한다. Reconciliation success 전에는
-normal production deploy를 재개하지 않는다.
+두 environment job의 `deployment: false`는 environment protection과 secret
+scope를 적용하면서 workflow reference 자체의 automatic Deployment object는
+만들지 않는다. 검증이 성공한 뒤 recorder가 명시적으로
+`production-runtime-config`에 `maintenance-reconcile` success를 기록한다.
+`production` application deployment 이력은 바꾸지 않는다.
+`production-runtime-config` reviewer와 `production` credential secret은
+repository 밖 운영 prerequisite다. Custom deployment protection rule을 함께
+쓰는 경우 `deployment: false`와 호환되지 않으므로 사전에 확인한다.
+Reconciliation success 전에는 normal production deploy를 재개하지 않는다.
 
 첫 배포는 기존 image SHA가 없으므로 다음 순서로 진행한다.
 

--- a/homeserver/scripts/workflow-config.test.mjs
+++ b/homeserver/scripts/workflow-config.test.mjs
@@ -460,7 +460,15 @@ test("should_applyLeastPrivilegePermissionsPerJob", () => {
   const publish = workflowJob(deployWorkflow, "publish");
   const deploy = workflowJob(deployWorkflow, "deploy");
   const recordRuntime = workflowJob(deployWorkflow, "record-runtime-baseline");
-  const reconcile = workflowJob(reconcileWorkflow, "reconcile");
+  const validateIntent = workflowJob(reconcileWorkflow, "validate-intent");
+  const authorizeRuntime = workflowJob(
+    reconcileWorkflow,
+    "authorize-runtime-reconcile",
+  );
+  const inspectAndRecord = workflowJob(
+    reconcileWorkflow,
+    "inspect-and-record",
+  );
 
   assert.match(publish, /actions: read/);
   assert.match(publish, /contents: read/);
@@ -477,13 +485,32 @@ test("should_applyLeastPrivilegePermissionsPerJob", () => {
   assert.match(recordRuntime, /deployments: write/);
   assert.doesNotMatch(recordRuntime, /id-token: write|packages: write/);
 
-  assert.match(reconcile, /contents: read/);
-  assert.match(reconcile, /deployments: write/);
-  assert.match(reconcile, /id-token: write/);
-  assert.doesNotMatch(reconcile, /contents: write|packages: write|actions: write/);
+  assert.match(validateIntent, /contents: read/);
+  assert.doesNotMatch(
+    validateIntent,
+    /contents: write|deployments: write|id-token: write|packages: write|actions: write/,
+  );
+
+  assert.match(authorizeRuntime, /contents: read/);
+  assert.doesNotMatch(
+    authorizeRuntime,
+    /contents: write|deployments: write|id-token: write|packages: write|actions: write/,
+  );
+
+  assert.match(inspectAndRecord, /contents: read/);
+  assert.match(inspectAndRecord, /deployments: write/);
+  assert.match(inspectAndRecord, /id-token: write/);
+  assert.doesNotMatch(
+    inspectAndRecord,
+    /contents: write|packages: write|actions: write/,
+  );
   assert.match(
-    reconcile,
+    authorizeRuntime,
     /environment:\n      name: production-runtime-config\n      deployment: false/,
+  );
+  assert.match(
+    inspectAndRecord,
+    /environment:\n      name: production\n      deployment: false/,
   );
 });
 
@@ -508,6 +535,84 @@ test("should_useTailscaleOidcAndRestrictedSshForDeployment", () => {
     /inspection_command="inspect-cubing-hub-runtime \$\{EXPECTED_APPLICATION_REVISION\} \$\{EXPECTED_RUNTIME_CONFIG_REVISION\} \$\{EXPECTED_RUNTIME_CONFIG_DIGEST\} \$\{EXPECTED_DB_IMAGE\} \$\{EXPECTED_DB_VOLUME\} \$\{EXPECTED_MYSQL_VERSION\}"/,
   );
   assert.doesNotMatch(reconcileWorkflow, /ssh-keyscan|StrictHostKeyChecking=no/);
+});
+
+test("should_gateRuntimeReconciliationApprovalBeforeProductionCredentialAccess", () => {
+  const validateIntent = workflowJob(reconcileWorkflow, "validate-intent");
+  const authorizeRuntime = workflowJob(
+    reconcileWorkflow,
+    "authorize-runtime-reconcile",
+  );
+  const inspectAndRecord = workflowJob(
+    reconcileWorkflow,
+    "inspect-and-record",
+  );
+  const credentialSecrets = [
+    "TS_OAUTH_CLIENT_ID",
+    "TS_AUDIENCE",
+    "HOME_MINI_SSH_KEY",
+    "HOME_MINI_KNOWN_HOSTS",
+  ];
+  const reconciliationInputs = [
+    "expected_application_revision",
+    "expected_runtime_config_revision",
+    "expected_runtime_config_digest",
+    "expected_db_image",
+    "expected_db_volume",
+    "expected_mysql_version",
+  ];
+
+  assert.match(
+    reconcileWorkflow,
+    /concurrency:\n  group: cubing-hub-production\n  cancel-in-progress: false/,
+  );
+
+  assert.doesNotMatch(validateIntent, /^    environment:/m);
+  assert.doesNotMatch(validateIntent, /\$\{\{ secrets\./);
+
+  assert.match(
+    authorizeRuntime,
+    /^    needs:\n      - validate-intent$/m,
+  );
+  assert.match(
+    authorizeRuntime,
+    /environment:\n      name: production-runtime-config\n      deployment: false/,
+  );
+  assert.doesNotMatch(authorizeRuntime, /\$\{\{ secrets\./);
+  assert.doesNotMatch(authorizeRuntime, /always\(\)/);
+  assert.doesNotMatch(
+    authorizeRuntime,
+    /tailscale\/github-action|Configure restricted SSH|inspect-cubing-hub-runtime/,
+  );
+
+  assert.match(
+    inspectAndRecord,
+    /^    needs:\n      - authorize-runtime-reconcile$/m,
+  );
+  assert.doesNotMatch(inspectAndRecord, /always\(\)|- validate-intent/);
+  assert.match(
+    inspectAndRecord,
+    /environment:\n      name: production\n      deployment: false/,
+  );
+
+  for (const secret of credentialSecrets) {
+    const reference = `\${{ secrets.${secret} }}`;
+
+    assert.equal(countLiteral(reconcileWorkflow, reference), 1);
+    assert.match(inspectAndRecord, new RegExp(`secrets\\.${secret}`));
+  }
+
+  for (const input of reconciliationInputs) {
+    const reference = new RegExp(`inputs\\.${input}`);
+
+    assert.match(validateIntent, reference);
+    assert.match(inspectAndRecord, reference);
+  }
+
+  assert.match(
+    runtimeBaselineRecorder,
+    /readonly RUNTIME_ENVIRONMENT=production-runtime-config/,
+  );
 });
 
 test("should_recordRuntimeBaselineOnlyAfterSafeRuntimeDeploySuccess", () => {
@@ -536,15 +641,19 @@ test("should_recordRuntimeBaselineOnlyAfterSafeRuntimeDeploySuccess", () => {
 });
 
 test("should_reconcileOnlyExplicitVerifiedHostStateWithoutMutatingProduction", () => {
-  const reconcile = workflowJob(reconcileWorkflow, "reconcile");
+  const validateIntent = workflowJob(reconcileWorkflow, "validate-intent");
+  const inspectAndRecord = workflowJob(
+    reconcileWorkflow,
+    "inspect-and-record",
+  );
 
   assert.match(reconcileWorkflow, /^on:\n  workflow_dispatch:/m);
   assert.doesNotMatch(reconcileWorkflow, /\n  push:|\n  pull_request:/);
-  assert.match(reconcile, /if: github\.ref == 'refs\/heads\/main'/);
-  assert.match(reconcile, /git merge-base --is-ancestor/);
-  assert.match(reconcile, /verify-runtime-baseline-inspection\.sh/);
+  assert.match(validateIntent, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(validateIntent, /git merge-base --is-ancestor/);
+  assert.match(inspectAndRecord, /verify-runtime-baseline-inspection\.sh/);
   assert.match(
-    reconcile,
+    inspectAndRecord,
     /record-runtime-config-baseline\.sh \\\n+\s+maintenance-reconcile/,
   );
   assert.match(runtimeInspectionVerifier, /APPLICATION_REVISION/);
@@ -683,6 +792,10 @@ function javaToolchainVersion(buildGradle) {
 
 function countMatches(value, pattern) {
   return [...value.matchAll(pattern)].length;
+}
+
+function countLiteral(value, needle) {
+  return value.split(needle).length - 1;
 }
 
 function actionReferences(workflow) {


### PR DESCRIPTION
## Goal

Post-maintenance runtime reconciliation의 approval boundary와 production credential scope 분리를 official main release에 반영한다.

## Release scope

- `production-runtime-config` reviewer approval job 분리
- `production` environment의 기존 Tailscale/SSH credential 사용
- 두 environment job의 `deployment: false` 유지
- verified runtime baseline destination을 `production-runtime-config`로 유지
- workflow semantic regression과 운영 문서 동기화

## Production behavior

이 merge는 다음 흐름을 기대한다.

- Main release validation
- API/Web ARM64 image publication
- Immutable runtime-config publication
- `runtime_config_mode=update`
- `data_service_maintenance_required=true`
- Production deploy skip
- Runtime baseline unchanged

Published API/Web images는 이 release에서 production에 배포하지 않는다.

## Runtime baseline

현재 resolver는 legacy production success `b8e243ed65dd016772ffe928d3675979842383e7`을 bootstrap baseline으로 사용한다. Artifact publication만으로 `production-runtime-config` baseline을 갱신하지 않는다.

## Database

- Before: MySQL 8.0.46
- Target: MySQL 8.4.11
- Volume: `cubing-hub_mysql-data` 유지

이 PR은 production DB cutover를 수행하지 않는다.

## Validation

- PR #35 required checks green
- Dev merge push Validate run `31815068778` green
- Runtime config detector: `update`
- Data-service maintenance detector: `true`
- Main-only release merge commit과 previous dev tree 동일
- PR #35 Codex review major issue 없음, review threads 0

## Operations

Main release 성공 뒤 새 runtime revision/digest를 고정하고 production final change gate를 다시 수행한다. Runtime reconciliation은 MySQL 8.4 maintenance, smoke, post-upgrade backup 뒤에만 실행한다.

## Out of Scope

- Production deploy
- MySQL maintenance apply
- Runtime reconciliation 실행
- Tag 또는 GitHub Release 생성