### PR TITLE
chore: add MySQL maintenance quiesce gate

### DIFF
--- a/docs/03-architecture/deployment-architecture.md
+++ b/docs/03-architecture/deployment-architecture.md
@@ -65,7 +65,9 @@ application·runtime config 실패는 이전에 검증된 exact pair로 복구�
 - source와 target DB volume
 - verified pre-transition backup
 
-Maintenance도 deploy·backup과 같은 operation lock과 canonical `runtime-config/pending`을 사용한다. 성공 후에만 explicit DB binding, verified runtime `state`·`current`, maintenance audit state를 확정한다. Rollback은 upgraded original volume을 보존하고, backup parity를 검증한 fresh 이전-engine volume으로 binding을 전환한다.
+Maintenance도 deploy·backup과 같은 operation lock과 canonical `runtime-config/pending`을 사용한다. Operation lock은 command 실행을 직렬화하고, 별도 `mysql-maintenance/quiesce.state`는 command 사이의 application write-stop을 증명한다. Quiesce는 verified source에서 API·Web만 중지하고 DB·Redis를 healthy 상태로 유지한다. Normal deploy/recovery는 evidence가 있는 동안 fail closed하며 final backup은 pending 이전 quiesced state에서 허용한다.
+
+Upgrade candidate는 quiesce evidence ID·timestamp와 quiesce 이후 시작한 final backup을 source runtime·DB identity에 묶는다. Human confirmation token만으로 `apply`할 수 없다. 성공 후에만 explicit DB binding, verified runtime `state`·`current`, maintenance audit state를 확정하고 pending과 quiesce evidence를 제거한다. DB transition 전 취소는 unchanged source에서만 `resume-source`가 담당하고, pending 이후에는 dedicated recover/rollback이 우선한다. Rollback은 upgraded original volume을 보존하고, backup parity를 검증한 fresh 이전-engine volume으로 binding을 전환한다.
 
 Main release가 data-service maintenance를 요구하면 GitHub Actions는 runtime-config revision과 digest를 기록한 뒤 production environment, Tailscale, SSH 단계 전에 deploy job을 skip한다. Host deploy worker의 drift guard도 독립된 방어선으로 유지한다.
 

--- a/docs/07-operations/backup-restore.md
+++ b/docs/07-operations/backup-restore.md
@@ -31,6 +31,8 @@ Redis는 현재 backup set에서 제외된다. ranking은 MySQL에서 rebuild하
 
 restore는 격리된 target, write freeze, source snapshot, schema·engine version, expected count와 rollback을 먼저 확인한다. DB와 image를 같은 set에서 복구하고 application smoke와 ranking rebuild를 수행한다.
 
-MySQL engine rollback은 upgraded original volume을 downgrade하지 않는다. Pre-upgrade backup을 fresh 이전-engine volume에 restore·검증한 뒤 dedicated maintenance candidate로 runtime binding을 전환한다. Candidate·restore evidence·exact command는 command-level Source of Truth를 따른다.
+MySQL engine maintenance의 final backup은 canonical quiesce evidence가 만들어진 뒤 시작해야 한다. Quiesce는 API·Web write path와 post-image write를 중지하고 DB를 healthy 상태로 유지한다. Backup manifest는 실제 DB exact image·image ID·volume을 기록하고, candidate는 source runtime·DB identity와 backup 시작 시각을 quiesce evidence에 결합한다. Human confirmation token만으로 cutover를 허용하지 않는다.
+
+MySQL engine rollback은 upgraded original volume을 downgrade하지 않는다. Pre-upgrade backup을 fresh 이전-engine volume에 restore·검증한 뒤 dedicated maintenance candidate로 runtime binding을 전환한다. Candidate·quiesce·restore evidence·exact command는 command-level Source of Truth를 따른다.
 
 실제 backup, restore, retention 삭제는 각각 별도 운영·data 승인 대상이다.

--- a/homeserver/docs/db-backup-restore.md
+++ b/homeserver/docs/db-backup-restore.md
@@ -72,8 +72,8 @@ Backup worker는 HomeOps에 실제 경로가 아닌 `cubing-hub/data/...` logica
 5. dump의 제한된 single-row INSERT를 streaming 해석해 같은 transaction
    snapshot의 table row count와 `post_attachments.object_key` 목록 생성
 6. dump reference와 snapshot 파일 대조
-7. DB engine/version, row-count/reference source·SHA-256, 파일
-   count·bytes·SHA-256 기록
+7. 실제 DB exact image·image ID·volume·engine/version,
+   row-count/reference source·SHA-256, 파일 count·bytes·SHA-256 기록
 8. `manifest.json` 생성 뒤 `SUCCESS` marker를 마지막으로 생성
 9. 검증한 임시 directory를 최종 backup 이름으로 원자 이동
 10. 삭제하지 않는 retention dry-run plan 생성
@@ -282,9 +282,32 @@ test "$(/usr/bin/shasum -a 256 "${source_script}" | /usr/bin/awk '{print $1}')" 
 - maintenance worker source/install SHA-256 일치
 - post-maintenance inspection을 지원하는 approved stable deploy wrapper 설치와 SHA-256 검증
 
+### Application quiesce
+
+Maintenance final backup 전에 canonical worker로 application write path를 중단한다. `quiesce`는 current verified runtime, 실제 API·Web container image, DB image·volume·`SELECT VERSION()`을 확인하고 공통 operation lock 아래 API·Web을 중지한다. DB와 Redis는 running·healthy 상태로 유지한다.
+
+```bash
+maintenance=/Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh
+"${maintenance}" status
+"${maintenance}" quiesce
+"${maintenance}" status
+```
+
+성공하면 `runtime-config/mysql-maintenance/quiesce.state`에 application/runtime identity, runtime content hash, exact DB image와 image ID, volume, MySQL patch, UTC quiesce 시각과 content-derived evidence ID를 mode `400`으로 기록한다. 이 파일은 operation lock을 대신하지 않는다. Lock은 command 실행을 직렬화하고, quiesce evidence는 final backup·restore rehearsal·candidate 준비 사이에 유지되는 maintenance-window state다.
+
+Quiesce evidence가 있으면 stable deploy wrapper와 active deploy worker는 normal deploy와 normal deploy recovery를 fail closed한다. Canonical backup bootstrap은 DB가 healthy하고 maintenance `pending`이 없는 동안 계속 사용할 수 있으므로 stopped API·Web과 정지된 post-image write path에서 final snapshot을 만든다. Read-only inspection은 별도 command contract를 유지한다.
+
+DB transition을 시작하지 않았고 `pending`이 없으며 source runtime과 MySQL 8.0.46 binding이 그대로라면 아래 command만 source API·Web을 다시 시작하고 전체 health를 확인한 뒤 evidence를 제거한다.
+
+```bash
+"${maintenance}" resume-source
+```
+
+`pending`이 생겼거나 DB/runtime binding이 target으로 이동한 뒤에는 `resume-source`를 사용하지 않는다. Dedicated `recover` 또는 verified rollback candidate를 사용한다.
+
 ### Immutable upgrade candidate
 
-Candidate 생성은 running runtime을 변경하지 않는다. `state`, `current`, `.env`, container는 그대로 유지한다. Exact runtime release가 없으면 `runtime-config/releases/<digest>`에 검증본을 staging하고, `runtime-config/mysql-maintenance/candidates/<candidate-id>/candidate.env`를 생성한다. Backup manifest의 `source.applicationSha`와 `source.runtimeConfigDigest`는 candidate source application revision·runtime digest와 정확히 일치해야 한다. Source metadata가 없거나 다른 runtime에서 생성한 backup이면 candidate를 만들지 않는다.
+Candidate 생성은 quiesced source의 `state`, `current`, `.env`, DB/Redis container를 변경하지 않는다. Exact runtime release가 없으면 `runtime-config/releases/<digest>`에 검증본을 staging하고, `runtime-config/mysql-maintenance/candidates/<candidate-id>/candidate.env`를 생성한다. Backup manifest의 `source.applicationSha`와 `source.runtimeConfigDigest`는 candidate source application revision·runtime digest와 정확히 일치해야 한다. Manifest의 DB exact image·image ID·volume도 quiesce evidence와 정확히 일치해야 하며, backup `startedAt`은 active quiesce 시각보다 뒤여야 한다. Source metadata나 DB binding evidence가 없거나 다른 runtime/DB에서 생성했거나 quiesce 이전 또는 같은 초에 시작한 backup이면 candidate를 만들지 않는다.
 
 ```bash
 maintenance=/Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh
@@ -315,18 +338,20 @@ target runtime revision/content hash
 source/target DB image tag, repository digest, local image ID
 source/target DB volume
 backup identifier/manifest SHA-256
+quiesce evidence ID/timestamp
 created timestamp
 ```
 
-API·Web image drift, Redis·network·DB command drift, target image digest 불일치, backup evidence 부재·source runtime 불일치, current state/pointer/actual DB 불일치는 candidate 생성을 차단한다.
+API·Web image drift, Redis·network·DB command drift, target image digest 불일치, backup evidence 부재·source runtime 불일치, current state/pointer/actual DB 불일치, missing/stale quiesce evidence는 candidate 생성을 차단한다. 새 candidate schema를 적용하기 전에 만든 candidate는 historical preparation evidence이며 final `apply`에 사용할 수 없다.
 
 ### Upgrade
 
-1. application write를 중단하고 maintenance 상태를 확인한다.
-2. 운영 backup worker로 pre-upgrade logical backup과 게시글 image snapshot을 만든다.
-3. `SUCCESS`, manifest, dump·image checksum, engine/version, row count를 검증한다.
-4. 별도 fresh MySQL 8.4.11 환경에 backup을 restore하고 schema, FK, index, Flyway history, 핵심 row count를 확인한다.
-5. 기록한 candidate ID와 write stop을 다시 확인한 뒤 아래 command를 실행한다.
+1. `status`로 pending·quiesce 상태를 확인하고 `quiesce`로 API·Web을 중단한다. Evidence와 실제 stopped state를 다시 확인한다.
+2. 운영 backup worker로 quiesce 이후 시작한 final logical backup과 게시글 image snapshot을 만든다.
+3. `SUCCESS`, manifest, dump·image checksum, engine/version, row count, source provenance, exact DB image·image ID·volume과 `startedAt > QUIESCED_AT`을 검증한다.
+4. 별도 fresh MySQL 8.4.11 환경에 같은 backup을 restore하고 schema, FK, index, Flyway history, 핵심 row count를 확인한다.
+5. 같은 final backup으로 `prepare-upgrade`를 실행하고 fresh MySQL 8.0.46 rollback volume을 restore한 뒤 `verify-rollback-volume` evidence까지 준비한다.
+6. 기록한 candidate ID, active quiesce evidence와 write stop을 다시 확인한 뒤 아래 command를 실행한다.
 
    ```bash
    maintenance=/Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh
@@ -334,17 +359,18 @@ API·Web image drift, Redis·network·DB command drift, target image digest 불�
    "${maintenance}" apply "${candidate_id}" WRITE_STOP_CONFIRMED
    ```
 
-6. Worker는 공통 operation lock을 획득하고 current state·pointer·actual DB identity를 다시 검증한다. 첫 service mutation 전에 canonical `runtime-config/pending`을 생성한 뒤 API/Web과 DB를 정상 종료하고 exact 8.4.11 image에 original volume을 연결한다.
-7. Target DB와 application 전체 health gate를 통과하기 전에는 `.env`, runtime config `state`·`current`가 마지막 committed source binding을 유지한다. Target DB image·volume은 maintenance worker가 Compose process override로만 전달한다.
-8. Exact `mysql:8.4.11@sha256:<digest>` 형식과 Docker image ID만으로 server version을 확정하지 않는다. Target DB health와 image·volume identity 확인 직후 running container에서 `SELECT VERSION()`을 실행하고, `8.4.11` 또는 배포 suffix가 붙은 동일 patch인지 확인한 뒤에만 Redis/API/Web을 시작한다.
-9. MySQL version gate와 application 전체 service health가 성공한 뒤에만 runtime config `state`·`current`, `.env`의 `DB_IMAGE`·`DB_VOLUME_NAME`, `mysql-maintenance/state`를 확정하고 `pending`을 제거한다. 이어서 charset/collation, application DB user의 `caching_sha2_password` 연결, Flyway validation을 확인한다.
-10. users, records, user_pbs, posts/comments 수와 PB·Penalty 분포, Record ID·timestamp 범위를 pre-upgrade evidence와 대조한다.
-11. API health, auth, Record create/PATCH/delete, Ranking, Growth summary/trend/progression, Community와 image read smoke를 수행한다.
-12. 모든 gate가 끝난 뒤에만 write를 재개한다.
-13. MySQL 8.4.11 상태에서 post-upgrade backup을 생성하고 manifest·checksum을 검증한다.
-14. 아래 post-maintenance runtime baseline reconciliation을 성공시킨 뒤 normal production deploy를 재개한다.
+7. `WRITE_STOP_CONFIRMED` literal은 operator approval이며 단독 write-stop 증거가 아니다. Worker는 공통 operation lock을 획득한 뒤 quiesce evidence와 candidate identity, API·Web stopped state, source DB health·identity, final backup binding을 모두 재검증한다. 첫 DB mutation 전에 canonical `runtime-config/pending`을 생성하고 이미 stopped인 API·Web stop을 idempotent하게 확인한 뒤 DB를 정상 종료해 exact 8.4.11 image에 original volume을 연결한다.
+8. Target DB와 application 전체 health gate를 통과하기 전에는 `.env`, runtime config `state`·`current`가 마지막 committed source binding을 유지한다. Target DB image·volume은 maintenance worker가 Compose process override로만 전달한다.
+9. Exact `mysql:8.4.11@sha256:<digest>` 형식과 Docker image ID만으로 server version을 확정하지 않는다. Target DB health와 image·volume identity 확인 직후 running container에서 `SELECT VERSION()`을 실행하고, `8.4.11` 또는 배포 suffix가 붙은 동일 patch인지 확인한 뒤에만 Redis/API/Web을 시작한다.
+10. MySQL version gate와 application 전체 service health가 성공한 뒤에만 runtime config `state`·`current`, `.env`의 `DB_IMAGE`·`DB_VOLUME_NAME`, `mysql-maintenance/state`를 확정하고 `pending`을 제거한다. 마지막으로 quiesce evidence를 제거한다. 중간 실패에서는 pending과 evidence를 보존한다.
+11. charset/collation, application DB user의 `caching_sha2_password` 연결, Flyway validation을 확인한다.
+12. users, records, user_pbs, posts/comments 수와 PB·Penalty 분포, Record ID·timestamp 범위를 pre-upgrade evidence와 대조한다.
+13. API health, auth, Record create/PATCH/delete, Ranking, Growth summary/trend/progression, Community와 image read smoke를 수행한다.
+14. 모든 gate가 끝난 뒤에만 write를 재개한다.
+15. MySQL 8.4.11 상태에서 post-upgrade backup을 생성하고 manifest·checksum을 검증한다.
+16. 아래 post-maintenance runtime baseline reconciliation을 성공시킨 뒤 normal production deploy를 재개한다.
 
-`apply`가 target DB startup 뒤 state/current 확정 전에 중단됐다면 normal deploy `recover`가 아니라 dedicated maintenance recovery를 사용한다. Recovery는 target DB identity와 health를 먼저 확인하고 `SELECT VERSION()`으로 candidate operation의 exact target patch를 다시 검증한 뒤 API·Web을 candidate binding으로 기동한다. 전체 service가 healthy인 경우에만 partial state를 확정한다.
+`apply`가 target DB startup 뒤 state/current 확정 전에 중단됐다면 normal deploy `recover`가 아니라 dedicated maintenance recovery를 사용한다. Recovery는 pending candidate와 active quiesce evidence binding, target DB identity와 health를 먼저 확인하고 `SELECT VERSION()`으로 candidate operation의 exact target patch를 다시 검증한 뒤 API·Web을 candidate binding으로 기동한다. 전체 service가 healthy인 경우에만 partial state를 확정하고 evidence를 제거한다. Success state와 pending 제거까지 완료되고 마지막 evidence unlink만 중단된 경우에도 dedicated `recover`가 completed maintenance state, current target identity와 전체 health를 재검증한 뒤 evidence cleanup만 마친다.
 
 ```bash
 /Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh recover
@@ -516,7 +542,9 @@ rollback_candidate_id="$(
 "${maintenance}" apply "${rollback_candidate_id}" WRITE_STOP_CONFIRMED
 ```
 
-Rollback candidate는 target runtime release와 current API·Web image를 유지하고 DB binding만 exact MySQL 8.0.46 image·verified fresh volume로 바꾼다. `SOURCE_DB_VOLUME`과 `TARGET_DB_VOLUME`이 같거나 restore evidence가 없으면 candidate/apply를 차단한다. `apply`는 과거 restore evidence만 신뢰하지 않는다. Cutover 직전에 exact MySQL 8.0.46 임시 container로 rollback volume의 version, table inventory, manifest row count를 다시 검증하고 container를 제거한 뒤에만 pending 기록과 service 전환을 시작한다. Production binding으로 시작한 rollback target도 health·identity 뒤 `SELECT VERSION()`이 exact 8.0.46인지 다시 확인하며, 성공 후에도 original upgraded volume은 그대로 보존한다.
+Completed upgrade에서 rollback candidate를 준비하려면 현재 MySQL 8.4.11 source를 먼저 `quiesce`한다. Upgrade `pending`에서 즉시 rollback하는 경우에는 그 pending candidate가 보존한 original quiesce evidence를 이어받는다. State나 evidence를 직접 바꾸어 이 경계를 우회하지 않는다.
+
+Rollback candidate는 target runtime release와 current API·Web image를 유지하고 DB binding만 exact MySQL 8.0.46 image·verified fresh volume로 바꾼다. `SOURCE_DB_VOLUME`과 `TARGET_DB_VOLUME`이 같거나 restore evidence·active quiesce evidence가 없으면 candidate/apply를 차단한다. `apply`는 과거 restore evidence만 신뢰하지 않는다. Cutover 직전에 exact MySQL 8.0.46 임시 container로 rollback volume의 version, table inventory, manifest row count를 다시 검증하고 container를 제거한 뒤에만 pending 기록과 service 전환을 시작한다. Production binding으로 시작한 rollback target도 health·identity 뒤 `SELECT VERSION()`이 exact 8.0.46인지 다시 확인하며, 성공 후에도 original upgraded volume은 그대로 보존한다.
 
 Rollback `apply`가 target MySQL을 healthy 상태로 만들기 전에 중단되면 canonical `pending`의 `OPERATION=ROLLBACK`과 `CANDIDATE_ID`를 확인한 뒤 같은 command를 다시 실행한다. Worker는 동일 rollback candidate와 source upgrade candidate, restore evidence, application image, target image·volume을 모두 다시 검증한다. Candidate와 일치하는 unhealthy target container가 남아 있으면 volume을 보존한 채 container만 stop/remove하고 content parity를 다시 확인한다. 첫 `apply`의 검증 결과를 재사용하지 않으며, 다른 rollback candidate는 pending transaction을 이어받을 수 없다.
 
@@ -532,6 +560,9 @@ Target rollback DB가 이미 healthy하고 application/runtime state 확정만 �
 
 ### State와 중단 처리
 
+- `quiesce.state`는 API·Web write-stop의 persistent evidence다. Candidate는 evidence ID·timestamp를 고정하며 literal confirmation token만으로 `apply`할 수 없다.
+- Operation lock은 deploy·backup·quiesce·resume·prepare·apply·recover command 실행을 직렬화한다. Quiesce evidence는 lock 해제 뒤에도 maintenance window state를 유지한다.
+- Quiesced 상태의 normal deploy와 normal deploy recovery는 fail closed한다. Final backup은 pending이 생기기 전까지 canonical backup bootstrap으로 허용한다.
 - Candidate 생성은 `state`, `current`, `.env`, container를 변경하지 않는다.
 - `apply`는 첫 container stop 전에 canonical `runtime-config/pending`을 원자 생성한다. 이 동안 normal deploy와 backup은 fail closed한다.
 - Target DB와 application 전체 health를 확인하기 전에는 `.env`, `state`, `current`가 source binding을 유지한다. Worker는 candidate DB binding을 Compose process override로만 사용한다.
@@ -539,6 +570,7 @@ Target rollback DB가 이미 healthy하고 application/runtime state 확정만 �
 - `ROLLBACK` pending에서 target DB가 아직 healthy하지 않으면 동일 candidate의 `apply`만 재시도할 수 있다. Pending candidate ID·context나 restore evidence가 다르면 중단한다.
 - Rollback `apply`는 최초 실행과 재시도 모두 cutover 직전에 fresh volume의 current table inventory·row count를 backup manifest와 대조한다. 사전 restore evidence만으로 전환하지 않는다.
 - Target DB가 healthy하지만 application startup이나 success finalization이 끝나지 않았으면 `recover`를 사용한다. `recover`는 pending candidate의 target image ID·volume·health와 actual MySQL patch가 일치할 때만 application을 기동하고, 전체 service health 뒤 source/target 중간 state를 target으로 확정해 `.env` binding을 기록한다.
+- 성공 finalization은 pending을 제거한 뒤 quiesce evidence를 제거한다. 실패하면 evidence를 보존하며, DB transition 전 취소만 `resume-source`로 처리한다.
 - 성공 state의 current/previous runtime은 모두 explicit DB binding을 지원하는 target release를 가리킨다. Maintenance source release는 immutable candidate에 보존한다.
 - Target이 healthy하지 않으면 `recover`로 source를 자동 재연결하지 않는다. Fresh rollback volume을 검증한 뒤 rollback candidate를 적용한다.
 - Candidate, restore evidence, pending, maintenance state에는 secret을 남기지 않는다.

--- a/homeserver/docs/home-server-runbook.md
+++ b/homeserver/docs/home-server-runbook.md
@@ -186,6 +186,18 @@ MySQL engine image·volume binding은 일반 deploy worker의 예외로 허용�
 
 Command별 exact 절차, fresh rollback volume 준비, dedicated recovery는 [DB와 이미지 백업·복구](db-backup-restore.md)를 따른다.
 
+MySQL cutover의 canonical write-stop은 maintenance worker의 `quiesce`다. Worker는 current verified runtime과 DB identity를 검증하고 API·Web을 중지한 뒤 `runtime-config/mysql-maintenance/quiesce.state`에 immutable evidence를 남긴다. 이 상태에서는 normal deploy와 normal deploy recovery가 fail closed하지만, `pending`이 생기기 전 canonical backup bootstrap은 final DB·post-image snapshot을 만들 수 있다. `WRITE_STOP_CONFIRMED` token만으로는 maintenance `apply`를 실행할 수 없다.
+
+```bash
+maintenance=/Users/homeserver/Server/scripts/maintenance/mysql-maintenance-cubing-hub.sh
+"${maintenance}" status
+"${maintenance}" quiesce
+# final backup, restore rehearsal, candidate와 rollback evidence 준비
+"${maintenance}" apply '<candidate-id>' WRITE_STOP_CONFIRMED
+```
+
+DB transition 전에 maintenance를 취소하려면 `pending` 부재와 unchanged MySQL 8.0.46 source를 확인한 뒤 `"${maintenance}" resume-source`를 사용한다. Pending 또는 target binding에서는 normal deploy나 `resume-source`로 복구하지 않고 dedicated `recover`/rollback contract를 따른다. Operation lock은 command 단위 직렬화이고 quiesce evidence는 command 사이 maintenance-window state다.
+
 Maintenance가 target runtime을 적용하면 `APPLICATION_REVISION`은 기존
 application SHA를 유지하고 `RUNTIME_CONFIG_REVISION`만 maintenance release
 SHA로 바뀔 수 있다. 두 revision이 다른 것은 정상이다. MySQL upgrade smoke와

--- a/homeserver/scripts/backup-home-server.sh
+++ b/homeserver/scripts/backup-home-server.sh
@@ -485,6 +485,113 @@ compose() {
     "$@"
 }
 
+resolve_database_identity() {
+  local actual_health
+  local actual_image_id
+  local actual_project
+  local actual_service
+  local actual_volume
+  local configured_image
+  local configured_volume
+  local container_id
+  local expected_image_id
+  local rendered
+  local repo_digests
+  local volume_users
+
+  rendered="$(
+    unset POST_IMAGES_HOST_DIR
+    compose config --format json
+  )"
+  IFS=$'\t' read -r configured_image configured_volume <<<"$(
+    printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
+import json
+import re
+import sys
+
+config = json.load(sys.stdin)
+database = config.get("services", {}).get("db", {})
+volume = config.get("volumes", {}).get("mysql-data", {})
+image = database.get("image")
+volume_name = volume.get("name")
+if not isinstance(image, str) or not image:
+    raise SystemExit("backup DB image contract is invalid")
+if not isinstance(volume_name, str) or not re.fullmatch(
+    r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", volume_name
+):
+    raise SystemExit("backup DB volume contract is invalid")
+print(f"{image}\t{volume_name}", end="")
+'
+  )"
+  container_id="$(compose ps -q db)"
+  [[ "${container_id}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] \
+    || fail "backup DB container identity is missing or invalid"
+  expected_image_id="$(
+    "${DOCKER_BIN}" image inspect --format '{{.Id}}' "${configured_image}"
+  )"
+  actual_image_id="$(
+    "${DOCKER_BIN}" container inspect --format '{{.Image}}' "${container_id}"
+  )"
+  actual_volume="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{range .Mounts}}{{if eq .Destination "/var/lib/mysql"}}{{.Name}}{{end}}{{end}}' \
+      "${container_id}"
+  )"
+  actual_project="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.project" }}' \
+      "${container_id}"
+  )"
+  actual_service="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.service" }}' \
+      "${container_id}"
+  )"
+  actual_health="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+      "${container_id}"
+  )"
+  volume_users="$(
+    "${DOCKER_BIN}" ps -a --no-trunc \
+      --filter "volume=${configured_volume}" \
+      --format '{{.ID}}'
+  )"
+  [[ "${expected_image_id}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    && [[ "${actual_image_id}" == "${expected_image_id}" ]] \
+    || fail "backup DB image does not match the active Compose binding"
+  [[ "${actual_volume}" == "${configured_volume}" ]] \
+    || fail "backup DB volume does not match the active Compose binding"
+  [[ "${actual_project}" == "${PROJECT_NAME}" && "${actual_service}" == db ]] \
+    || fail "backup DB container does not belong to the active Compose service"
+  [[ "${actual_health}" == healthy && "${volume_users}" == "${container_id}" ]] \
+    || fail "backup DB health or exclusive volume attachment is invalid"
+
+  repo_digests="$(
+    "${DOCKER_BIN}" image inspect --format '{{json .RepoDigests}}' "${configured_image}"
+  )"
+  backup_db_image_exact="$(
+    printf '%s' "${repo_digests}" | "${PYTHON_BIN}" -c '
+import json
+import re
+import sys
+
+configured = sys.argv[1]
+values = json.load(sys.stdin)
+digests = []
+for value in values:
+    match = re.search(r"@(?P<digest>sha256:[0-9a-f]{64})$", value)
+    if match:
+        digests.append(match.group("digest"))
+if len(set(digests)) != 1:
+    raise SystemExit("backup DB image does not resolve to one repository digest")
+print("{}@{}".format(configured.split("@", 1)[0], digests[0]), end="")
+' "${configured_image}"
+  )"
+  backup_db_image_id="${actual_image_id}"
+  backup_db_volume="${actual_volume}"
+}
+
 resolve_post_images_host_dir() {
   local rendered
 
@@ -531,6 +638,7 @@ running_services="$(compose ps --status running --services)"
 if ! /usr/bin/grep -qx db <<<"${running_services}"; then
   fail "production db service is not running"
 fi
+resolve_database_identity
 
 prepare_private_directory "${BACKUP_ROOT}"
 
@@ -902,6 +1010,9 @@ completed_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
   "${completed_at}" \
   "${application_sha}" \
   "${runtime_config_digest}" \
+  "${backup_db_image_exact}" \
+  "${backup_db_image_id}" \
+  "${backup_db_volume}" \
   "${db_version_file}" \
   "${record_counts_file}" \
   "${post_images_stats}" \
@@ -919,6 +1030,9 @@ import sys
     completed_at,
     application_sha,
     runtime_config_digest,
+    database_image,
+    database_image_id,
+    database_volume,
     version_file_value,
     record_counts_file_value,
     file_stats_value,
@@ -935,6 +1049,12 @@ if runtime_config_digest != "unknown" and not re.fullmatch(
     r"sha256:[0-9a-f]{64}", runtime_config_digest
 ):
     raise SystemExit("runtime config digest has an unexpected format")
+if not re.fullmatch(r"mysql:[^@\s]+@sha256:[0-9a-f]{64}", database_image):
+    raise SystemExit("database image identity has an unexpected format")
+if not re.fullmatch(r"sha256:[0-9a-f]{64}", database_image_id):
+    raise SystemExit("database image ID has an unexpected format")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", database_volume):
+    raise SystemExit("database volume has an unexpected format")
 
 record_counts = {}
 for raw_line in pathlib.Path(record_counts_file_value).read_text(encoding="utf-8").splitlines():
@@ -980,6 +1100,9 @@ manifest = {
     "database": {
         "engine": "mysql",
         "version": pathlib.Path(version_file_value).read_text(encoding="utf-8").strip(),
+        "image": database_image,
+        "imageId": database_image_id,
+        "volume": database_volume,
         "dumpFile": "database/dump",
         "bytes": dump_file.stat().st_size,
         "sha256": sha256(dump_file),

--- a/homeserver/scripts/deploy-home-server-ci.sh
+++ b/homeserver/scripts/deploy-home-server-ci.sh
@@ -14,6 +14,7 @@ readonly RUNTIME_CONFIG_STATE="${RUNTIME_CONFIG_ROOT}/state"
 readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
 readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
 readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
+readonly MAINTENANCE_QUIESCE="${RUNTIME_CONFIG_ROOT}/mysql-maintenance/quiesce.state"
 readonly OPERATION_LOCK="${APP_DIR}/.cubing-hub-operation.lock"
 readonly PROJECT_NAME=cubing-hub
 readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
@@ -23,6 +24,12 @@ readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000
 fail() {
   printf 'Cubing Hub deploy bootstrap failed: %s\n' "$1" >&2
   exit 1
+}
+
+fail_if_maintenance_quiesced() {
+  if [[ -e "${MAINTENANCE_QUIESCE}" || -L "${MAINTENANCE_QUIESCE}" ]]; then
+    fail "application is quiesced for MySQL maintenance; use the maintenance worker"
+  fi
 }
 
 acquire_operation_lock() {
@@ -612,6 +619,7 @@ validated_recovery_release() {
 
 if [[ "$#" -eq 1 && "$1" == recover && -z "${SSH_ORIGINAL_COMMAND:-}" ]]; then
   acquire_operation_lock
+  fail_if_maintenance_quiesced
   if [[ -f "${RUNTIME_CONFIG_PENDING}" ]] \
     && [[ "$(
       /usr/bin/sed -n 's/^TRANSACTION_TYPE=//p' "${RUNTIME_CONFIG_PENDING}" \
@@ -663,6 +671,7 @@ if [[ "${original_command}" =~ ^inspect-cubing-hub-runtime[[:space:]]([0-9a-f]{4
 fi
 if [[ "${original_command}" =~ ^deploy-cubing-hub[[:space:]]([0-9a-fA-F]{40})[[:space:]]([A-Za-z0-9_-]+)$ ]]; then
   acquire_operation_lock
+  fail_if_maintenance_quiesced
   exec "${LEGACY_DEPLOY_SCRIPT}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
 fi
 
@@ -692,6 +701,7 @@ if [[ "${config_mode}" == update ]] && ! is_digest "${config_digest}"; then
   exit 64
 fi
 acquire_operation_lock
+fail_if_maintenance_quiesced
 if [[ ! -x "${DOCKER_BIN}" ]]; then
   fail "Docker CLI is not executable: ${DOCKER_BIN}"
 fi

--- a/homeserver/scripts/deploy-home-server.sh
+++ b/homeserver/scripts/deploy-home-server.sh
@@ -20,6 +20,7 @@ readonly RUNTIME_CONFIG_PENDING="${RUNTIME_CONFIG_ROOT}/pending"
 readonly RUNTIME_CONFIG_HOMEOPS_CONTEXT="${RUNTIME_CONFIG_ROOT}/homeops-deployment"
 readonly RUNTIME_CONFIG_CURRENT="${RUNTIME_CONFIG_ROOT}/current"
 readonly RUNTIME_CONFIG_INITIALIZED="${APP_DIR}/.runtime-config-v2-initialized"
+readonly MAINTENANCE_QUIESCE="${RUNTIME_CONFIG_ROOT}/mysql-maintenance/quiesce.state"
 readonly API_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-api
 readonly WEB_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-web
 readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
@@ -47,6 +48,12 @@ usage() {
 fail() {
   printf 'Cubing Hub deployment failed: %s\n' "$1" >&2
   exit 1
+}
+
+fail_if_maintenance_quiesced() {
+  if [[ -e "${MAINTENANCE_QUIESCE}" || -L "${MAINTENANCE_QUIESCE}" ]]; then
+    fail "application is quiesced for MySQL maintenance; use the maintenance worker"
+  fi
 }
 
 require_legacy_compose() {
@@ -145,6 +152,8 @@ fi
 if [[ ! -f "${ENV_FILE}" ]]; then
   fail "production environment configuration is missing"
 fi
+
+fail_if_maintenance_quiesced
 
 if [[ "${recovery_mode}" == false ]] \
   && [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]

--- a/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
+++ b/homeserver/scripts/fixtures/mock-cubing-hub-docker.sh
@@ -13,6 +13,64 @@ if [[ -n "${FAKE_DOCKER_LOG:-}" ]]; then
   printf '%s %s\n' "${command_name}" "$*" >>"${FAKE_DOCKER_LOG}"
 fi
 
+fake_service_state() {
+  local service="$1"
+
+  if [[ -n "${FAKE_SERVICE_STATE_DIR:-}" ]] \
+    && [[ -f "${FAKE_SERVICE_STATE_DIR}/${service}" ]]
+  then
+    /bin/cat "${FAKE_SERVICE_STATE_DIR}/${service}"
+  else
+    printf 'running\n'
+  fi
+}
+
+fake_set_service_state() {
+  local service="$1"
+  local state="$2"
+
+  if [[ -n "${FAKE_SERVICE_STATE_DIR:-}" ]]; then
+    printf '%s\n' "${state}" >"${FAKE_SERVICE_STATE_DIR}/${service}"
+  fi
+}
+
+fake_service_status_json() {
+  local api_health="${FAKE_API_HEALTH:-}"
+  local api_state
+  local service_health="${FAKE_SOURCE_SERVICE_HEALTH:-healthy}"
+  local db_health
+  local db_state
+  local redis_health
+  local redis_state
+  local web_health
+  local web_state
+
+  if [[ -z "${FAKE_DB_STATE_DIR:-}" ]] \
+    || [[ ! -f "${FAKE_DB_STATE_DIR}/image-ref" ]]
+  then
+    service_health="${FAKE_SERVICE_HEALTH:-healthy}"
+  elif [[ "$(/bin/cat "${FAKE_DB_STATE_DIR}/image-ref")" == mysql:8.4.11* ]]; then
+    service_health="${FAKE_SERVICE_HEALTH:-healthy}"
+  fi
+  db_health="${service_health}"
+  redis_health="${service_health}"
+  web_health="${service_health}"
+  api_state="$(fake_service_state api)"
+  db_state="$(fake_service_state db)"
+  redis_state="$(fake_service_state redis)"
+  web_state="$(fake_service_state web)"
+  [[ "${api_state}" == running ]] || api_health=
+  [[ "${db_state}" == running ]] || db_health=
+  [[ "${redis_state}" == running ]] || redis_health=
+  [[ "${web_state}" == running ]] || web_health=
+  printf \
+    '[{"Service":"db","State":"%s","Health":"%s"},{"Service":"redis","State":"%s","Health":"%s"},{"Service":"api","State":"%s","Health":"%s"},{"Service":"web","State":"%s","Health":"%s"}]\n' \
+    "${db_state}" "${db_health}" \
+    "${redis_state}" "${redis_health}" \
+    "${api_state}" "${api_health}" \
+    "${web_state}" "${web_health}"
+}
+
 case "${command_name}" in
   pull)
     if [[ -n "${FAKE_HOMEOPS_CONTEXT_CAPTURE:-}" ]] \
@@ -216,13 +274,32 @@ case "${command_name}" in
     done
     case "${query}" in
       running-version)
-        if [[ "${FAKE_RUNNING_DB_VERSION_QUERY_FAIL:-false}" == true ]]; then
+        running_db_is_target=true
+        if [[ -n "${FAKE_DB_STATE_DIR:-}" ]] \
+          && [[ -f "${FAKE_DB_STATE_DIR}/image-ref" ]] \
+          && [[ "$(/bin/cat "${FAKE_DB_STATE_DIR}/image-ref")" != mysql:8.4.11* ]]
+        then
+          running_db_is_target=false
+        elif [[ -n "${FAKE_DB_STATE_DIR:-}" ]] \
+          && [[ ! -f "${FAKE_DB_STATE_DIR}/image-ref" ]]
+        then
+          running_db_is_target=false
+        else
+          running_db_is_target=true
+        fi
+        if [[ "${running_db_is_target}" == true ]] \
+          && [[ "${FAKE_RUNNING_DB_VERSION_QUERY_FAIL:-false}" == true ]]
+        then
           exit 1
         fi
-        if [[ "${FAKE_RUNNING_DB_VERSION_EMPTY:-false}" == true ]]; then
+        if [[ "${running_db_is_target}" == true ]] \
+          && [[ "${FAKE_RUNNING_DB_VERSION_EMPTY:-false}" == true ]]
+        then
           exit 0
         fi
-        if [[ -n "${FAKE_RUNNING_DB_VERSION_OVERRIDE:-}" ]]; then
+        if [[ "${running_db_is_target}" == true ]] \
+          && [[ -n "${FAKE_RUNNING_DB_VERSION_OVERRIDE:-}" ]]
+        then
           printf '%s\n' "${FAKE_RUNNING_DB_VERSION_OVERRIDE}"
         elif [[ -n "${FAKE_DB_STATE_DIR:-}" ]] \
           && [[ -f "${FAKE_DB_STATE_DIR}/image-ref" ]] \
@@ -319,15 +396,10 @@ users}"
       printf '%s\n' "${FAKE_API_CONTAINER_ID:-mock-api-container}"
     elif [[ "${arguments}" == *" ps -q web "* ]]; then
       printf '%s\n' "${FAKE_WEB_CONTAINER_ID:-mock-web-container}"
+    elif [[ "${arguments}" == *" ps --all --format json "* ]]; then
+      fake_service_status_json
     elif [[ "${arguments}" == *" ps --format json "* ]]; then
-      service_health="${FAKE_SERVICE_HEALTH:-healthy}"
-      api_health="${FAKE_API_HEALTH:-}"
-      printf \
-        '[{"Service":"db","State":"running","Health":"%s"},{"Service":"redis","State":"running","Health":"%s"},{"Service":"api","State":"running","Health":"%s"},{"Service":"web","State":"running","Health":"%s"}]\n' \
-        "${service_health}" \
-        "${service_health}" \
-        "${api_health}" \
-        "${service_health}"
+      fake_service_status_json
     elif [[ "${arguments}" == *" --format json "* ]]; then
       compose_file=
       previous_argument=
@@ -513,10 +585,18 @@ users}"
       if [[ -n "${FAKE_DB_STATE_DIR:-}" ]]; then
         printf 'false\n' >"${FAKE_DB_STATE_DIR}/running"
       fi
+      fake_set_service_state db exited
+    elif [[ "${arguments}" == *" stop api web "* ]]; then
+      if [[ "${FAKE_APP_STOP_FAIL:-false}" == true ]]; then
+        exit 1
+      fi
+      fake_set_service_state api exited
+      fake_set_service_state web exited
     elif [[ "${arguments}" == *" stop db "* ]]; then
       if [[ -n "${FAKE_DB_STATE_DIR:-}" ]]; then
         printf 'false\n' >"${FAKE_DB_STATE_DIR}/running"
       fi
+      fake_set_service_state db exited
     elif [[ "${arguments}" == *" up "* ]] && [[ "${arguments}" == *" db "* ]]; then
       if [[ "${FAKE_MAINTENANCE_DB_UP_FAIL:-false}" == true ]]; then
         if [[ "${FAKE_MAINTENANCE_DB_UP_FAIL_AFTER_BIND:-false}" == true ]] \
@@ -533,6 +613,7 @@ users}"
           printf '%s\n' "${DB_VOLUME_NAME:-cubing-hub_mysql-data}" >"${FAKE_DB_STATE_DIR}/volume"
           printf 'unhealthy\n' >"${FAKE_DB_STATE_DIR}/health"
           printf 'true\n' >"${FAKE_DB_STATE_DIR}/running"
+          fake_set_service_state db running
         fi
         exit 1
       fi
@@ -549,11 +630,22 @@ users}"
         printf 'healthy\n' >"${FAKE_DB_STATE_DIR}/health"
         printf 'true\n' >"${FAKE_DB_STATE_DIR}/running"
       fi
+      fake_set_service_state db running
+    elif [[ "${arguments}" == *" up "* ]] \
+      && [[ "${arguments}" == *" redis api web "* ]]
+    then
+      fake_set_service_state redis running
+      fake_set_service_state api running
+      fake_set_service_state web running
     elif [[ "${arguments}" == *" ps --status running --services "* ]]; then
-      printf '%s\n' "${FAKE_RUNNING_SERVICES:-db
-redis
-api
-web}"
+      if [[ -n "${FAKE_RUNNING_SERVICES:-}" ]]; then
+        printf '%s\n' "${FAKE_RUNNING_SERVICES}"
+      else
+        for service in db redis api web; do
+          [[ "$(fake_service_state "${service}")" == running ]] \
+            && printf '%s\n' "${service}"
+        done
+      fi
     fi
     ;;
   ps)

--- a/homeserver/scripts/mysql-maintenance-home-server.sh
+++ b/homeserver/scripts/mysql-maintenance-home-server.sh
@@ -19,6 +19,7 @@ readonly MAINTENANCE_ROOT="${RUNTIME_CONFIG_ROOT}/mysql-maintenance"
 readonly MAINTENANCE_CANDIDATES="${MAINTENANCE_ROOT}/candidates"
 readonly MAINTENANCE_RESTORES="${MAINTENANCE_ROOT}/restores"
 readonly MAINTENANCE_STATE="${MAINTENANCE_ROOT}/state"
+readonly MAINTENANCE_QUIESCE="${MAINTENANCE_ROOT}/quiesce.state"
 readonly OPERATION_LOCK="${APP_DIR}/.cubing-hub-operation.lock"
 readonly RUNTIME_CONFIG_REPOSITORY=ghcr.io/xxh3898/cubing-hub-runtime-config
 readonly API_IMAGE_REPOSITORY=ghcr.io/xxh3898/cubing-hub-api
@@ -32,6 +33,9 @@ readonly ZERO_DIGEST=sha256:0000000000000000000000000000000000000000000000000000
 usage() {
   cat >&2 <<'USAGE'
 Usage:
+  mysql-maintenance-cubing-hub.sh quiesce
+  mysql-maintenance-cubing-hub.sh status
+  mysql-maintenance-cubing-hub.sh resume-source
   mysql-maintenance-cubing-hub.sh prepare-upgrade <runtime-digest> <runtime-revision> <mysql:8.4.11@sha256:digest> <backup-id> <registry-user>
   mysql-maintenance-cubing-hub.sh verify-rollback-volume <upgrade-candidate-id> <rollback-volume> <validation-container>
   mysql-maintenance-cubing-hub.sh prepare-rollback <upgrade-candidate-id> <rollback-volume>
@@ -572,6 +576,7 @@ validate_running_mysql_version() {
       fail "expected MySQL version is unsupported"
       ;;
   esac
+  validated_mysql_version="${actual_version}"
 }
 
 validate_candidate_target_mysql_version() {
@@ -698,17 +703,479 @@ load_current_db_identity() {
     "${current_release}"
 }
 
+load_current_mysql_version() {
+  case "${current_db_image}" in
+    "mysql:${SOURCE_DB_VERSION}"|mysql:8.0.46@sha256:*)
+      current_mysql_expected_version="${SOURCE_DB_VERSION}"
+      ;;
+    "mysql:${TARGET_DB_VERSION}"|mysql:8.4.11@sha256:*)
+      current_mysql_expected_version="${TARGET_DB_VERSION}"
+      ;;
+    *)
+      fail "current MySQL version is unsupported for maintenance quiesce"
+      ;;
+  esac
+  validate_running_mysql_version \
+    "${current_mysql_expected_version}" \
+    "${current_db_image}" \
+    "${current_db_volume}" \
+    "${current_release}"
+  current_mysql_version="${validated_mysql_version}"
+}
+
+validate_running_application_identity() {
+  local actual_image_id
+  local actual_project
+  local actual_service
+  local container_id
+  local expected_image="$2"
+  local expected_image_id
+  local service="$1"
+
+  container_id="$(
+    compose_for \
+      "${current_release}" \
+      "${current_db_image_exact}" \
+      "${current_db_volume}" \
+      ps -q "${service}"
+  )"
+  [[ "${container_id}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] \
+    || fail "${service} container identity is missing or invalid"
+  expected_image_id="$(image_id_for "${expected_image}")"
+  actual_image_id="$(
+    "${DOCKER_BIN}" container inspect --format '{{.Image}}' "${container_id}"
+  )"
+  actual_project="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.project" }}' \
+      "${container_id}"
+  )"
+  actual_service="$(
+    "${DOCKER_BIN}" container inspect \
+      --format '{{ index .Config.Labels "com.docker.compose.service" }}' \
+      "${container_id}"
+  )"
+  [[ "${actual_image_id}" == "${expected_image_id}" ]] \
+    || fail "${service} container image does not match the committed application"
+  [[ "${actual_project}" == "${PROJECT_NAME}" && "${actual_service}" == "${service}" ]] \
+    || fail "${service} container does not belong to the expected Compose service"
+}
+
+service_set_is_healthy_for() {
+  local db_image="$2"
+  local db_volume="$3"
+  local release_dir="$1"
+  local rendered
+
+  rendered="$(
+    compose_for \
+      "${release_dir}" \
+      "${db_image}" \
+      "${db_volume}" \
+      ps --format json
+  )"
+  printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("no service status was returned")
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
+entries = value if isinstance(value, list) else [value]
+required = {"api", "db", "redis", "web"}
+seen = set()
+for entry in entries:
+    service = entry.get("Service")
+    if service not in required or str(entry.get("State", "")).lower() != "running":
+        raise SystemExit("service set is not running")
+    seen.add(service)
+    health = str(entry.get("Health", "")).lower()
+    if service in {"db", "redis", "web"} and health != "healthy":
+        raise SystemExit("service health is not ready")
+    if health and health != "healthy":
+        raise SystemExit("service health is invalid")
+if seen != required:
+    raise SystemExit("service set is incomplete")
+'
+}
+
+service_set_is_quiesced_for() {
+  local db_image="$2"
+  local db_volume="$3"
+  local release_dir="$1"
+  local rendered
+
+  rendered="$(
+    compose_for \
+      "${release_dir}" \
+      "${db_image}" \
+      "${db_volume}" \
+      ps --all --format json
+  )"
+  printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("no quiesce service status was returned")
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
+entries = value if isinstance(value, list) else [value]
+required = {"api", "db", "redis", "web"}
+by_service = {}
+for entry in entries:
+    service = entry.get("Service")
+    if service not in required or service in by_service:
+        raise SystemExit("quiesce service set is invalid")
+    by_service[service] = entry
+if set(by_service) != required:
+    raise SystemExit("quiesce service set is incomplete")
+for service in ("db", "redis"):
+    entry = by_service[service]
+    if (
+        str(entry.get("State", "")).lower() != "running"
+        or str(entry.get("Health", "")).lower() != "healthy"
+    ):
+        raise SystemExit("quiesce data service is not healthy")
+for service in ("api", "web"):
+    if str(by_service[service].get("State", "")).lower() != "exited":
+        raise SystemExit("quiesce application service is not stopped")
+'
+}
+
+application_services_are_stopped_for() {
+  local db_image="$2"
+  local db_volume="$3"
+  local release_dir="$1"
+  local rendered
+
+  rendered="$(
+    compose_for \
+      "${release_dir}" \
+      "${db_image}" \
+      "${db_volume}" \
+      ps --all --format json
+  )"
+  printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit("no application service status was returned")
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
+entries = value if isinstance(value, list) else [value]
+states = {
+    entry.get("Service"): str(entry.get("State", "")).lower()
+    for entry in entries
+    if entry.get("Service") in {"api", "web"}
+}
+if states != {"api": "exited", "web": "exited"}:
+    raise SystemExit("application services are not stopped")
+'
+}
+
+start_current_application() {
+  compose_for \
+    "${current_release}" \
+    "${current_db_image_exact}" \
+    "${current_db_volume}" \
+    up --detach --no-build --pull never --remove-orphans --wait \
+      --wait-timeout "${HEALTH_TIMEOUT_SECONDS}" redis api web
+}
+
+validate_quiesce_evidence() {
+  local computed_id
+  local keys
+
+  if [[ ! -d "${MAINTENANCE_ROOT}" || -L "${MAINTENANCE_ROOT}" ]] \
+    || ! has_mode "${MAINTENANCE_ROOT}" 700 \
+    || [[ ! -f "${MAINTENANCE_QUIESCE}" || -L "${MAINTENANCE_QUIESCE}" ]] \
+    || ! has_mode "${MAINTENANCE_QUIESCE}" 400
+  then
+    fail "maintenance quiesce evidence is missing, unsafe, or mutable"
+  fi
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${MAINTENANCE_QUIESCE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'API_IMAGE\nAPPLICATION_REVISION\nDB_IMAGE_EXACT\nDB_IMAGE_ID\nDB_VOLUME\nEVIDENCE_ID\nMYSQL_VERSION\nQUIESCED_AT\nRUNTIME_CONFIG_CONTENT_SHA256\nRUNTIME_CONFIG_DIGEST\nRUNTIME_CONFIG_REVISION\nSCHEMA_VERSION\nWEB_IMAGE' ]]; then
+    fail "maintenance quiesce evidence keys are invalid"
+  fi
+  quiesce_application_revision="$(read_exact_value "${MAINTENANCE_QUIESCE}" APPLICATION_REVISION)"
+  quiesce_api_image="$(read_exact_value "${MAINTENANCE_QUIESCE}" API_IMAGE)"
+  quiesce_web_image="$(read_exact_value "${MAINTENANCE_QUIESCE}" WEB_IMAGE)"
+  quiesce_runtime_revision="$(read_exact_value "${MAINTENANCE_QUIESCE}" RUNTIME_CONFIG_REVISION)"
+  quiesce_runtime_digest="$(read_exact_value "${MAINTENANCE_QUIESCE}" RUNTIME_CONFIG_DIGEST)"
+  quiesce_runtime_content_sha="$(read_exact_value "${MAINTENANCE_QUIESCE}" RUNTIME_CONFIG_CONTENT_SHA256)"
+  quiesce_db_image_exact="$(read_exact_value "${MAINTENANCE_QUIESCE}" DB_IMAGE_EXACT)"
+  quiesce_db_image_id="$(read_exact_value "${MAINTENANCE_QUIESCE}" DB_IMAGE_ID)"
+  quiesce_db_volume="$(read_exact_value "${MAINTENANCE_QUIESCE}" DB_VOLUME)"
+  quiesce_mysql_version="$(read_exact_value "${MAINTENANCE_QUIESCE}" MYSQL_VERSION)"
+  quiesced_at="$(read_exact_value "${MAINTENANCE_QUIESCE}" QUIESCED_AT)"
+  quiesce_evidence_id="$(read_exact_value "${MAINTENANCE_QUIESCE}" EVIDENCE_ID)"
+  computed_id="$(
+    /usr/bin/sed '/^EVIDENCE_ID=/d' "${MAINTENANCE_QUIESCE}" \
+      | /usr/bin/shasum -a 256 \
+      | /usr/bin/awk '{print $1}'
+  )"
+  if [[ "$(read_exact_value "${MAINTENANCE_QUIESCE}" SCHEMA_VERSION)" != 1 ]] \
+    || ! is_sha "${quiesce_application_revision}" \
+    || [[ "${quiesce_api_image}" != "${API_IMAGE_REPOSITORY}:${quiesce_application_revision}" ]] \
+    || [[ "${quiesce_web_image}" != "${WEB_IMAGE_REPOSITORY}:${quiesce_application_revision}" ]] \
+    || ! is_sha "${quiesce_runtime_revision}" \
+    || ! is_digest "${quiesce_runtime_digest}" \
+    || [[ ! "${quiesce_runtime_content_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || [[ ! "${quiesce_db_image_exact}" =~ ^mysql:(8\.0\.46|8\.4\.11)@sha256:[0-9a-f]{64}$ ]] \
+    || ! is_image_id "${quiesce_db_image_id}" \
+    || ! is_volume_name "${quiesce_db_volume}" \
+    || [[ ! "${quiesced_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || ! is_candidate_id "${quiesce_evidence_id}" \
+    || [[ "${quiesce_evidence_id}" != "${computed_id}" ]]
+  then
+    fail "maintenance quiesce evidence values or integrity are invalid"
+  fi
+  "${PYTHON_BIN}" - "${quiesced_at}" <<'PY'
+import datetime as dt
+import sys
+
+dt.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ")
+PY
+  case "${quiesce_db_image_exact}" in
+    mysql:8.0.46@sha256:*)
+      [[ "${quiesce_mysql_version}" =~ ^8\.0\.46([-+].*)?$ ]] \
+        || fail "quiesce MySQL version does not match its DB image"
+      ;;
+    mysql:8.4.11@sha256:*)
+      [[ "${quiesce_mysql_version}" =~ ^8\.4\.11([-+].*)?$ ]] \
+        || fail "quiesce MySQL version does not match its DB image"
+      ;;
+  esac
+}
+
+validate_quiesce_matches_current() {
+  validate_quiesce_evidence
+  [[ "${quiesce_application_revision}" == "${current_application_revision}" ]] \
+    && [[ "${quiesce_api_image}" == "${current_api_image}" ]] \
+    && [[ "${quiesce_web_image}" == "${current_web_image}" ]] \
+    && [[ "${quiesce_runtime_revision}" == "${current_runtime_revision}" ]] \
+    && [[ "${quiesce_runtime_digest}" == "${current_runtime_digest}" ]] \
+    && [[ "${quiesce_runtime_content_sha}" == "${current_runtime_content_sha}" ]] \
+    && [[ "${quiesce_db_image_exact}" == "${current_db_image_exact}" ]] \
+    && [[ "${quiesce_db_image_id}" == "${current_db_image_id}" ]] \
+    && [[ "${quiesce_db_volume}" == "${current_db_volume}" ]] \
+    && [[ "${quiesce_mysql_version}" == "${current_mysql_version}" ]] \
+    || fail "maintenance quiesce evidence does not match the current source runtime"
+}
+
+write_quiesce_evidence() {
+  local evidence_id
+  local evidence_temp
+  local recorded_at
+
+  recorded_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 1
+  evidence_temp="$(/usr/bin/mktemp "${MAINTENANCE_ROOT}/.quiesce.tmp.XXXXXX")" \
+    || return 1
+  if ! {
+    printf 'SCHEMA_VERSION=1\n'
+    printf 'APPLICATION_REVISION=%s\n' "${current_application_revision}"
+    printf 'API_IMAGE=%s\n' "${current_api_image}"
+    printf 'WEB_IMAGE=%s\n' "${current_web_image}"
+    printf 'RUNTIME_CONFIG_REVISION=%s\n' "${current_runtime_revision}"
+    printf 'RUNTIME_CONFIG_DIGEST=%s\n' "${current_runtime_digest}"
+    printf 'RUNTIME_CONFIG_CONTENT_SHA256=%s\n' "${current_runtime_content_sha}"
+    printf 'DB_IMAGE_EXACT=%s\n' "${current_db_image_exact}"
+    printf 'DB_IMAGE_ID=%s\n' "${current_db_image_id}"
+    printf 'DB_VOLUME=%s\n' "${current_db_volume}"
+    printf 'MYSQL_VERSION=%s\n' "${current_mysql_version}"
+    printf 'QUIESCED_AT=%s\n' "${recorded_at}"
+  } >"${evidence_temp}"
+  then
+    /bin/rm -f -- "${evidence_temp}"
+    return 1
+  fi
+  evidence_id="$(
+    /usr/bin/shasum -a 256 "${evidence_temp}" | /usr/bin/awk '{print $1}'
+  )" || {
+    /bin/rm -f -- "${evidence_temp}"
+    return 1
+  }
+  printf 'EVIDENCE_ID=%s\n' "${evidence_id}" >>"${evidence_temp}" || {
+    /bin/rm -f -- "${evidence_temp}"
+    return 1
+  }
+  /bin/chmod 400 "${evidence_temp}" || {
+    /bin/rm -f -- "${evidence_temp}"
+    return 1
+  }
+  if [[ -e "${MAINTENANCE_QUIESCE}" || -L "${MAINTENANCE_QUIESCE}" ]] \
+    || ! /bin/mv -- "${evidence_temp}" "${MAINTENANCE_QUIESCE}"
+  then
+    /bin/rm -f -- "${evidence_temp}"
+    return 1
+  fi
+  quiesce_evidence_id="${evidence_id}"
+  quiesced_at="${recorded_at}"
+}
+
+remove_quiesce_evidence() {
+  validate_quiesce_evidence
+  /bin/rm -f -- "${MAINTENANCE_QUIESCE}"
+  [[ ! -e "${MAINTENANCE_QUIESCE}" && ! -L "${MAINTENANCE_QUIESCE}" ]] \
+    || fail "maintenance quiesce evidence could not be removed"
+}
+
+validate_candidate_quiesce_evidence() {
+  validate_quiesce_evidence
+  [[ "${quiesce_evidence_id}" == "${candidate_quiesce_evidence_id}" ]] \
+    && [[ "${quiesced_at}" == "${candidate_quiesced_at}" ]] \
+    || fail "maintenance candidate is not bound to the active quiesce evidence"
+}
+
+validate_current_quiesce_for_candidate() {
+  load_current_db_identity
+  load_current_mysql_version
+  validate_quiesce_matches_current
+  validate_candidate_quiesce_evidence
+  service_set_is_quiesced_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+    || fail "maintenance candidate requires the verified quiesced service state"
+}
+
+quiesce_source() {
+  [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]] \
+    || fail "an incomplete runtime transaction cannot be quiesced"
+  load_current_runtime
+  load_current_db_identity
+  load_current_mysql_version
+
+  if [[ -e "${MAINTENANCE_QUIESCE}" || -L "${MAINTENANCE_QUIESCE}" ]]; then
+    validate_quiesce_matches_current
+    service_set_is_quiesced_for \
+      "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+      || fail "existing maintenance quiesce service state is invalid"
+    printf 'Cubing Hub application is already quiesced: %s\n' "${quiesce_evidence_id}"
+    return
+  fi
+
+  ensure_private_directory "${MAINTENANCE_ROOT}"
+  service_set_is_healthy_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+    || fail "source service set must be healthy before quiesce"
+  validate_running_application_identity api "${current_api_image}"
+  validate_running_application_identity web "${current_web_image}"
+  if ! compose_for \
+    "${current_release}" \
+    "${current_db_image_exact}" \
+    "${current_db_volume}" \
+    stop api web
+  then
+    start_current_application >/dev/null 2>&1 || true
+    fail "application stop failed; source application restart was attempted"
+  fi
+  if ! service_set_is_quiesced_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}"
+  then
+    start_current_application >/dev/null 2>&1 || true
+    fail "application quiesce state validation failed; source application restart was attempted"
+  fi
+  if ! write_quiesce_evidence; then
+    start_current_application >/dev/null 2>&1 || true
+    fail "application was stopped but quiesce evidence could not be committed"
+  fi
+  printf 'Cubing Hub application quiesced: %s\n' "${quiesce_evidence_id}"
+}
+
+resume_source() {
+  [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]] \
+    || fail "source application cannot resume while maintenance is pending"
+  load_current_runtime
+  load_current_db_identity
+  load_current_mysql_version
+  validate_quiesce_matches_current
+  [[ "${current_mysql_expected_version}" == "${SOURCE_DB_VERSION}" ]] \
+    || fail "resume-source is allowed only on the unchanged MySQL 8.0.46 source"
+
+  if service_set_is_quiesced_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}"
+  then
+    start_current_application \
+      || fail "source application startup failed; quiesce evidence was preserved"
+  fi
+  service_set_is_healthy_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+    || fail "source service set is unhealthy; quiesce evidence was preserved"
+  remove_quiesce_evidence
+  printf 'Cubing Hub source application resumed\n'
+}
+
+show_quiesce_status() {
+  if [[ ! -e "${MAINTENANCE_QUIESCE}" && ! -L "${MAINTENANCE_QUIESCE}" ]]; then
+    [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]] \
+      || fail "maintenance pending state exists without quiesce evidence"
+    printf 'QUIESCE_STATUS=inactive\n'
+    printf 'PENDING=none\n'
+    return
+  fi
+
+  validate_quiesce_evidence
+  if [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+    validate_maintenance_pending
+    validate_candidate_quiesce_evidence
+    printf 'QUIESCE_STATUS=maintenance-pending\n'
+    printf 'PENDING=%s\n' "${pending_candidate_id}"
+  else
+    load_current_runtime
+    load_current_db_identity
+    load_current_mysql_version
+    validate_quiesce_matches_current
+    service_set_is_quiesced_for \
+      "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+      || fail "maintenance quiesce service state is invalid"
+    printf 'QUIESCE_STATUS=active\n'
+    printf 'PENDING=none\n'
+  fi
+  printf 'EVIDENCE_ID=%s\n' "${quiesce_evidence_id}"
+  printf 'QUIESCED_AT=%s\n' "${quiesced_at}"
+}
+
 validate_backup() {
   local backup_id="$1"
   local backup_path="${BACKUP_ROOT}/${backup_id}"
   local expected_application_revision="${2:-}"
   local expected_runtime_digest="${3:-}"
+  local expected_quiesced_at="${4:-}"
+  local expected_db_image_exact="${5:-}"
+  local expected_db_image_id="${6:-}"
+  local expected_db_volume="${7:-}"
 
   is_backup_id "${backup_id}" || fail "backup identifier is invalid"
   if { [[ -n "${expected_application_revision}" ]] && [[ -z "${expected_runtime_digest}" ]]; } \
     || { [[ -z "${expected_application_revision}" ]] && [[ -n "${expected_runtime_digest}" ]]; }
   then
     fail "backup source runtime validation requires both application revision and runtime digest"
+  fi
+  if [[ -n "${expected_quiesced_at}" ]] \
+    && { [[ -z "${expected_application_revision}" ]] || [[ -z "${expected_runtime_digest}" ]]; }
+  then
+    fail "quiesced backup validation requires the complete source runtime identity"
+  fi
+  if [[ -n "${expected_quiesced_at}" ]] \
+    && { [[ -z "${expected_db_image_exact}" ]] \
+      || [[ -z "${expected_db_image_id}" ]] \
+      || [[ -z "${expected_db_volume}" ]]; }
+  then
+    fail "quiesced backup validation requires the complete source DB identity"
   fi
   if [[ ! -d "${backup_path}" || -L "${backup_path}" ]]; then
     fail "verified backup directory is missing or unsafe"
@@ -717,7 +1184,12 @@ validate_backup() {
     "${PYTHON_BIN}" - \
       "${backup_path}" \
       "${expected_application_revision}" \
-      "${expected_runtime_digest}" <<'PY'
+      "${expected_runtime_digest}" \
+      "${expected_quiesced_at}" \
+      "${expected_db_image_exact}" \
+      "${expected_db_image_id}" \
+      "${expected_db_volume}" <<'PY'
+import datetime as dt
 import hashlib
 import json
 import pathlib
@@ -727,6 +1199,10 @@ import sys
 root = pathlib.Path(sys.argv[1])
 expected_application_revision = sys.argv[2]
 expected_runtime_digest = sys.argv[3]
+expected_quiesced_at = sys.argv[4]
+expected_db_image_exact = sys.argv[5]
+expected_db_image_id = sys.argv[6]
+expected_db_volume = sys.argv[7]
 success = root / "SUCCESS"
 manifest_path = root / "manifest.json"
 if (
@@ -739,6 +1215,11 @@ if (
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 database = manifest.get("database", {})
 source = manifest.get("source", {})
+try:
+    started_at = dt.datetime.strptime(manifest.get("startedAt", ""), "%Y-%m-%dT%H:%M:%SZ")
+    completed_at = dt.datetime.strptime(manifest.get("completedAt", ""), "%Y-%m-%dT%H:%M:%SZ")
+except (TypeError, ValueError) as error:
+    raise SystemExit("backup timestamps are invalid") from error
 if (
     manifest.get("schemaVersion") != 1
     or manifest.get("status") != "success"
@@ -755,6 +1236,7 @@ if (
     or database.get("recordCountsSource") != "database/dump"
     or not isinstance(database.get("recordCounts"), dict)
     or not database["recordCounts"]
+    or completed_at < started_at
 ):
     raise SystemExit("backup manifest is not an 8.0.46 production snapshot")
 if expected_application_revision and (
@@ -762,6 +1244,19 @@ if expected_application_revision and (
     or source["runtimeConfigDigest"] != expected_runtime_digest
 ):
     raise SystemExit("backup source runtime does not match the maintenance source")
+if expected_quiesced_at:
+    try:
+        quiesced_at = dt.datetime.strptime(expected_quiesced_at, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise SystemExit("quiesce timestamp is invalid") from error
+    if started_at <= quiesced_at:
+        raise SystemExit("maintenance backup did not start after application quiesce")
+    if (
+        database.get("image") != expected_db_image_exact
+        or database.get("imageId") != expected_db_image_id
+        or database.get("volume") != expected_db_volume
+    ):
+        raise SystemExit("maintenance backup DB binding does not match application quiesce")
 for table, count in database["recordCounts"].items():
     if not re.fullmatch(r"[A-Za-z0-9_]+", table) or type(count) is not int or count < 0:
         raise SystemExit("backup record count inventory is invalid")
@@ -1109,8 +1604,10 @@ write_candidate() {
   created_at="$(/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
   candidate_temp="$(/usr/bin/mktemp "${MAINTENANCE_ROOT}/.candidate.tmp.XXXXXX")"
   {
-    printf 'SCHEMA_VERSION=1\n'
+    printf 'SCHEMA_VERSION=2\n'
     printf 'OPERATION=%s\n' "${candidate_operation}"
+    printf 'QUIESCE_EVIDENCE_ID=%s\n' "${candidate_quiesce_evidence_id}"
+    printf 'QUIESCED_AT=%s\n' "${candidate_quiesced_at}"
     printf 'APPLICATION_REVISION=%s\n' "${candidate_application_revision}"
     printf 'API_IMAGE=%s\n' "${candidate_api_image}"
     printf 'WEB_IMAGE=%s\n' "${candidate_web_image}"
@@ -1179,10 +1676,10 @@ validate_candidate() {
   )"
   candidate_operation="$(read_exact_value "${candidate_file}" OPERATION)"
   if [[ "${candidate_operation}" == UPGRADE ]]; then
-    [[ "${keys}" == $'API_IMAGE\nAPPLICATION_REVISION\nBACKUP_ID\nBACKUP_MANIFEST_SHA256\nCANDIDATE_ID\nCREATED_AT\nOPERATION\nSCHEMA_VERSION\nSOURCE_DB_IMAGE\nSOURCE_DB_IMAGE_EXACT\nSOURCE_DB_IMAGE_ID\nSOURCE_DB_VOLUME\nSOURCE_RUNTIME_CONFIG_DIGEST\nTARGET_DB_IMAGE\nTARGET_DB_IMAGE_EXACT\nTARGET_DB_IMAGE_ID\nTARGET_DB_VOLUME\nTARGET_RUNTIME_CONFIG_CONTENT_SHA256\nTARGET_RUNTIME_CONFIG_DIGEST\nTARGET_RUNTIME_CONFIG_REVISION\nWEB_IMAGE' ]] \
+    [[ "${keys}" == $'API_IMAGE\nAPPLICATION_REVISION\nBACKUP_ID\nBACKUP_MANIFEST_SHA256\nCANDIDATE_ID\nCREATED_AT\nOPERATION\nQUIESCED_AT\nQUIESCE_EVIDENCE_ID\nSCHEMA_VERSION\nSOURCE_DB_IMAGE\nSOURCE_DB_IMAGE_EXACT\nSOURCE_DB_IMAGE_ID\nSOURCE_DB_VOLUME\nSOURCE_RUNTIME_CONFIG_DIGEST\nTARGET_DB_IMAGE\nTARGET_DB_IMAGE_EXACT\nTARGET_DB_IMAGE_ID\nTARGET_DB_VOLUME\nTARGET_RUNTIME_CONFIG_CONTENT_SHA256\nTARGET_RUNTIME_CONFIG_DIGEST\nTARGET_RUNTIME_CONFIG_REVISION\nWEB_IMAGE' ]] \
       || fail "maintenance candidate keys are invalid"
   elif [[ "${candidate_operation}" == ROLLBACK ]]; then
-    [[ "${keys}" == $'API_IMAGE\nAPPLICATION_REVISION\nBACKUP_ID\nBACKUP_MANIFEST_SHA256\nCANDIDATE_ID\nCREATED_AT\nOPERATION\nSCHEMA_VERSION\nSOURCE_DB_IMAGE\nSOURCE_DB_IMAGE_EXACT\nSOURCE_DB_IMAGE_ID\nSOURCE_DB_VOLUME\nSOURCE_RUNTIME_CONFIG_DIGEST\nSOURCE_UPGRADE_CANDIDATE_ID\nTARGET_DB_IMAGE\nTARGET_DB_IMAGE_EXACT\nTARGET_DB_IMAGE_ID\nTARGET_DB_VOLUME\nTARGET_RUNTIME_CONFIG_CONTENT_SHA256\nTARGET_RUNTIME_CONFIG_DIGEST\nTARGET_RUNTIME_CONFIG_REVISION\nWEB_IMAGE' ]] \
+    [[ "${keys}" == $'API_IMAGE\nAPPLICATION_REVISION\nBACKUP_ID\nBACKUP_MANIFEST_SHA256\nCANDIDATE_ID\nCREATED_AT\nOPERATION\nQUIESCED_AT\nQUIESCE_EVIDENCE_ID\nSCHEMA_VERSION\nSOURCE_DB_IMAGE\nSOURCE_DB_IMAGE_EXACT\nSOURCE_DB_IMAGE_ID\nSOURCE_DB_VOLUME\nSOURCE_RUNTIME_CONFIG_DIGEST\nSOURCE_UPGRADE_CANDIDATE_ID\nTARGET_DB_IMAGE\nTARGET_DB_IMAGE_EXACT\nTARGET_DB_IMAGE_ID\nTARGET_DB_VOLUME\nTARGET_RUNTIME_CONFIG_CONTENT_SHA256\nTARGET_RUNTIME_CONFIG_DIGEST\nTARGET_RUNTIME_CONFIG_REVISION\nWEB_IMAGE' ]] \
       || fail "maintenance candidate keys are invalid"
   else
     fail "maintenance candidate operation is invalid"
@@ -1197,6 +1694,8 @@ validate_candidate() {
     || fail "maintenance candidate integrity check failed"
 
   candidate_application_revision="$(read_exact_value "${candidate_file}" APPLICATION_REVISION)"
+  candidate_quiesce_evidence_id="$(read_exact_value "${candidate_file}" QUIESCE_EVIDENCE_ID)"
+  candidate_quiesced_at="$(read_exact_value "${candidate_file}" QUIESCED_AT)"
   candidate_api_image="$(read_exact_value "${candidate_file}" API_IMAGE)"
   candidate_web_image="$(read_exact_value "${candidate_file}" WEB_IMAGE)"
   candidate_source_runtime_digest="$(read_exact_value "${candidate_file}" SOURCE_RUNTIME_CONFIG_DIGEST)"
@@ -1218,7 +1717,7 @@ validate_candidate() {
     candidate_source_upgrade_id="$(read_exact_value "${candidate_file}" SOURCE_UPGRADE_CANDIDATE_ID)"
   fi
 
-  if [[ "$(read_exact_value "${candidate_file}" SCHEMA_VERSION)" != 1 ]] \
+  if [[ "$(read_exact_value "${candidate_file}" SCHEMA_VERSION)" != 2 ]] \
     || { [[ "${candidate_operation}" != UPGRADE ]] && [[ "${candidate_operation}" != ROLLBACK ]]; } \
     || ! is_sha "${candidate_application_revision}" \
     || [[ "${candidate_api_image}" != "${API_IMAGE_REPOSITORY}:${candidate_application_revision}" ]] \
@@ -1232,10 +1731,18 @@ validate_candidate() {
     || ! is_volume_name "${candidate_source_db_volume}" \
     || ! is_volume_name "${candidate_target_db_volume}" \
     || ! is_backup_id "${candidate_backup_id}" \
-    || [[ ! "${candidate_backup_manifest_sha}" =~ ^[0-9a-f]{64}$ ]]
+    || [[ ! "${candidate_backup_manifest_sha}" =~ ^[0-9a-f]{64}$ ]] \
+    || ! is_candidate_id "${candidate_quiesce_evidence_id}" \
+    || [[ ! "${candidate_quiesced_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
   then
     fail "maintenance candidate values are invalid"
   fi
+  "${PYTHON_BIN}" - "${candidate_quiesced_at}" <<'PY'
+import datetime as dt
+import sys
+
+dt.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ")
+PY
   if [[ "${candidate_operation}" == UPGRADE ]]; then
     [[ "${candidate_source_db_image}" == "mysql:${SOURCE_DB_VERSION}" ]] \
       || fail "upgrade source must be mysql:${SOURCE_DB_VERSION}"
@@ -1264,7 +1771,11 @@ validate_candidate() {
     validate_backup \
       "${candidate_backup_id}" \
       "${candidate_application_revision}" \
-      "${candidate_source_runtime_digest}"
+      "${candidate_source_runtime_digest}" \
+      "${candidate_quiesced_at}" \
+      "${candidate_source_db_image_exact}" \
+      "${candidate_source_db_image_id}" \
+      "${candidate_source_db_volume}"
   else
     # ROLLBACK provenance is revalidated through its immutable source UPGRADE candidate.
     validate_backup "${candidate_backup_id}"
@@ -1284,6 +1795,8 @@ validate_rollback_source_candidate() {
   local rollback_backup_id="${candidate_backup_id}"
   local rollback_backup_manifest_sha="${candidate_backup_manifest_sha}"
   local rollback_candidate_id="$1"
+  local rollback_quiesce_evidence_id="${candidate_quiesce_evidence_id}"
+  local rollback_quiesced_at="${candidate_quiesced_at}"
   local rollback_source_db_image_exact="${candidate_source_db_image_exact}"
   local rollback_source_db_image_id="${candidate_source_db_image_id}"
   local rollback_source_db_volume="${candidate_source_db_volume}"
@@ -1313,6 +1826,8 @@ validate_rollback_source_candidate() {
     && [[ "${candidate_source_db_image_id}" == "${rollback_target_db_image_id}" ]] \
     && [[ "${candidate_backup_id}" == "${rollback_backup_id}" ]] \
     && [[ "${candidate_backup_manifest_sha}" == "${rollback_backup_manifest_sha}" ]] \
+    && [[ "${rollback_quiesce_evidence_id}" =~ ^[0-9a-f]{64}$ ]] \
+    && [[ "${rollback_quiesced_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
     || fail "rollback candidate does not match its source upgrade candidate"
   validate_candidate "${rollback_candidate_id}"
 }
@@ -1330,7 +1845,9 @@ validate_completed_upgrade_state() {
   local expected_candidate_id="$1"
   local keys
 
-  if [[ ! -f "${MAINTENANCE_STATE}" || -L "${MAINTENANCE_STATE}" ]]; then
+  if [[ ! -f "${MAINTENANCE_STATE}" || -L "${MAINTENANCE_STATE}" ]] \
+    || ! has_mode "${MAINTENANCE_STATE}" 600
+  then
     fail "completed upgrade maintenance state is missing or unsafe"
   fi
   keys="$(
@@ -1350,6 +1867,57 @@ validate_completed_upgrade_state() {
     && [[ "$(read_exact_value "${MAINTENANCE_STATE}" DB_VOLUME)" == "${candidate_target_db_volume}" ]] \
     && [[ "$(read_exact_value "${MAINTENANCE_STATE}" BACKUP_ID)" == "${candidate_backup_id}" ]] \
     || fail "completed upgrade maintenance state does not match the upgrade candidate"
+}
+
+recover_completed_quiesce_cleanup() {
+  local completed_candidate_id
+  local keys
+
+  if [[ ! -f "${MAINTENANCE_STATE}" || -L "${MAINTENANCE_STATE}" ]] \
+    || ! has_mode "${MAINTENANCE_STATE}" 600
+  then
+    fail "completed maintenance state is missing, unsafe, or mutable"
+  fi
+  keys="$(
+    /usr/bin/awk -F= 'NF >= 2 { print $1 }' "${MAINTENANCE_STATE}" \
+      | LC_ALL=C /usr/bin/sort
+  )"
+  if [[ "${keys}" != $'APPLICATION_REVISION\nBACKUP_ID\nCANDIDATE_ID\nCOMPLETED_AT\nDB_IMAGE_EXACT\nDB_IMAGE_ID\nDB_VOLUME\nOPERATION\nRUNTIME_CONFIG_DIGEST\nSCHEMA_VERSION' ]]; then
+    fail "completed maintenance state keys are invalid"
+  fi
+  completed_candidate_id="$(read_exact_value "${MAINTENANCE_STATE}" CANDIDATE_ID)"
+  validate_candidate "${completed_candidate_id}"
+  validate_candidate_quiesce_evidence
+  [[ "$(read_exact_value "${MAINTENANCE_STATE}" SCHEMA_VERSION)" == 1 ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" OPERATION)" == "${candidate_operation}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" APPLICATION_REVISION)" == "${candidate_application_revision}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" RUNTIME_CONFIG_DIGEST)" == "${candidate_target_runtime_digest}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" DB_IMAGE_EXACT)" == "${candidate_target_db_image_exact}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" DB_IMAGE_ID)" == "${candidate_target_db_image_id}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" DB_VOLUME)" == "${candidate_target_db_volume}" ]] \
+    && [[ "$(read_exact_value "${MAINTENANCE_STATE}" BACKUP_ID)" == "${candidate_backup_id}" ]] \
+    || fail "completed maintenance state does not match its immutable candidate"
+
+  load_current_runtime
+  [[ "${current_application_revision}" == "${candidate_application_revision}" ]] \
+    && [[ "${current_api_image}" == "${candidate_api_image}" ]] \
+    && [[ "${current_web_image}" == "${candidate_web_image}" ]] \
+    && [[ "${current_runtime_digest}" == "${candidate_target_runtime_digest}" ]] \
+    && [[ "${current_runtime_revision}" == "${candidate_target_runtime_revision}" ]] \
+    && [[ "${current_runtime_content_sha}" == "${candidate_target_runtime_content_sha}" ]] \
+    || fail "completed maintenance runtime does not match its immutable candidate"
+  load_current_db_identity
+  load_current_mysql_version
+  [[ "${current_db_image_exact}" == "${candidate_target_db_image_exact}" ]] \
+    && [[ "${current_db_image_id}" == "${candidate_target_db_image_id}" ]] \
+    && [[ "${current_db_volume}" == "${candidate_target_db_volume}" ]] \
+    || fail "completed maintenance DB binding does not match its immutable candidate"
+  service_set_is_healthy_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+    || fail "completed maintenance service set is unhealthy"
+  remove_quiesce_evidence
+  printf 'Completed Cubing Hub MySQL maintenance quiesce finalized: %s\n' \
+    "${completed_candidate_id}"
 }
 
 write_restore_evidence() {
@@ -1605,45 +2173,14 @@ commit_success_state() {
   write_db_env "${candidate_target_db_image_exact}" "${candidate_target_db_volume}"
   /bin/mv -f -- "${maintenance_temp}" "${MAINTENANCE_STATE}"
   /bin/rm -f -- "${RUNTIME_CONFIG_PENDING}"
+  remove_quiesce_evidence
 }
 
 service_set_is_healthy() {
-  local rendered
-
-  rendered="$(
-    compose_for \
-      "${candidate_target_release}" \
-      "${candidate_target_db_image_exact}" \
-      "${candidate_target_db_volume}" \
-      ps --format json
-  )"
-  printf '%s' "${rendered}" | "${PYTHON_BIN}" -c '
-import json
-import sys
-
-raw = sys.stdin.read().strip()
-if not raw:
-    raise SystemExit("no maintenance target service status was returned")
-try:
-    value = json.loads(raw)
-except json.JSONDecodeError:
-    value = [json.loads(line) for line in raw.splitlines() if line.strip()]
-entries = value if isinstance(value, list) else [value]
-required = {"api", "db", "redis", "web"}
-seen = set()
-for entry in entries:
-    service = entry.get("Service")
-    if service not in required or str(entry.get("State", "")).lower() != "running":
-        raise SystemExit("maintenance target service set is not running")
-    seen.add(service)
-    health = str(entry.get("Health", "")).lower()
-    if service in {"db", "redis", "web"} and health != "healthy":
-        raise SystemExit("maintenance target service health is not ready")
-    if health and health != "healthy":
-        raise SystemExit("maintenance target service health is invalid")
-if seen != required:
-    raise SystemExit("maintenance target service set is incomplete")
-'
+  service_set_is_healthy_for \
+    "${candidate_target_release}" \
+    "${candidate_target_db_image_exact}" \
+    "${candidate_target_db_volume}"
 }
 
 apply_candidate() {
@@ -1655,6 +2192,7 @@ apply_candidate() {
   local source_upgrade_candidate_id=
 
   validate_candidate "${candidate_id}"
+  validate_candidate_quiesce_evidence
   if [[ "${candidate_operation}" == ROLLBACK ]] \
     && [[ -e "${RUNTIME_CONFIG_PENDING}" || -L "${RUNTIME_CONFIG_PENDING}" ]]
   then
@@ -1674,11 +2212,11 @@ apply_candidate() {
       || fail "another runtime transaction is pending"
     [[ "${current_runtime_digest}" == "${candidate_source_runtime_digest}" ]] \
       || fail "upgrade candidate source runtime is no longer current"
-    validate_actual_db_identity \
-      "${candidate_source_db_image}" \
-      "${candidate_source_db_image_id}" \
-      "${candidate_source_db_volume}" \
-      "${current_release}"
+    validate_current_quiesce_for_candidate
+    [[ "${current_db_image_exact}" == "${candidate_source_db_image_exact}" ]] \
+      && [[ "${current_db_image_id}" == "${candidate_source_db_image_id}" ]] \
+      && [[ "${current_db_volume}" == "${candidate_source_db_volume}" ]] \
+      || fail "upgrade candidate source DB binding is stale"
   else
     rollback_volume="${candidate_target_db_volume}"
     source_upgrade_candidate_id="${candidate_source_upgrade_id}"
@@ -1707,19 +2245,32 @@ apply_candidate() {
         fail "existing pending transition cannot start or resume rollback"
       fi
       validate_candidate "${candidate_id}"
+      validate_candidate_quiesce_evidence
     else
       [[ "${current_runtime_digest}" == "${candidate_source_runtime_digest}" ]] \
         || fail "rollback candidate source runtime is no longer current"
-      validate_actual_db_identity \
-        "${candidate_source_db_image_exact}" \
-        "${candidate_source_db_image_id}" \
-        "${candidate_source_db_volume}" \
-        "${current_release}"
+      validate_current_quiesce_for_candidate
+      [[ "${current_db_image_exact}" == "${candidate_source_db_image_exact}" ]] \
+        && [[ "${current_db_image_id}" == "${candidate_source_db_image_id}" ]] \
+        && [[ "${current_db_volume}" == "${candidate_source_db_volume}" ]] \
+        || fail "rollback candidate source DB binding is stale"
     fi
   fi
 
   validate_target_artifacts "${rollback_resume}"
   if [[ "${candidate_operation}" == ROLLBACK ]]; then
+    if [[ "${rollback_with_pending}" == true ]]; then
+      compose_for \
+        "${candidate_target_release}" \
+        "${candidate_source_db_image_exact}" \
+        "${candidate_source_db_volume}" \
+        stop api web
+      application_services_are_stopped_for \
+        "${candidate_target_release}" \
+        "${candidate_source_db_image_exact}" \
+        "${candidate_source_db_volume}" \
+        || fail "pending rollback retry could not verify application quiescence"
+    fi
     revalidate_rollback_volume_before_cutover \
       "${candidate_id}" \
       "${rollback_resume}"
@@ -1790,15 +2341,24 @@ prepare_upgrade() {
 
   load_current_runtime
   load_current_db_identity
+  load_current_mysql_version
   if [[ "${current_db_image}" != "mysql:${SOURCE_DB_VERSION}" ]] \
     && [[ ! "${current_db_image}" =~ ^mysql:8\.0\.46@sha256:[0-9a-f]{64}$ ]]
   then
     fail "upgrade source must be exact MySQL ${SOURCE_DB_VERSION}"
   fi
+  validate_quiesce_matches_current
+  service_set_is_quiesced_for \
+    "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+    || fail "upgrade preparation requires the verified quiesced source service state"
   validate_backup \
     "${backup_id}" \
     "${current_application_revision}" \
-    "${current_runtime_digest}"
+    "${current_runtime_digest}" \
+    "${quiesced_at}" \
+    "${current_db_image_exact}" \
+    "${current_db_image_id}" \
+    "${current_db_volume}"
 
   registry_token="$(/bin/cat)"
   [[ -n "${registry_token}" ]] || fail "GHCR token must not be empty"
@@ -1839,6 +2399,8 @@ prepare_upgrade() {
     "${prepared_release}"
 
   candidate_operation=UPGRADE
+  candidate_quiesce_evidence_id="${quiesce_evidence_id}"
+  candidate_quiesced_at="${quiesced_at}"
   candidate_application_revision="${current_application_revision}"
   candidate_api_image="${current_api_image}"
   candidate_web_image="${current_web_image}"
@@ -1888,12 +2450,16 @@ verify_rollback_volume() {
 prepare_rollback() {
   local baseline_json
   local candidate_json
+  local rollback_quiesce_evidence_id
+  local rollback_quiesced_at
   local upgrade_candidate_id="$1"
 
   rollback_volume="$2"
   validate_candidate "${upgrade_candidate_id}"
   [[ "${candidate_operation}" == UPGRADE ]] \
     || fail "rollback preparation requires an upgrade candidate"
+  rollback_quiesce_evidence_id="${candidate_quiesce_evidence_id}"
+  rollback_quiesced_at="${candidate_quiesced_at}"
   is_volume_name "${rollback_volume}" || fail "rollback volume name is invalid"
   [[ "${rollback_volume}" != "${candidate_source_db_volume}" ]] \
     || fail "rollback volume must differ from the upgraded original volume"
@@ -1909,6 +2475,7 @@ prepare_rollback() {
     [[ "${pending_candidate_id}" == "${upgrade_candidate_id}" ]] \
       || fail "pending maintenance does not match the rollback source"
     validate_candidate "${upgrade_candidate_id}"
+    validate_candidate_quiesce_evidence
   else
     load_current_runtime
     [[ "${current_application_revision}" == "${candidate_application_revision}" ]] \
@@ -1917,12 +2484,19 @@ prepare_rollback() {
       || fail "completed upgrade application images no longer match"
     [[ "${current_runtime_digest}" == "${candidate_target_runtime_digest}" ]] \
       || fail "completed upgrade runtime is no longer current"
-    validate_actual_db_identity \
-      "${candidate_target_db_image_exact}" \
-      "${candidate_target_db_image_id}" \
-      "${candidate_target_db_volume}" \
-      "${current_release}"
+    load_current_db_identity
+    load_current_mysql_version
+    validate_quiesce_matches_current
+    service_set_is_quiesced_for \
+      "${current_release}" "${current_db_image_exact}" "${current_db_volume}" \
+      || fail "completed upgrade rollback preparation requires a fresh quiesce"
+    [[ "${current_db_image_exact}" == "${candidate_target_db_image_exact}" ]] \
+      && [[ "${current_db_image_id}" == "${candidate_target_db_image_id}" ]] \
+      && [[ "${current_db_volume}" == "${candidate_target_db_volume}" ]] \
+      || fail "completed upgrade DB binding no longer matches the source candidate"
     validate_completed_upgrade_state "${upgrade_candidate_id}"
+    rollback_quiesce_evidence_id="${quiesce_evidence_id}"
+    rollback_quiesced_at="${quiesced_at}"
   fi
 
   baseline_json="$(
@@ -1949,6 +2523,8 @@ prepare_rollback() {
     "${candidate_target_release}"
 
   candidate_operation=ROLLBACK
+  candidate_quiesce_evidence_id="${rollback_quiesce_evidence_id}"
+  candidate_quiesced_at="${rollback_quiesced_at}"
   candidate_source_upgrade_id="${upgrade_candidate_id}"
   candidate_source_runtime_digest="${candidate_target_runtime_digest}"
   candidate_source_db_image="mysql:${TARGET_DB_VERSION}"
@@ -1967,7 +2543,12 @@ recover_transition() {
   local recovery_candidate_id
   local source_upgrade_candidate_id
 
+  if [[ ! -e "${RUNTIME_CONFIG_PENDING}" && ! -L "${RUNTIME_CONFIG_PENDING}" ]]; then
+    recover_completed_quiesce_cleanup
+    return
+  fi
   validate_maintenance_pending
+  validate_candidate_quiesce_evidence
   recovery_candidate_id="${pending_candidate_id}"
   if [[ "${candidate_operation}" == ROLLBACK ]]; then
     source_upgrade_candidate_id="${candidate_source_upgrade_id}"
@@ -2008,6 +2589,9 @@ command_name="${1:-}"
 shift || true
 
 case "${command_name}" in
+  quiesce|status|resume-source)
+    [[ "$#" -eq 0 ]] || usage
+    ;;
   prepare-upgrade)
     [[ "$#" -eq 5 ]] || usage
     ;;
@@ -2078,6 +2662,15 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 case "${command_name}" in
+  quiesce)
+    quiesce_source
+    ;;
+  status)
+    show_quiesce_status
+    ;;
+  resume-source)
+    resume_source
+    ;;
   prepare-upgrade)
     prepare_upgrade "$@"
     ;;

--- a/homeserver/scripts/operations-config.test.mjs
+++ b/homeserver/scripts/operations-config.test.mjs
@@ -190,7 +190,44 @@ test("should_isolateMySqlMaintenanceFromNormalDeploy_when_dataServiceChanges", (
   );
   assert.match(
     mysqlMaintenanceScript,
-    /prepare-upgrade[\s\S]*verify-rollback-volume[\s\S]*prepare-rollback[\s\S]*apply[\s\S]*recover/,
+    /quiesce[\s\S]*status[\s\S]*resume-source[\s\S]*prepare-upgrade[\s\S]*verify-rollback-volume[\s\S]*prepare-rollback[\s\S]*apply[\s\S]*recover/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /readonly MAINTENANCE_QUIESCE="\$\{MAINTENANCE_ROOT\}\/quiesce\.state"/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /QUIESCE_EVIDENCE_ID/,
+  );
+  assert.match(mysqlMaintenanceScript, /QUIESCED_AT/);
+  assert.match(
+    mysqlMaintenanceScript,
+    /maintenance backup did not start after application quiesce/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /maintenance backup DB binding does not match application quiesce/,
+  );
+  assert.match(
+    backupScript,
+    /"image": database_image,[\s\S]*"imageId": database_image_id,[\s\S]*"volume": database_volume/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /validate_running_application_identity api[\s\S]*validate_running_application_identity web[\s\S]*stop api web/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /validate_candidate_quiesce_evidence[\s\S]*maintenance candidate is not bound to the active quiesce evidence/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /stop api web[\s\S]*service_set_is_quiesced_for[\s\S]*write_quiesce_evidence/,
+  );
+  assert.match(
+    mysqlMaintenanceScript,
+    /\/bin\/rm -f -- "\$\{RUNTIME_CONFIG_PENDING\}"[\s\S]*remove_quiesce_evidence/,
   );
   assert.match(
     mysqlMaintenanceScript,
@@ -216,6 +253,17 @@ test("should_isolateMySqlMaintenanceFromNormalDeploy_when_dataServiceChanges", (
     mysqlMaintenanceScript,
     /maintenance target service set is unhealthy[\s\S]*commit_success_state/,
   );
+  for (const deployEntryPoint of [restrictedWrapper, deployScript]) {
+    assert.match(
+      deployEntryPoint,
+      /MAINTENANCE_QUIESCE[\s\S]*fail_if_maintenance_quiesced/,
+    );
+    assert.match(
+      deployEntryPoint,
+      /application is quiesced for MySQL maintenance; use the maintenance worker/,
+    );
+  }
+  assert.doesNotMatch(backupBootstrap, /MAINTENANCE_QUIESCE/);
   assert.match(
     dataServiceMaintenanceDetector,
     /docker[\s\S]*compose[\s\S]*config[\s\S]*--no-env-resolution[\s\S]*--format json/,

--- a/homeserver/scripts/test-backup-home-server.sh
+++ b/homeserver/scripts/test-backup-home-server.sh
@@ -15,6 +15,10 @@ readonly APPLICATION_SHA=1111111111111111111111111111111111111111
 readonly PREVIOUS_SHA=2222222222222222222222222222222222222222
 readonly CONFIG_DIGEST=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 readonly CONFIG_SHA=3333333333333333333333333333333333333333
+readonly MYSQL_IMAGE_DIGEST=8484848484848484848484848484848484848484848484848484848484848484
+readonly MYSQL_IMAGE_ID=sha256:8484848484848484848484848484848484848484848484848484848484848484
+readonly MYSQL_IMAGE_EXACT="mysql:8.4.11@sha256:${MYSQL_IMAGE_DIGEST}"
+readonly MYSQL_VOLUME=cubing-hub_mysql-data
 
 test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/cubing-backup-test.XXXXXX")"
 
@@ -80,7 +84,23 @@ export MOCK_DUMP_FILE="${default_dump_file}"
     '#!/bin/bash' \
     'set -Eeuo pipefail' \
     'printf "%s\n" "$*" >>"${DOCKER_LOG}"' \
-    'if [[ " $* " != *" --project-name cubing-hub "* ]]; then' \
+    'if [[ " $* " == *" image inspect --format {{.Id}} "* ]]; then' \
+    '  printf "%s\n" "sha256:8484848484848484848484848484848484848484848484848484848484848484"' \
+    'elif [[ " $* " == *" image inspect --format {{json .RepoDigests}} "* ]]; then' \
+    '  printf "%s\n" "[\"mysql@sha256:8484848484848484848484848484848484848484848484848484848484848484\"]"' \
+    'elif [[ " $* " == *" container inspect --format {{.Image}} "* ]]; then' \
+    '  printf "%s\n" "sha256:8484848484848484848484848484848484848484848484848484848484848484"' \
+    'elif [[ " $* " == *" container inspect --format {{range .Mounts}}"* ]]; then' \
+    '  printf "%s\n" "cubing-hub_mysql-data"' \
+    'elif [[ " $* " == *"com.docker.compose.project"* ]]; then' \
+    '  printf "cubing-hub\n"' \
+    'elif [[ " $* " == *"com.docker.compose.service"* ]]; then' \
+    '  printf "db\n"' \
+    'elif [[ " $* " == *" container inspect --format {{if .State.Health}}"* ]]; then' \
+    '  printf "healthy\n"' \
+    'elif [[ " $* " == *" ps -a --no-trunc --filter volume=cubing-hub_mysql-data "* ]]; then' \
+    '  printf "mock-db-container\n"' \
+    'elif [[ " $* " != *" --project-name cubing-hub "* ]]; then' \
     '  printf "Compose project name was not pinned: %s\n" "$*" >&2' \
     '  exit 1' \
     'elif [[ " $* " == *" config --format json "* ]]; then' \
@@ -88,9 +108,11 @@ export MOCK_DUMP_FILE="${default_dump_file}"
     '    printf "ambient POST_IMAGES_HOST_DIR reached Compose rendering\n" >&2' \
     '    exit 1' \
     '  fi' \
-    '  printf '\''{"services":{"api":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]},"web":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]}}}\n'\'' "${MOCK_POST_IMAGES_DIR}" "${MOCK_POST_IMAGES_DIR}"' \
+    '  printf '\''{"services":{"db":{"image":"mysql:8.4.11"},"api":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]},"web":{"volumes":[{"type":"bind","source":"%s","target":"/data/post-images"}]}},"volumes":{"mysql-data":{"name":"cubing-hub_mysql-data"}}}\n'\'' "${MOCK_POST_IMAGES_DIR}" "${MOCK_POST_IMAGES_DIR}"' \
     'elif [[ " $* " == *" ps --status running --services "* ]]; then' \
     '  printf "%s\n" "${FAKE_RUNNING_SERVICES:-db}"' \
+    'elif [[ " $* " == *" ps -q db "* ]]; then' \
+    '  printf "mock-db-container\n"' \
     'elif [[ "$*" == *"BACKUP_QUERY=dump"* ]]; then' \
     '  /bin/cat "${MOCK_DUMP_FILE}"' \
     'elif [[ "$*" == *"BACKUP_QUERY=version"* ]]; then' \
@@ -500,7 +522,10 @@ assert_snapshot_contract() {
     "${backup_root}/retention-plan.json" \
     "${expected_trigger}" \
     "${APPLICATION_SHA}" \
-    "${CONFIG_DIGEST}" <<'PY'
+    "${CONFIG_DIGEST}" \
+    "${MYSQL_IMAGE_EXACT}" \
+    "${MYSQL_IMAGE_ID}" \
+    "${MYSQL_VOLUME}" <<'PY'
 import hashlib
 import json
 import pathlib
@@ -508,7 +533,14 @@ import sys
 
 snapshot = pathlib.Path(sys.argv[1])
 plan_path = pathlib.Path(sys.argv[2])
-trigger, application_sha, config_digest = sys.argv[3:]
+(
+    trigger,
+    application_sha,
+    config_digest,
+    database_image,
+    database_image_id,
+    database_volume,
+) = sys.argv[3:]
 manifest = json.loads((snapshot / "manifest.json").read_text(encoding="utf-8"))
 dump = snapshot / manifest["database"]["dumpFile"]
 assert manifest["schemaVersion"] == 1
@@ -520,6 +552,9 @@ assert manifest["source"]["applicationSha"] == application_sha
 assert manifest["source"]["runtimeConfigDigest"] == config_digest
 assert manifest["database"]["engine"] == "mysql"
 assert manifest["database"]["version"] == "8.4.11"
+assert manifest["database"]["image"] == database_image
+assert manifest["database"]["imageId"] == database_image_id
+assert manifest["database"]["volume"] == database_volume
 assert manifest["database"]["recordCounts"] == {"post_attachments": 1, "users": 1}
 assert manifest["database"]["recordCountsSource"] == "database/dump"
 assert manifest["database"]["bytes"] == dump.stat().st_size
@@ -637,13 +672,17 @@ fi
 /usr/bin/grep -Fq '"status":"RUNNING"' "${event_log}"
 /usr/bin/grep -Fq '"status":"FAILED"' "${event_log}"
 
-COMPOSE_PROJECT_NAME=ambient-project \
-POST_IMAGES_HOST_DIR="${test_root}/ambient-post-images" \
-DOCKER_LOG="${docker_log}" \
-HEARTBEAT_LOG="${heartbeat_log}" \
-FAIL_HOMEOPS_SIZE=true \
-MOCK_POST_IMAGES_DIR="${v2_post_images}" \
-  "${v2_script}" >"${v2_output}" 2>&1
+if ! COMPOSE_PROJECT_NAME=ambient-project \
+  POST_IMAGES_HOST_DIR="${test_root}/ambient-post-images" \
+  DOCKER_LOG="${docker_log}" \
+  HEARTBEAT_LOG="${heartbeat_log}" \
+  FAIL_HOMEOPS_SIZE=true \
+  MOCK_POST_IMAGES_DIR="${v2_post_images}" \
+    "${v2_script}" >"${v2_output}" 2>&1
+then
+  /bin/cat "${v2_output}" >&2
+  exit 1
+fi
 expected_release="${v2_app}/runtime-config/releases/${CONFIG_DIGEST#sha256:}"
 /usr/bin/grep -Fq -- "--project-name cubing-hub" "${docker_log}"
 /usr/bin/grep -Fq -- "--project-directory ${expected_release}" "${docker_log}"

--- a/homeserver/scripts/test-mysql-maintenance-home-server.sh
+++ b/homeserver/scripts/test-mysql-maintenance-home-server.sh
@@ -18,6 +18,7 @@ readonly MYSQL_80_DIGEST=8080808080808080808080808080808080808080808080808080808
 readonly MYSQL_84_DIGEST=8484848484848484848484848484848484848484848484848484848484848484
 readonly MYSQL_80_ID=sha256:8080808080808080808080808080808080808080808080808080808080808080
 readonly MYSQL_84_ID=sha256:8484848484848484848484848484848484848484848484848484848484848484
+readonly APPLICATION_IMAGE_ID=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 readonly BACKUP_ID=cubing-hub-production-20260813T000000Z
 readonly NEXT_BACKUP_ID=cubing-hub-production-20260813T010000Z
 readonly ORIGINAL_VOLUME=cubing-hub_mysql-data
@@ -43,6 +44,7 @@ trap cleanup EXIT INT TERM
 app_dir="${test_root}/app"
 backup_root="${test_root}/backups"
 db_state="${test_root}/db-state"
+service_state="${test_root}/service-state"
 test_script="${test_root}/mysql-maintenance-cubing-hub.sh"
 source_release="${app_dir}/runtime-config/releases/${SOURCE_RUNTIME_DIGEST#sha256:}"
 target_release="${app_dir}/runtime-config/releases/${TARGET_RUNTIME_DIGEST#sha256:}"
@@ -58,7 +60,8 @@ operation_lock="${app_dir}/.cubing-hub-operation.lock"
   "${source_release}/nginx" \
   "${source_release}/scripts" \
   "${backup_path}/database" \
-  "${db_state}"
+  "${db_state}" \
+  "${service_state}"
 /bin/cp "${PROJECT_ROOT}/homeserver/docker-compose.yml" "${runtime_compose}"
 /bin/cp "${runtime_compose}" "${source_release}/compose.yaml"
 /bin/cp \
@@ -125,17 +128,31 @@ dump_bytes="$(
   "${dump_sha}" \
   "${dump_bytes}" \
   "${APPLICATION_REVISION}" \
-  "${SOURCE_RUNTIME_DIGEST}" <<'PY'
+  "${SOURCE_RUNTIME_DIGEST}" \
+  "mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" \
+  "${MYSQL_80_ID}" \
+  "${ORIGINAL_VOLUME}" <<'PY'
 import json
 import pathlib
 import sys
 
-path, digest, size, application_revision, runtime_digest = sys.argv[1:]
+(
+    path,
+    digest,
+    size,
+    application_revision,
+    runtime_digest,
+    database_image,
+    database_image_id,
+    database_volume,
+) = sys.argv[1:]
 manifest = {
     "schemaVersion": 1,
     "status": "success",
     "project": "cubing-hub",
     "environment": "production",
+    "startedAt": "2026-08-13T00:00:00Z",
+    "completedAt": "2026-08-13T00:00:01Z",
     "source": {
         "applicationSha": application_revision,
         "runtimeConfigDigest": runtime_digest,
@@ -143,6 +160,9 @@ manifest = {
     "database": {
         "engine": "mysql",
         "version": "8.0.46",
+        "image": database_image,
+        "imageId": database_image_id,
+        "volume": database_volume,
         "dumpFile": "database/dump",
         "bytes": int(size),
         "sha256": digest,
@@ -161,6 +181,9 @@ printf '%s\n' \
 printf '%s\n' "${ORIGINAL_VOLUME}" >"${db_state}/volume"
 printf 'healthy\n' >"${db_state}/health"
 printf 'true\n' >"${db_state}/running"
+for service in db redis api web; do
+  printf 'running\n' >"${service_state}/${service}"
+done
 : >"${docker_log}"
 
 /usr/bin/sed \
@@ -181,6 +204,7 @@ run_maintenance() {
     FAKE_CONFIG_PROJECT=cubing-hub \
     FAKE_RENDER_DB_IMAGE=mysql:8.0.46 \
     FAKE_DB_STATE_DIR="${db_state}" \
+    FAKE_SERVICE_STATE_DIR="${service_state}" \
     FAKE_DOCKER_LOG="${docker_log}" \
     FAKE_MYSQL_80_IMAGE_ID="${FAKE_MYSQL_80_IMAGE_ID:-${MYSQL_80_ID}}" \
     FAKE_MYSQL_84_IMAGE_ID="${FAKE_MYSQL_84_IMAGE_ID:-${MYSQL_84_ID}}" \
@@ -207,6 +231,11 @@ users}" \
     FAKE_RUNNING_DB_VERSION_QUERY_FAIL="${FAKE_RUNNING_DB_VERSION_QUERY_FAIL:-false}" \
     FAKE_RUNNING_DB_VERSION_EMPTY="${FAKE_RUNNING_DB_VERSION_EMPTY:-false}" \
     FAKE_SERVICE_HEALTH="${FAKE_SERVICE_HEALTH:-healthy}" \
+    FAKE_SOURCE_SERVICE_HEALTH="${FAKE_SOURCE_SERVICE_HEALTH:-healthy}" \
+    FAKE_APP_STOP_FAIL="${FAKE_APP_STOP_FAIL:-false}" \
+    FAKE_ACTUAL_API_IMAGE_ID="${FAKE_ACTUAL_API_IMAGE_ID:-${APPLICATION_IMAGE_ID}}" \
+    FAKE_ACTUAL_WEB_IMAGE_ID="${FAKE_ACTUAL_WEB_IMAGE_ID:-${APPLICATION_IMAGE_ID}}" \
+    FAKE_DEFAULT_IMAGE_ID="${APPLICATION_IMAGE_ID}" \
     /bin/bash "${test_script}" "$@"
 }
 
@@ -261,6 +290,65 @@ path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
 PY
 }
 
+set_backup_database_binding() {
+  local mode="$1"
+
+  /usr/bin/python3 - "${backup_path}/manifest.json" "${mode}" \
+    "mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" \
+    "${MYSQL_80_ID}" \
+    "${ORIGINAL_VOLUME}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+mode, expected_image, expected_image_id, expected_volume = sys.argv[2:]
+manifest = json.loads(path.read_text(encoding="utf-8"))
+database = manifest["database"]
+database.update(
+    image=expected_image,
+    imageId=expected_image_id,
+    volume=expected_volume,
+)
+if mode == "image-mismatch":
+    database["image"] = "mysql:8.0.46@sha256:" + "9" * 64
+elif mode == "image-id-mismatch":
+    database["imageId"] = "sha256:" + "9" * 64
+elif mode == "volume-mismatch":
+    database["volume"] = "cubing-hub_mysql-other"
+elif mode != "valid":
+    raise SystemExit(f"unsupported backup DB binding fixture: {mode}")
+path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+PY
+}
+
+bind_backup_to_active_quiesce() {
+  local manifest_path="$1"
+  local quiesce_file="${app_dir}/runtime-config/mysql-maintenance/quiesce.state"
+
+  /usr/bin/python3 - "${manifest_path}" "${quiesce_file}" <<'PY'
+import datetime as dt
+import json
+import pathlib
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+quiesce_path = pathlib.Path(sys.argv[2])
+values = dict(
+    line.split("=", 1)
+    for line in quiesce_path.read_text(encoding="utf-8").splitlines()
+)
+quiesced = dt.datetime.strptime(values["QUIESCED_AT"], "%Y-%m-%dT%H:%M:%SZ")
+started = quiesced + dt.timedelta(seconds=1)
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+manifest["startedAt"] = started.strftime("%Y-%m-%dT%H:%M:%SZ")
+manifest["completedAt"] = (started + dt.timedelta(seconds=1)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
+manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+PY
+}
+
 reset_source_db_fixture() {
   /bin/rm -f -- "${app_dir}/runtime-config/pending"
   printf '%s\n' "${MYSQL_80_ID}" >"${db_state}/image-id"
@@ -268,10 +356,15 @@ reset_source_db_fixture() {
   printf '%s\n' "${ORIGINAL_VOLUME}" >"${db_state}/volume"
   printf 'healthy\n' >"${db_state}/health"
   printf 'true\n' >"${db_state}/running"
+  printf 'running\n' >"${service_state}/db"
+  printf 'running\n' >"${service_state}/redis"
+  printf 'exited\n' >"${service_state}/api"
+  printf 'exited\n' >"${service_state}/web"
 }
 
 assert_upgrade_version_gate_failure() {
   test -f "${app_dir}/runtime-config/pending"
+  test -f "${app_dir}/runtime-config/mysql-maintenance/quiesce.state"
   /usr/bin/grep -Fxq 'TRANSACTION_TYPE=MYSQL_MAINTENANCE' \
     "${app_dir}/runtime-config/pending"
   test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
@@ -308,6 +401,107 @@ assert version_index < application_index
 PY
 }
 
+# A literal confirmation is not a write-stop. The maintenance lifecycle starts
+# by proving a healthy source and committing an immutable quiesce record.
+test "$(run_maintenance status)" = $'QUIESCE_STATUS=inactive\nPENDING=none'
+expect_failure "upgrade preparation without quiesce" prepare_upgrade_fixture
+
+printf 'foreign transaction\n' >"${app_dir}/runtime-config/pending"
+expect_failure "quiesce with pending transaction" run_maintenance quiesce
+/bin/rm -f -- "${app_dir}/runtime-config/pending"
+
+/bin/unlink "${app_dir}/runtime-config/current"
+/bin/ln -s \
+  "releases/${TARGET_RUNTIME_DIGEST#sha256:}" \
+  "${app_dir}/runtime-config/current"
+expect_failure "quiesce with runtime pointer drift" run_maintenance quiesce
+/bin/unlink "${app_dir}/runtime-config/current"
+/bin/ln -s \
+  "releases/${SOURCE_RUNTIME_DIGEST#sha256:}" \
+  "${app_dir}/runtime-config/current"
+
+printf '%s\n' \
+  sha256:9999999999999999999999999999999999999999999999999999999999999999 \
+  >"${db_state}/image-id"
+expect_failure "quiesce with source DB identity drift" run_maintenance quiesce
+printf '%s\n' "${MYSQL_80_ID}" >"${db_state}/image-id"
+
+FAKE_SOURCE_SERVICE_HEALTH=unhealthy \
+  expect_failure "quiesce with unhealthy source" run_maintenance quiesce
+FAKE_ACTUAL_API_IMAGE_ID=sha256:9999999999999999999999999999999999999999999999999999999999999999 \
+  expect_failure "quiesce with application image drift" run_maintenance quiesce
+FAKE_APP_STOP_FAIL=true \
+  expect_failure "quiesce application stop failure" run_maintenance quiesce
+test "$(/bin/cat "${service_state}/api")" = running
+test "$(/bin/cat "${service_state}/web")" = running
+
+maintenance_root="${app_dir}/runtime-config/mysql-maintenance"
+/bin/mkdir -p "${maintenance_root}"
+/bin/chmod 700 "${maintenance_root}"
+printf 'unsafe\n' >"${test_root}/unsafe-quiesce"
+/bin/ln -s "${test_root}/unsafe-quiesce" "${maintenance_root}/quiesce.state"
+expect_failure "unsafe quiesce evidence" run_maintenance quiesce
+/bin/unlink "${maintenance_root}/quiesce.state"
+
+lock_ready="${test_root}/quiesce-lock-ready"
+/usr/bin/python3 - "${operation_lock}" "${lock_ready}" <<'PY' &
+import fcntl
+import pathlib
+import sys
+import time
+
+lock_path, ready_path = sys.argv[1:]
+with open(lock_path, "a", encoding="utf-8") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    pathlib.Path(ready_path).write_text("ready\n", encoding="utf-8")
+    time.sleep(30)
+PY
+lock_holder_pid="$!"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [[ -f "${lock_ready}" ]] && break
+  /bin/sleep 0.1
+done
+test -f "${lock_ready}"
+expect_failure "quiesce operation lock conflict" run_maintenance quiesce
+/bin/kill "${lock_holder_pid}"
+wait "${lock_holder_pid}" 2>/dev/null || true
+lock_holder_pid=
+
+run_maintenance quiesce >/dev/null
+quiesce_file="${maintenance_root}/quiesce.state"
+test -f "${quiesce_file}"
+/usr/bin/python3 - "${quiesce_file}" <<'PY'
+import os
+import stat
+import sys
+
+assert stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o400
+PY
+quiesce_evidence_id="$(/usr/bin/sed -n 's/^EVIDENCE_ID=//p' "${quiesce_file}")"
+[[ "${quiesce_evidence_id}" =~ ^[0-9a-f]{64}$ ]]
+test "$(/bin/cat "${service_state}/api")" = exited
+test "$(/bin/cat "${service_state}/web")" = exited
+test "$(/bin/cat "${service_state}/db")" = running
+/usr/bin/grep -Fxq 'QUIESCE_STATUS=active' <(run_maintenance status)
+test "$(run_maintenance quiesce | /usr/bin/sed -n 's/.*: //p')" = \
+  "${quiesce_evidence_id}"
+
+expect_failure "backup started before quiesce" prepare_upgrade_fixture
+quiesced_at="$(/usr/bin/sed -n 's/^QUIESCED_AT=//p' "${quiesce_file}")"
+/usr/bin/python3 - "${backup_path}/manifest.json" "${quiesced_at}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["startedAt"] = sys.argv[2]
+manifest["completedAt"] = sys.argv[2]
+path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+PY
+expect_failure "backup started at ambiguous quiesce second" prepare_upgrade_fixture
+bind_backup_to_active_quiesce "${backup_path}/manifest.json"
+
 # Upgrade backups must originate from the exact committed source runtime.
 set_backup_provenance application-mismatch
 expect_failure "backup application revision mismatch" prepare_upgrade_fixture
@@ -322,6 +516,30 @@ set_backup_provenance missing-runtime
 expect_failure "backup runtime provenance missing" prepare_upgrade_fixture
 test ! -e "${app_dir}/runtime-config/mysql-maintenance/candidates"
 set_backup_provenance valid
+
+set_backup_database_binding image-mismatch
+expect_failure "backup exact DB image mismatch" prepare_upgrade_fixture
+set_backup_database_binding image-id-mismatch
+expect_failure "backup DB image ID mismatch" prepare_upgrade_fixture
+set_backup_database_binding volume-mismatch
+expect_failure "backup DB volume mismatch" prepare_upgrade_fixture
+set_backup_database_binding valid
+
+# Before any DB transition starts, resume-source is the only canonical way to
+# restore the source application and clear the write-stop evidence.
+printf 'foreign transaction\n' >"${app_dir}/runtime-config/pending"
+expect_failure "resume source with pending transaction" run_maintenance resume-source
+/bin/rm -f -- "${app_dir}/runtime-config/pending"
+run_maintenance resume-source >/dev/null
+test ! -e "${quiesce_file}"
+test "$(/bin/cat "${service_state}/api")" = running
+test "$(/bin/cat "${service_state}/web")" = running
+test "$(run_maintenance status)" = $'QUIESCE_STATUS=inactive\nPENDING=none'
+expect_failure "resume source without evidence" run_maintenance resume-source
+
+run_maintenance quiesce >/dev/null
+bind_backup_to_active_quiesce "${backup_path}/manifest.json"
+quiesce_evidence_id="$(/usr/bin/sed -n 's/^EVIDENCE_ID=//p' "${quiesce_file}")"
 
 # Candidate creation must not change current runtime state or binding.
 state_before="$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')"
@@ -345,9 +563,17 @@ PY
 /usr/bin/grep -Fxq "WEB_IMAGE=ghcr.io/xxh3898/cubing-hub-web:${APPLICATION_REVISION}" "${upgrade_file}"
 /usr/bin/grep -Fxq "TARGET_DB_IMAGE=mysql:8.4.11" "${upgrade_file}"
 /usr/bin/grep -Fxq "TARGET_DB_VOLUME=${ORIGINAL_VOLUME}" "${upgrade_file}"
+/usr/bin/grep -Fxq 'SCHEMA_VERSION=2' "${upgrade_file}"
+/usr/bin/grep -Fxq "QUIESCE_EVIDENCE_ID=${quiesce_evidence_id}" "${upgrade_file}"
 test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk '{print $1}')" = "${state_before}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
 test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_before}"
+
+# The confirmation token cannot substitute for persistent quiesce evidence.
+/bin/mv "${quiesce_file}" "${quiesce_file}.hold"
+expect_failure "literal confirmation without quiesce evidence" \
+  run_maintenance apply "${upgrade_candidate}" WRITE_STOP_CONFIRMED
+/bin/mv "${quiesce_file}.hold" "${quiesce_file}"
 
 # Missing candidate, image drift, pending state, API drift, volume failure, and
 # backup tampering must stop before a destructive transition.
@@ -382,6 +608,35 @@ expect_failure "runtime state and current pointer mismatch" \
   run_maintenance apply "${upgrade_candidate}" WRITE_STOP_CONFIRMED
 /bin/unlink "${app_dir}/runtime-config/current"
 /bin/ln -s "${current_before}" "${app_dir}/runtime-config/current"
+
+/bin/cp "${app_dir}/runtime-config/state" "${test_root}/source-state.valid"
+/usr/bin/sed \
+  's/^RUNTIME_CONFIG_REVISION=.*/RUNTIME_CONFIG_REVISION=4444444444444444444444444444444444444444/' \
+  "${test_root}/source-state.valid" >"${app_dir}/runtime-config/state"
+/bin/chmod 600 "${app_dir}/runtime-config/state"
+expect_failure "stale quiesce runtime revision" \
+  run_maintenance apply "${upgrade_candidate}" WRITE_STOP_CONFIRMED
+/bin/cp "${test_root}/source-state.valid" "${app_dir}/runtime-config/state"
+/bin/chmod 600 "${app_dir}/runtime-config/state"
+
+/bin/cp "${app_dir}/.env" "${test_root}/source-env.valid"
+/usr/bin/sed \
+  -e 's/^APPLICATION_REVISION=.*/APPLICATION_REVISION=4444444444444444444444444444444444444444/' \
+  "${test_root}/source-state.valid" >"${app_dir}/runtime-config/state"
+/usr/bin/sed \
+  -e 's/1111111111111111111111111111111111111111/4444444444444444444444444444444444444444/g' \
+  "${test_root}/source-env.valid" >"${app_dir}/.env"
+/bin/chmod 600 "${app_dir}/runtime-config/state" "${app_dir}/.env"
+expect_failure "stale quiesce application revision" \
+  run_maintenance apply "${upgrade_candidate}" WRITE_STOP_CONFIRMED
+/bin/cp "${test_root}/source-state.valid" "${app_dir}/runtime-config/state"
+/bin/cp "${test_root}/source-env.valid" "${app_dir}/.env"
+/bin/chmod 600 "${app_dir}/runtime-config/state" "${app_dir}/.env"
+
+printf 'cubing-hub_mysql-drift\n' >"${db_state}/volume"
+expect_failure "stale quiesce DB volume" \
+  run_maintenance apply "${upgrade_candidate}" WRITE_STOP_CONFIRMED
+printf '%s\n' "${ORIGINAL_VOLUME}" >"${db_state}/volume"
 
 printf 'foreign transaction\n' >"${app_dir}/runtime-config/pending"
 expect_failure "pending runtime transaction" \
@@ -478,6 +733,7 @@ test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk 
 test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_before}"
 /usr/bin/grep -Fxq "DB_IMAGE=mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" "${app_dir}/.env"
 /usr/bin/grep -Fxq "DB_VOLUME_NAME=${ORIGINAL_VOLUME}" "${app_dir}/.env"
+test -f "${quiesce_file}"
 
 # Reset only the isolated fixture so application-startup failure can exercise
 # a fresh apply from the same committed source state.
@@ -504,6 +760,7 @@ test "$(/usr/bin/shasum -a 256 "${app_dir}/runtime-config/state" | /usr/bin/awk 
 test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_before}"
 /usr/bin/grep -Fxq "DB_IMAGE=mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" "${app_dir}/.env"
 /usr/bin/grep -Fxq "DB_VOLUME_NAME=${ORIGINAL_VOLUME}" "${app_dir}/.env"
+test -f "${quiesce_file}"
 
 printf '%s\n' "${MYSQL_84_ID}" >"${db_state}/image-id"
 printf '%s\n' "mysql:8.4.11@sha256:${MYSQL_84_DIGEST}" >"${db_state}/image-ref"
@@ -529,15 +786,18 @@ FAKE_RUNNING_DB_VERSION_OVERRIDE=8.0.46 \
   expect_failure "wrong running MySQL version during recovery" \
     run_maintenance recover
 test -f "${app_dir}/runtime-config/pending"
+test -f "${quiesce_file}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
 test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_before}"
 FAKE_SERVICE_HEALTH=unhealthy \
   expect_failure "unhealthy target recovery" run_maintenance recover
 test -f "${app_dir}/runtime-config/pending"
+test -f "${quiesce_file}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = "${current_before}"
 test "$(/usr/bin/shasum -a 256 "${app_dir}/.env" | /usr/bin/awk '{print $1}')" = "${env_before}"
 run_maintenance recover
 test ! -e "${app_dir}/runtime-config/pending"
+test ! -e "${quiesce_file}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = \
   "releases/${TARGET_RUNTIME_DIGEST#sha256:}"
 /usr/bin/grep -Fxq "DB_IMAGE=mysql:8.4.11@sha256:${MYSQL_84_DIGEST}" "${app_dir}/.env"
@@ -545,6 +805,16 @@ test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = \
 /usr/bin/grep -Fxq \
   "PREVIOUS_RUNTIME_CONFIG_DIGEST=${TARGET_RUNTIME_DIGEST}" \
   "${app_dir}/runtime-config/state"
+
+# A completed upgrade requires a new quiesce of the running 8.4 source before
+# rollback preparation. resume-source cannot cross the completed DB boundary.
+run_maintenance quiesce >/dev/null
+rollback_quiesce_evidence_id="$(
+  /usr/bin/sed -n 's/^EVIDENCE_ID=//p' "${quiesce_file}"
+)"
+/bin/cp "${quiesce_file}" "${test_root}/rollback-quiesce.fixture"
+expect_failure "resume source after completed upgrade" run_maintenance resume-source
+test -f "${quiesce_file}"
 
 # Rollback volume verification binds the backup, 8.0 image, row parity, and a
 # fresh volume before it can become a candidate.
@@ -581,6 +851,9 @@ rollback_file="${app_dir}/runtime-config/mysql-maintenance/candidates/${rollback
 /usr/bin/grep -Fxq 'TARGET_DB_IMAGE=mysql:8.0.46' "${rollback_file}"
 /usr/bin/grep -Fxq "SOURCE_DB_VOLUME=${ORIGINAL_VOLUME}" "${rollback_file}"
 /usr/bin/grep -Fxq "TARGET_DB_VOLUME=${ROLLBACK_VOLUME}" "${rollback_file}"
+/usr/bin/grep -Fxq \
+  "QUIESCE_EVIDENCE_ID=${rollback_quiesce_evidence_id}" \
+  "${rollback_file}"
 
 # A second immutable rollback candidate for the same restore must not replace
 # an interrupted rollback transaction.
@@ -667,10 +940,12 @@ test "$(/bin/cat "${db_state}/health")" = unhealthy
 test -f "${upgrade_file}"
 test -f "${restore_evidence}"
 test -f "${rollback_file}"
+test -f "${quiesce_file}"
 /bin/cp "${rollback_pending}" "${test_root}/failed-rollback-pending.fixture"
 
 expect_failure "unhealthy rollback target recovery" run_maintenance recover
 test -f "${rollback_pending}"
+test -f "${quiesce_file}"
 
 # A resumed rollback must not reuse the parity result from its first apply.
 # The exact unhealthy target container is removed, then current volume contents
@@ -700,6 +975,7 @@ expect_failure "tampered rollback pending transaction" \
 
 run_maintenance apply "${rollback_candidate}" WRITE_STOP_CONFIRMED
 test ! -e "${app_dir}/runtime-config/pending"
+test ! -e "${quiesce_file}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = \
   "releases/${TARGET_RUNTIME_DIGEST#sha256:}"
 /usr/bin/grep -Fxq "DB_IMAGE=mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" "${app_dir}/.env"
@@ -711,17 +987,21 @@ test "$(/bin/cat "${db_state}/image-id")" = "${MYSQL_80_ID}"
 
 # When the rollback DB binding is already healthy and only state finalization
 # remains, dedicated recover keeps its original responsibility.
+/bin/cp "${test_root}/rollback-quiesce.fixture" "${quiesce_file}"
+/bin/chmod 400 "${quiesce_file}"
 /bin/unlink "${app_dir}/runtime-config/current"
 /bin/ln -s \
   "releases/${SOURCE_RUNTIME_DIGEST#sha256:}" \
   "${app_dir}/runtime-config/current"
 /bin/cp "${test_root}/failed-rollback-pending.fixture" "${rollback_pending}"
 /bin/chmod 600 "${rollback_pending}"
-FAKE_SERVICE_HEALTH=unhealthy \
+FAKE_SOURCE_SERVICE_HEALTH=unhealthy \
   expect_failure "rollback application recovery failure" run_maintenance recover
 test -f "${rollback_pending}"
+test -f "${quiesce_file}"
 run_maintenance recover
 test ! -e "${rollback_pending}"
+test ! -e "${quiesce_file}"
 test "$(/usr/bin/readlink "${app_dir}/runtime-config/current")" = \
   "releases/${TARGET_RUNTIME_DIGEST#sha256:}"
 /usr/bin/grep -Fxq 'OPERATION=ROLLBACK' "${maintenance_state}"
@@ -737,6 +1017,7 @@ test "$(/bin/cat "${db_state}/image-id")" = "${MYSQL_80_ID}"
 # A later maintenance cycle treats the verified rollback binding as the new
 # normal 8.0 source and requires a backup from the current runtime instead of
 # reusing the previous cycle's source snapshot.
+run_maintenance quiesce >/dev/null
 next_backup_path="${backup_root}/${NEXT_BACKUP_ID}"
 /bin/mkdir -p "${next_backup_path}/database"
 /bin/cp "${backup_path}/database/dump" "${next_backup_path}/database/dump"
@@ -745,21 +1026,36 @@ next_backup_path="${backup_root}/${NEXT_BACKUP_ID}"
   "${backup_path}/manifest.json" \
   "${next_backup_path}/manifest.json" \
   "${APPLICATION_REVISION}" \
-  "${TARGET_RUNTIME_DIGEST}" <<'PY'
+  "${TARGET_RUNTIME_DIGEST}" \
+  "mysql:8.0.46@sha256:${MYSQL_80_DIGEST}" \
+  "${MYSQL_80_ID}" \
+  "${ROLLBACK_VOLUME}" <<'PY'
 import json
 import pathlib
 import sys
 
 source_path = pathlib.Path(sys.argv[1])
 target_path = pathlib.Path(sys.argv[2])
-application_revision, runtime_digest = sys.argv[3:]
+(
+    application_revision,
+    runtime_digest,
+    database_image,
+    database_image_id,
+    database_volume,
+) = sys.argv[3:]
 manifest = json.loads(source_path.read_text(encoding="utf-8"))
 manifest["source"] = {
     "applicationSha": application_revision,
     "runtimeConfigDigest": runtime_digest,
 }
+manifest["database"].update(
+    image=database_image,
+    imageId=database_image_id,
+    volume=database_volume,
+)
 target_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
 PY
+bind_backup_to_active_quiesce "${next_backup_path}/manifest.json"
 next_upgrade_candidate="$(
   printf 'test-token' | run_maintenance prepare-upgrade \
     "${TARGET_RUNTIME_DIGEST}" \
@@ -771,17 +1067,26 @@ next_upgrade_candidate="$(
 next_upgrade_file="${app_dir}/runtime-config/mysql-maintenance/candidates/${next_upgrade_candidate}/candidate.env"
 /usr/bin/grep -Fxq "SOURCE_DB_VOLUME=${ROLLBACK_VOLUME}" "${next_upgrade_file}"
 /usr/bin/grep -Fxq "TARGET_DB_VOLUME=${ROLLBACK_VOLUME}" "${next_upgrade_file}"
+/bin/cp "${quiesce_file}" "${test_root}/next-upgrade-quiesce.fixture"
 
 # Exact MySQL 8.4.11 allows the normal apply path to start the application and
 # commit the target binding only after the runtime version gate succeeds.
 : >"${docker_log}"
 run_maintenance apply "${next_upgrade_candidate}" WRITE_STOP_CONFIRMED
 test ! -e "${app_dir}/runtime-config/pending"
+test ! -e "${quiesce_file}"
 test "$(/bin/cat "${db_state}/image-id")" = "${MYSQL_84_ID}"
 /usr/bin/grep -Fxq "DB_IMAGE=mysql:8.4.11@sha256:${MYSQL_84_DIGEST}" "${app_dir}/.env"
 /usr/bin/grep -Fxq "DB_VOLUME_NAME=${ROLLBACK_VOLUME}" "${app_dir}/.env"
 /usr/bin/grep -Fxq 'OPERATION=UPGRADE' \
   "${app_dir}/runtime-config/mysql-maintenance/state"
 assert_version_gate_precedes_application_startup
+
+# If interruption happens after success state and pending removal but before
+# the last evidence unlink, dedicated recover can finish only that cleanup.
+/bin/cp "${test_root}/next-upgrade-quiesce.fixture" "${quiesce_file}"
+/bin/chmod 400 "${quiesce_file}"
+run_maintenance recover
+test ! -e "${quiesce_file}"
 
 printf 'Cubing Hub MySQL maintenance transition tests passed\n'

--- a/homeserver/scripts/test-runtime-script-bootstrap.sh
+++ b/homeserver/scripts/test-runtime-script-bootstrap.sh
@@ -294,6 +294,56 @@ test "$(
   /usr/bin/wc -l <"${legacy_backup_marker}" | /usr/bin/tr -d ' '
 )" = "${legacy_backup_count}"
 
+# Quiesce state persists across commands: deploy and normal recovery must not
+# restart API/Web, while the canonical backup path remains available for the
+# final maintenance snapshot.
+quiesce_root="${app_dir}/runtime-config/mysql-maintenance"
+quiesce_file="${quiesce_root}/quiesce.state"
+/bin/mkdir -p "${quiesce_root}"
+/bin/chmod 700 "${quiesce_root}"
+printf 'fixture quiesce\n' >"${quiesce_file}"
+/bin/chmod 400 "${quiesce_file}"
+candidate_count_before_quiesce="$((
+  $(/usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' ')
+))"
+set +e
+run_update >/dev/null 2>&1
+quiesced_deploy_exit_code="$?"
+/usr/bin/env \
+  FAKE_CANDIDATE_LOG="${candidate_log}" \
+  /bin/bash "${deploy_bootstrap}" recover >/dev/null 2>&1
+quiesced_recover_exit_code="$?"
+set -e
+if [[ "${quiesced_deploy_exit_code}" -ne 1 ]] \
+  || [[ "${quiesced_recover_exit_code}" -ne 1 ]] \
+  || [[ "$(/usr/bin/wc -l <"${candidate_log}" | /usr/bin/tr -d ' ')" != "${candidate_count_before_quiesce}" ]]
+then
+  printf 'Deploy and recover must fail closed while maintenance quiesce exists\n' >&2
+  exit 1
+fi
+backup_count_before_quiesce="$((
+  $(/usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' ')
+))"
+/usr/bin/env \
+  FAKE_BACKUP_MARKER="${backup_marker}" \
+  FAKE_LEGACY_BACKUP_MARKER="${legacy_backup_marker}" \
+  /bin/bash "${backup_bootstrap}"
+test "$((
+  $(/usr/bin/wc -l <"${backup_marker}" | /usr/bin/tr -d ' ')
+))" -eq "$((backup_count_before_quiesce + 1))"
+/bin/rm -f -- "${quiesce_file}"
+printf 'unsafe quiesce\n' >"${test_root}/unsafe-quiesce"
+/bin/ln -s "${test_root}/unsafe-quiesce" "${quiesce_file}"
+set +e
+run_update >/dev/null 2>&1
+unsafe_quiesce_exit_code="$?"
+set -e
+if [[ "${unsafe_quiesce_exit_code}" -ne 1 ]]; then
+  printf 'Deploy must fail closed for an unsafe quiesce path\n' >&2
+  exit 1
+fi
+/bin/unlink "${quiesce_file}"
+
 assert_preflight_failure() {
   local label="$1"
   local candidate_count_before


### PR DESCRIPTION
## Goal

MySQL engine cutover 전 final backup부터 `apply`까지 application write path가 중단된 상태를 canonical command와 persistent evidence로 검증합니다.

## Quiesce lifecycle

- `quiesce`: verified source identity와 service health 확인 후 API/Web 중지 및 evidence 기록
- `status`: inactive, active, maintenance-pending 상태 검증·출력
- `resume-source`: pending 전 unchanged MySQL 8.0.46 source만 안전하게 재기동
- success finalization: state/current/DB binding과 pending 확정 후 evidence 제거

## Persistent evidence

`runtime-config/mysql-maintenance/quiesce.state`에 application/runtime identity, exact DB image·image ID·volume, MySQL patch, UTC timestamp와 content-derived evidence ID를 mode 400으로 기록합니다. Operation lock은 command 직렬화, quiesce evidence는 command 사이 maintenance-window state를 담당합니다.

## Final backup binding

Backup manifest에 actual DB exact image·image ID·volume을 기록합니다. Upgrade candidate는 source application/runtime provenance와 DB binding이 quiesce evidence와 같고 `startedAt > QUIESCED_AT`인 final backup만 허용합니다. 같은 초는 ordering이 모호하므로 fail closed합니다.

## Apply and deploy safety

- `WRITE_STOP_CONFIRMED` literal만으로는 `apply`할 수 없습니다.
- Apply/recover는 active evidence, candidate binding, actual stopped state와 DB identity를 재검증합니다.
- Quiesce 중 normal deploy와 normal deploy recovery는 stable wrapper와 active worker에서 모두 차단합니다.
- Pending 전 canonical backup은 final snapshot 생성을 위해 계속 허용합니다.

## Tests

- quiesce success/repeat/failure/unsafe evidence/lock conflict
- deploy/recover rejection과 backup allowance
- final backup timestamp·runtime provenance·DB binding 검증
- literal-only apply와 stale runtime/application/DB evidence rejection
- source resume 허용·금지 경계
- upgrade/rollback apply·recover·interrupted retry regression
- runtime bootstrap, deploy, backup, detector, baseline inspection regression
- production/admin Compose render

## Validation

로컬에서 shell syntax, canonical shell fixtures, production/admin Compose render와 `git diff --check`를 통과했습니다. Node semantic tests와 runtime-config image build는 production Docker context를 변경하지 않기 위해 로컬에서 실행하지 않았으며 PR Validate에서 확인합니다.

## Production Changes

None.

## Release consequence

현재 `e9195e1e94fc0c2eed68cbb664465802a120cf72` runtime artifact와 기존 candidate는 historical preparation evidence로 유지합니다. 이 tooling이 main에 release되면 새 official main SHA와 runtime-config revision/digest를 final maintenance target으로 다시 고정해야 합니다.

## Out of Scope

- production command, SSH, backup/restore, MySQL cutover
- workflow/environment/secret 변경
- Compose, DB schema/Flyway, backend/frontend 기능 변경
