### PR TITLE
fix: stabilize AuthContext pending solve ownership

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useRef, useState } from 'react'
+import { createContext, useCallback, useEffect, useRef, useState } from 'react'
 import { clearRefreshCookie, getMe, refreshSession } from '../api.js'
 import { clearPendingTimerSolve } from '../lib/pendingTimerSolveStorage.js'
 import {
@@ -27,11 +27,23 @@ export function AuthProvider({ children }) {
   const [currentUser, setCurrentUser] = useState(null)
   const [isBootstrapping, setIsBootstrapping] = useState(true)
   const [isSessionSyncing, setIsSessionSyncing] = useState(false)
-  const currentUserRef = useRef(currentUser)
+  const confirmedUserIdRef = useRef(null)
 
-  useEffect(() => {
-    currentUserRef.current = currentUser
-  }, [currentUser])
+  const commitAuthenticatedUser = useCallback((nextUser) => {
+    const nextUserId = nextUser?.userId
+
+    if (Number.isSafeInteger(nextUserId) && nextUserId > 0) {
+      const previousUserId = confirmedUserIdRef.current
+
+      if (previousUserId != null && previousUserId !== nextUserId) {
+        clearPendingTimerSolve(previousUserId)
+      }
+
+      confirmedUserIdRef.current = nextUserId
+    }
+
+    setCurrentUser(nextUser ?? null)
+  }, [])
 
   useEffect(() => {
     return subscribeToAccessToken((nextToken) => {
@@ -86,7 +98,7 @@ export function AuthProvider({ children }) {
           return
         }
 
-        setCurrentUser(currentUserResponse.data ?? null)
+        commitAuthenticatedUser(currentUserResponse.data ?? null)
       } catch {
         if (isCancelled) {
           return
@@ -108,7 +120,7 @@ export function AuthProvider({ children }) {
     return () => {
       isCancelled = true
     }
-  }, [])
+  }, [commitAuthenticatedUser])
 
   const setAccessToken = async (nextToken) => {
     if (!nextToken) {
@@ -121,7 +133,7 @@ export function AuthProvider({ children }) {
 
     try {
       const response = await getMe()
-      setCurrentUser(response.data ?? null)
+      commitAuthenticatedUser(response.data ?? null)
     } catch (error) {
       clearStoredAccessToken()
       setCurrentUser(null)
@@ -132,7 +144,8 @@ export function AuthProvider({ children }) {
   }
 
   const clearAccessToken = () => {
-    clearPendingTimerSolve(currentUserRef.current?.userId)
+    clearPendingTimerSolve(confirmedUserIdRef.current)
+    confirmedUserIdRef.current = null
     setCurrentUser(null)
     setIsSessionSyncing(false)
     clearStoredAccessToken()

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import MockAdapter from 'axios-mock-adapter'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearStoredAccessToken, getStoredAccessToken, setStoredAccessToken } from '../authStorage.js'
 import { clearRefreshCookie, getMe, refreshSession } from '../api.js'
 import apiClient from '../lib/apiClient.js'
@@ -28,6 +28,16 @@ function AuthStateProbe() {
     }
   }
 
+  const handleSetAndClearAccessToken = async () => {
+    try {
+      await setAccessToken('manual-token')
+      clearAccessToken()
+      setActionError('none')
+    } catch (error) {
+      setActionError(error.message)
+    }
+  }
+
   return (
     <div>
       <span data-testid="has-auth-token">{String(hasAuthToken)}</span>
@@ -48,6 +58,9 @@ function AuthStateProbe() {
       <button type="button" onClick={() => handleSetAccessToken(null)}>
         빈 토큰 설정
       </button>
+      <button type="button" onClick={handleSetAndClearAccessToken}>
+        토큰 설정 후 즉시 정리
+      </button>
       <button type="button" onClick={clearAccessToken}>
         세션 정리
       </button>
@@ -56,10 +69,17 @@ function AuthStateProbe() {
 }
 
 describe('AuthProvider', () => {
+  let requestMock = null
+
   beforeEach(() => {
     clearStoredAccessToken()
     window.sessionStorage.clear()
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    requestMock?.restore()
+    requestMock = null
   })
 
   it('should_restore_current_user_when_refresh_and_me_requests_succeed_on_bootstrap', async () => {
@@ -537,6 +557,50 @@ describe('AuthProvider', () => {
     clearPendingTimerSolve(41)
   })
 
+  it('should_clear_the_confirmed_users_pending_solve_when_session_clear_follows_sign_in_immediately', async () => {
+    vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
+      status: 400,
+      isNetworkError: false,
+    }))
+    vi.mocked(getMe).mockResolvedValue({
+      data: {
+        userId: 41,
+        nickname: 'AccountA',
+        role: 'ROLE_USER',
+      },
+    })
+    savePendingTimerSolve({
+      schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+      userId: 41,
+      eventType: 'WCA_333',
+      timeMs: 1235,
+      penalty: 'NONE',
+      scramble: "R U R' U'",
+      inputMethod: 'KEYBOARD',
+      clientSubmissionId: 'd9428888-122b-4d3e-a58e-790c4e5f97ad',
+      savedAt: '2026-08-10T13:00:00.000Z',
+    })
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정 후 즉시 정리' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('has-auth-token')).toHaveTextContent('false')
+      expect(screen.getByTestId('nickname')).toHaveTextContent('none')
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toBeNull()
+  })
+
   it('should_preserve_the_current_users_pending_solve_when_a_record_401_refresh_fails_and_allow_the_same_account_to_sign_in_again', async () => {
     vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
       status: 400,
@@ -549,7 +613,7 @@ describe('AuthProvider', () => {
         role: 'ROLE_USER',
       },
     })
-    const requestMock = new MockAdapter(apiClient)
+    requestMock = new MockAdapter(apiClient)
     requestMock.onPost('/api/records').replyOnce(401)
     requestMock.onPost('/api/auth/refresh').networkErrorOnce()
 
@@ -596,8 +660,122 @@ describe('AuthProvider', () => {
     })
     expect(loadPendingTimerSolve(41).snapshot).toEqual(pendingSnapshot)
 
-    requestMock.restore()
     clearPendingTimerSolve(41)
+  })
+
+  it('should_clear_the_previous_users_pending_solve_when_another_account_signs_in_after_passive_auth_loss', async () => {
+    vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
+      status: 400,
+      isNetworkError: false,
+    }))
+    vi.mocked(getMe)
+      .mockResolvedValueOnce({
+        data: {
+          userId: 41,
+          nickname: 'AccountA',
+          role: 'ROLE_USER',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          userId: 42,
+          nickname: 'AccountB',
+          role: 'ROLE_USER',
+        },
+      })
+    requestMock = new MockAdapter(apiClient)
+    requestMock.onPost('/api/records').replyOnce(401)
+    requestMock.onPost('/api/auth/refresh').networkErrorOnce()
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountA')
+    })
+
+    const pendingSnapshot = {
+      schemaVersion: PENDING_TIMER_SOLVE_SCHEMA_VERSION,
+      userId: 41,
+      eventType: 'WCA_333',
+      timeMs: 1235,
+      penalty: 'NONE',
+      scramble: "R U R' U'",
+      inputMethod: 'KEYBOARD',
+      clientSubmissionId: 'd9428888-122b-4d3e-a58e-790c4e5f97ad',
+      savedAt: '2026-08-10T13:00:00.000Z',
+    }
+    savePendingTimerSolve(pendingSnapshot)
+
+    await expect(apiClient.post('/api/records', { timeMs: 1235 })).rejects.toThrow('Network Error')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-authenticated')).toHaveTextContent('false')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toEqual(pendingSnapshot)
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountB')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toBeNull()
+    expect(loadPendingTimerSolve(42).snapshot).toBeNull()
+  })
+
+  it('should_allow_an_account_switch_when_the_previous_user_has_no_pending_solve', async () => {
+    vi.mocked(refreshSession).mockRejectedValue(Object.assign(new Error('refresh_token 쿠키가 필요합니다.'), {
+      status: 400,
+      isNetworkError: false,
+    }))
+    vi.mocked(getMe)
+      .mockResolvedValueOnce({
+        data: {
+          userId: 41,
+          nickname: 'AccountA',
+          role: 'ROLE_USER',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          userId: 42,
+          nickname: 'AccountB',
+          role: 'ROLE_USER',
+        },
+      })
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-auth-loading')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountA')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '토큰 설정' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nickname')).toHaveTextContent('AccountB')
+    })
+    expect(loadPendingTimerSolve(41).snapshot).toBeNull()
+    expect(loadPendingTimerSolve(42).snapshot).toBeNull()
   })
 
   it('should_ignore_null_updates_when_update_current_user_is_called_without_payload_or_user', async () => {


### PR DESCRIPTION
## Problem

PR #41과 동일한 content tree의 dev push Validate에서 AuthContext pending solve 테스트 2건이 간헐적으로 실패했다.

명시적 session clear가 인증 사용자 state commit 직후 실행되면 pending owner ref를 갱신하는 effect보다 먼저 도달할 수 있었다. 첫 assertion 중단 뒤에는 남은 one-shot Account B mock이 다음 테스트에 전달되어 두 번째 실패를 연쇄시켰다.

## Ownership Contract

- passive access token loss와 refresh 실패는 현재 계정의 pending solve를 보존
- 같은 계정 재로그인은 pending solve recovery 유지
- 명시적 session clear는 confirmed owner pending solve 제거
- 다른 계정 인증 확정은 이전 confirmed owner pending solve 제거
- user-scoped storage는 다른 계정에 노출되지 않음

## Changes

- 인증 사용자 identity를 owner ref와 React state에 동기 반영
- account switch가 확정될 때 이전 owner pending solve 정리
- passive auth loss 중 confirmed owner identity 보존
- mock implementation queue와 Axios mock adapter의 test isolation 보강
- immediate clear, same-account recovery, passive loss 뒤 account switch, no-pending switch 회귀 추가

## Validation

- AuthContext focused: 25 tests passed
- AuthContext repeated: 20 consecutive passes
- frontend lint: passed
- full Vitest: 37 files / 508 tests passed
- production build: passed
- git diff --check: passed

## Production Changes

None
