### PR TITLE
refactor: transition legacy Profile consumers to Growth

### DIFF
--- a/docs/02-requirements/features/growth.md
+++ b/docs/02-requirements/features/growth.md
@@ -19,18 +19,19 @@ related:
 
 ## 문서 상태
 
-V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. metric formula, pure calculator, private Growth read API와 My Growth dashboard consumer는 구현했지만, legacy Profile consumer transition과 release evidence는 아직 application contract나 출시 약속이 아니다.
+V2.2 Growth & Profile은 main의 V2.1 Timer / Record Foundation을 기반으로 하는 `draft`다. metric formula, pure calculator, private Growth read API, My Growth dashboard와 legacy MyPage consumer transition은 dev에서 구현했다. release evidence는 아직 application contract나 출시 약속이 아니다.
 
 ```text
 Current
 - Timer의 recent Ao5/Ao12
-- private MyPage의 전체 요약, 최근 raw Record chart, history 관리
+- private MyPage의 canonical Growth API consumer
+- server pagination을 사용하는 Record History
+- Account/Profile 관리
 - Ranking의 nickname과 event PB
 - current Record projection을 계산하는 Growth metric calculator
 - event별 private Growth summary, 30-day trend, paginated PB progression API
 
 Next implementation
-- legacy Profile consumer transition
 - release evidence
 
 Future candidate

--- a/docs/02-requirements/features/profile.md
+++ b/docs/02-requirements/features/profile.md
@@ -22,14 +22,12 @@ related:
 
 ## 현재 동작
 
-- profile, 주 종목, 요약 통계 조회
-- 전체 Record history와 pagination
-- all-event 첫 page를 받은 뒤 client에서 선택 event의 최근 raw 기록 추세와 PB 표시
-- nickname과 주 종목 변경
-- 현재 비밀번호 확인 후 비밀번호 변경
-- Record penalty 수정과 삭제
+- Profile API는 nickname과 주 종목을 조회하고 account modal의 수정 상태를 동기화한다.
+- Record History는 `GET /api/users/me/records`의 1-based server pagination으로 관리한다.
+- Growth metric, trend, PB progression, activity는 private Growth aggregate API로만 표시한다.
+- nickname과 주 종목 변경, 현재 비밀번호 확인 후 비밀번호 변경, Record penalty 수정과 삭제를 유지한다.
 
-현재 summary의 `averageTimeMs`는 all-event, all-time arithmetic mean이고 DNF를 제외한다. UI의 `전체 평균`은 population과 event가 충분히 드러나지 않으므로 V2.2 canonical Growth metric으로 재사용하지 않는다.
+Profile response의 additive `summary.averageTimeMs`는 all-event, all-time arithmetic mean이고 DNF를 제외한다. MyPage는 이 값을 V2.2 canonical Growth metric으로 사용하지 않는다. provider field의 compatibility cleanup은 별도 API 결정이다.
 
 ## 요구사항
 
@@ -57,9 +55,9 @@ related:
 
 Growth, trend와 장기 activity history의 제품 범위는 [Roadmap](../../00-product/roadmap.md)의 V2.2에서 검증한다.
 
-## V2.2 Profile Proposal
+## V2.2 Profile 상태
 
-[Growth 요구사항](growth.md)의 `draft`를 따른다. 아래 범위는 current 구현이 아니다.
+[Growth 요구사항](growth.md)의 `draft`를 따른다. 아래 범위는 dev 구현 상태이며 release evidence는 아직 남아 있다.
 
 ### My Growth
 
@@ -67,6 +65,8 @@ Growth, trend와 장기 activity history의 제품 범위는 [Roadmap](../../00-
 - `/mypage`를 새 top-level route 없이 My Growth dashboard로 확장한다.
 - Account 관리와 Record penalty/delete는 current 기능을 유지한다.
 - Full Record history를 client metric 계산용으로 전송하지 않고 private Growth aggregate API를 사용한다.
+- Record mutation은 Growth와 current Record History page를 갱신하며 Profile/account request를 다시 시작하지 않는다.
+- Profile 수정은 Profile/account state와 AuthContext nickname만 갱신하며 Record History를 다시 읽지 않는다.
 
 ### Public Profile
 

--- a/docs/03-architecture/growth-architecture.md
+++ b/docs/03-architecture/growth-architecture.md
@@ -22,7 +22,7 @@ related:
 
 ## 문서 상태와 경계
 
-V2.2 Growth & Profile architecture는 `draft`다. pure metric calculator, private Growth read API, repository projection, MySQL query와 My Growth UI consumer는 구현했다. Legacy Profile consumer transition과 release evidence는 아직 구현하지 않았다. exact request·response는 Spring REST Docs test가 Source of Truth다.
+V2.2 Growth & Profile architecture는 `draft`다. pure metric calculator, private Growth read API, repository projection, MySQL query, My Growth UI consumer와 legacy MyPage consumer transition은 dev에서 구현했다. release evidence는 아직 구현하지 않았다. exact request·response는 Spring REST Docs test가 Source of Truth다.
 
 ```text
 Current
@@ -36,7 +36,7 @@ Current
 - Redis ranking read model
 
 Next implementation
-- Legacy Profile consumer transition과 release evidence
+- release evidence
 
 Future candidate
 - observed cost에 근거한 PB progression cache/projection
@@ -81,7 +81,7 @@ DNF      -> numeric result 없음
 - page size 상한은 100이다.
 - `GET /api/users/me/profile`의 `totalRecords`와 `averageTimeMs`는 모든 event를 섞는다. average는 DNF를 제외한 all-time arithmetic mean이며 population이 UI label에 드러나지 않는다.
 - Timer는 WCA_333 recent 12 Record를 받아 Ao5/Ao12를 frontend에서 계산한다.
-- MyPage는 all-event 첫 100 Record를 받은 뒤 client에서 event filter하고 최근 30 raw result line을 그린다. 이는 bounded transfer이지만 mixed event나 100개 밖의 target event가 있으면 Growth population으로 정확하지 않다.
+- MyPage는 Record History만 `GET /api/users/me/records?page={page}&size=10`으로 읽는다. Growth metric이나 chart를 위해 Record page를 bulk fetch하거나 client에서 raw trend를 계산하지 않는다.
 - public user Profile route/API는 없다. Ranking은 nickname, event와 PB를 보여 주지만 stable public user profile contract를 제공하지 않는다.
 
 따라서 current history API를 canonical Growth 계산에 그대로 사용하는 것은 client별 metric drift와 불필요한 Record payload를 만든다. 기존 endpoint는 Record 관리와 detail pagination에 유지하고 Growth는 별도 read contract로 둔다.
@@ -385,6 +385,8 @@ User timezone이 도입되면 historical day regrouping, profile setting, cache 
 - progression은 summary 뒤 lazy load한다. page 1을 먼저 표시하고 사용자가 전체 이력을 열 때 다음 page를 읽는다.
 - chart에는 text summary/timeline을 함께 제공하고 mobile tick 수를 줄인다.
 - Record create/PATCH/delete 성공 후 관련 Growth query를 invalidate/refetch한다.
+- Record penalty PATCH/delete 성공 후 current Record History page도 refetch한다. Profile/account request는 다시 시작하지 않는다.
+- Profile PATCH 성공 후 Profile read와 AuthContext nickname만 동기화한다. Record History와 Growth query를 다시 시작하지 않는다.
 
 ## Test 전략
 
@@ -467,11 +469,12 @@ Build와 CI success는 production request 성공을 뜻하지 않는다. main me
 
 ### PR D — Legacy Profile consumer 전환
 
-- scope: Home/MyPage의 ambiguous all-event average 제거, additive API field deprecation 문서, duplicate calculation 정리
+- status: implemented on dev
+- scope: MyPage의 legacy 100-record source와 raw Record trend 제거, Profile/Record/Growth refresh ownership 분리
 - dependency: PR C가 Growth replacement 제공
-- acceptance: existing account/history/PB consumer 회귀 없음, breaking API removal 없음
-- tests: profile service/REST Docs regression, frontend routes
-- rollback risk: legacy UI label 복원 가능. API field 제거는 별도 compatibility 결정 전 금지
+- acceptance: existing account/history/PB consumer 회귀 없음, Record History server pagination 유지, breaking API removal 없음
+- tests: frontend route와 pagination·mutation refresh regression
+- rollback risk: MyPage consumer transition만 되돌릴 수 있다. API field 제거는 별도 compatibility 결정 전 금지
 
 ### PR E — Release evidence
 

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -24,7 +24,6 @@ import { formatSeoulDateOnly, formatSeoulDateTime } from '../utils/dateTime.js'
 import { formatRecordTime } from '../utils/recordStats.js'
 
 const RECORDS_PAGE_SIZE = 10
-const TREND_FETCH_SIZE = 100
 const DEFAULT_MAIN_EVENT = eventOptions[0].value
 const GROWTH_EVENT_TYPE = 'WCA_333'
 const GROWTH_TREND_PERIOD = '30D'
@@ -234,21 +233,6 @@ export function getConsistencyComparisonLabel(consistency) {
   return null
 }
 
-export function buildFirstPageFromRecentRecords(sourcePage) {
-  const totalElements = sourcePage?.totalElements ?? 0
-  const totalPages = totalElements === 0 ? 0 : Math.ceil(totalElements / RECORDS_PAGE_SIZE)
-
-  return {
-    items: sourcePage?.items?.slice(0, RECORDS_PAGE_SIZE) ?? [],
-    page: 1,
-    size: RECORDS_PAGE_SIZE,
-    totalElements,
-    totalPages,
-    hasNext: totalPages > 1,
-    hasPrevious: false,
-  }
-}
-
 export default function MyPage() {
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false)
@@ -282,9 +266,6 @@ export default function MyPage() {
   const [currentPage, setCurrentPage] = useState(1)
   const [updatingRecordId, setUpdatingRecordId] = useState(null)
   const [deletingRecordId, setDeletingRecordId] = useState(null)
-  const [recentRecordsSource, setRecentRecordsSource] = useState(null)
-  const [recentRecordsSourceError, setRecentRecordsSourceError] = useState(null)
-  const [isLoadingRecentRecordsSource, setIsLoadingRecentRecordsSource] = useState(true)
   const [profileReloadKey, setProfileReloadKey] = useState(0)
   const [recordsReloadKey, setRecordsReloadKey] = useState(0)
   const [growthSummaryReloadKey, setGrowthSummaryReloadKey] = useState(0)
@@ -382,64 +363,6 @@ export default function MyPage() {
   useEffect(() => {
     let isCancelled = false
 
-    const loadRecentRecordsSource = async () => {
-      setIsLoadingRecentRecordsSource(true)
-      setRecentRecordsSourceError(null)
-
-      try {
-        const response = await getMyRecords({ page: 1, size: TREND_FETCH_SIZE })
-
-        if (isCancelled) {
-          return
-        }
-
-        setRecentRecordsSource(response.data)
-        setRecentRecordsSourceError(null)
-      } catch (error) {
-        if (isCancelled) {
-          return
-        }
-
-        setRecentRecordsSource(null)
-        setRecentRecordsSourceError(error.message)
-      } finally {
-        if (!isCancelled) {
-          setIsLoadingRecentRecordsSource(false)
-        }
-      }
-    }
-
-    loadRecentRecordsSource()
-
-    return () => {
-      isCancelled = true
-    }
-  }, [recordsReloadKey])
-
-  useEffect(() => {
-    if (currentPage === 1) {
-      setIsLoadingRecords(isLoadingRecentRecordsSource)
-
-      if (isLoadingRecentRecordsSource) {
-        return
-      }
-
-      if (recentRecordsSourceError) {
-        setRecordsPage(null)
-        setRecordsError(recentRecordsSourceError)
-        return
-      }
-
-      if (recentRecordsSource) {
-        setRecordsPage(buildFirstPageFromRecentRecords(recentRecordsSource))
-        setRecordsError(null)
-      }
-
-      return
-    }
-
-    let isCancelled = false
-
     const loadRecordsPage = async () => {
       setIsLoadingRecords(true)
       setRecordsError(null)
@@ -451,7 +374,15 @@ export default function MyPage() {
           return
         }
 
-        const nextPage = response.data
+        const nextPage = response.data ?? {
+          items: [],
+          page: currentPage,
+          size: RECORDS_PAGE_SIZE,
+          totalElements: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrevious: false,
+        }
         const normalizedPage = nextPage.totalPages > 0 ? Math.min(currentPage, nextPage.totalPages) : 1
 
         if (normalizedPage !== currentPage) {
@@ -479,7 +410,7 @@ export default function MyPage() {
     return () => {
       isCancelled = true
     }
-  }, [currentPage, isLoadingRecentRecordsSource, recentRecordsSource, recentRecordsSourceError])
+  }, [currentPage, recordsReloadKey])
 
   useEffect(() => {
     let isCancelled = false
@@ -627,75 +558,13 @@ export default function MyPage() {
     }
   }
 
-  const syncProfileAndRecords = async (page) => {
-    const [profileResult, recentRecordsResult, recordsResult] = await Promise.allSettled([
-      getMyProfile(),
-      getMyRecords({ page: 1, size: TREND_FETCH_SIZE }),
-      page > 1 ? getMyRecords({ page, size: RECORDS_PAGE_SIZE }) : Promise.resolve(null),
-    ])
-    let firstError = null
-    let nextProfileData = null
-    let nextRecentRecordsSource = null
-    let nextRecordsPage = null
-
-    if (profileResult.status === 'fulfilled') {
-      nextProfileData = profileResult.value.data
-      setProfileData(nextProfileData)
-      setProfileError(null)
-    } else {
-      firstError = profileResult.reason
-      setProfileError(profileResult.reason.message)
-    }
-
-    if (recentRecordsResult.status === 'fulfilled') {
-      nextRecentRecordsSource = recentRecordsResult.value.data
-      setRecentRecordsSource(nextRecentRecordsSource)
-      setRecentRecordsSourceError(null)
-    } else {
-      firstError ??= recentRecordsResult.reason
-      setRecentRecordsSourceError(recentRecordsResult.reason.message)
-      setRecordsError(recentRecordsResult.reason.message)
-    }
-
-    if (page > 1 && recordsResult.status === 'fulfilled') {
-      nextRecordsPage = recordsResult.value.data
-    } else if (page > 1) {
-      firstError ??= recordsResult.reason
-      setRecordsError(recordsResult.reason.message)
-    } else if (nextRecentRecordsSource) {
-      nextRecordsPage = buildFirstPageFromRecentRecords(nextRecentRecordsSource)
-    }
-
-    if (nextRecordsPage && page > 1) {
-      const normalizedPage = nextRecordsPage.totalPages > 0 ? Math.min(page, nextRecordsPage.totalPages) : 1
-
-      if (normalizedPage !== page) {
-        setCurrentPage(normalizedPage)
-      } else {
-        setRecordsPage(nextRecordsPage)
-        if (recentRecordsResult.status === 'fulfilled') {
-          setRecordsError(null)
-        }
-      }
-    } else if (nextRecordsPage) {
-      setRecordsPage(nextRecordsPage)
-      setRecordsError(null)
-    }
-
-    if (firstError) {
-      throw firstError
-    }
-
-    return nextProfileData
-  }
-
   const handleUpdateRecordPenalty = async (recordId, penalty) => {
     setUpdatingRecordId(recordId)
 
     try {
       const response = await updateRecordPenalty(recordId, { penalty })
       invalidateGrowthAfterRecordMutation()
-      await syncProfileAndRecords(currentPage)
+      setRecordsReloadKey((current) => current + 1)
       toast.success(response.message)
     } catch (error) {
       toast.error(error.message)
@@ -714,7 +583,7 @@ export default function MyPage() {
     try {
       const response = await deleteRecord(recordId)
       invalidateGrowthAfterRecordMutation()
-      await syncProfileAndRecords(currentPage)
+      setRecordsReloadKey((current) => current + 1)
       toast.success(response.message)
     } catch (error) {
       toast.error(error.message)
@@ -849,8 +718,11 @@ export default function MyPage() {
         nickname,
         mainEvent: profileForm.mainEvent,
       })
-      const nextProfileData = await syncProfileAndRecords(currentPage)
-      updateCurrentUser({ nickname: nextProfileData.nickname })
+      const profileResponse = await getMyProfile()
+      const nextProfileData = profileResponse.data
+      setProfileData(nextProfileData)
+      setProfileError(null)
+      updateCurrentUser({ nickname: nextProfileData?.nickname ?? nickname })
 
       handleCloseAccountModal()
       toast.success(response.message)
@@ -1537,21 +1409,6 @@ export function GrowthActivityTooltip({ active, payload }) {
     <div className="mypage-trend-tooltip">
       <p className="mypage-trend-tooltip-time">{formatGrowthTrendPointDate(point)}</p>
       <p className="mypage-trend-tooltip-date">solve {point.recordCount}회 · DNF {point.dnfCount}회 · +2 {point.plusTwoCount}회</p>
-    </div>
-  )
-}
-
-export function RecordTrendTooltip({ active, payload }) {
-  if (!active || !payload?.length) {
-    return null
-  }
-
-  const point = payload[0].payload
-
-  return (
-    <div className="mypage-trend-tooltip">
-      <p className="mypage-trend-tooltip-time">{point.displayTime}</p>
-      <p className="mypage-trend-tooltip-date">{formatDateTime(point.createdAt)}</p>
     </div>
   )
 }

--- a/frontend/src/pages/MyPage.test.jsx
+++ b/frontend/src/pages/MyPage.test.jsx
@@ -18,11 +18,9 @@ import MyPage, {
   GrowthPeriodCard,
   GrowthTrendSection,
   GrowthPbProgressionTooltip,
-  RecordTrendTooltip,
   GrowthTrendTooltip,
   buildPbProgressionChartData,
   buildGrowthTrendChartData,
-  buildFirstPageFromRecentRecords,
   formatDateTime,
   formatGrowthDate,
   formatGrowthMetric,
@@ -273,9 +271,7 @@ describe('MyPage', () => {
           },
         },
       })
-    vi.mocked(getMyRecords)
-      .mockResolvedValueOnce(createRecordsResponse([createRecord()]))
-      .mockResolvedValueOnce(createRecordsResponse([createRecord()]))
+    vi.mocked(getMyRecords).mockResolvedValueOnce(createRecordsResponse([createRecord()]))
     vi.mocked(updateMyProfile).mockResolvedValue({
       message: '내 정보를 수정했습니다.',
       data: null,
@@ -308,6 +304,7 @@ describe('MyPage', () => {
       expect(screen.queryByRole('dialog', { name: '계정 관리' })).not.toBeInTheDocument()
     })
     expect(await screen.findAllByText('2x2x2')).not.toHaveLength(0)
+    expect(getMyRecords).toHaveBeenCalledTimes(1)
   })
 
   it('should_clear_session_and_redirect_to_login_when_password_change_succeeds', async () => {
@@ -360,7 +357,7 @@ describe('MyPage', () => {
     })
   })
 
-  it('should_refresh_profile_and_records_when_record_penalty_update_succeeds', async () => {
+  it('should_refresh_record_history_and_growth_without_refetching_profile_when_record_penalty_update_succeeds', async () => {
     vi.mocked(getMyProfile)
       .mockResolvedValueOnce({
         data: {
@@ -411,8 +408,8 @@ describe('MyPage', () => {
 
     expect((await screen.findAllByText('11.344')).length).toBeGreaterThan(0)
     expect(toast.success).toHaveBeenCalledWith('기록 페널티가 수정되었습니다.')
-    expect(getMyProfile).toHaveBeenCalledTimes(2)
-    expect(getMyRecords).toHaveBeenCalledWith({ page: 1, size: 100 })
+    expect(getMyProfile).toHaveBeenCalledTimes(1)
+    expect(getMyRecords).toHaveBeenCalledWith({ page: 1, size: 10 })
     await waitFor(() => {
       expect(getMyGrowth).toHaveBeenCalledTimes(2)
       expect(getMyGrowthTrend).toHaveBeenCalledTimes(2)
@@ -445,6 +442,8 @@ describe('MyPage', () => {
     render(<MyPage />)
 
     expect(await screen.findByText('2026년 4월 4일 오후 6시 11분')).toBeInTheDocument()
+    expect(getMyRecords).toHaveBeenCalledWith({ page: 1, size: 10 })
+    expect(getMyRecords).not.toHaveBeenCalledWith({ page: 1, size: 100 })
 
     fireEvent.click(screen.getByRole('button', { name: '다음' }))
 
@@ -453,7 +452,7 @@ describe('MyPage', () => {
     expect(screen.getByRole('button', { name: '2' })).toBeDisabled()
   })
 
-  it('should_refresh_profile_and_records_when_record_delete_succeeds', async () => {
+  it('should_refresh_record_history_and_growth_without_refetching_profile_when_record_delete_succeeds', async () => {
     vi.mocked(getMyProfile)
       .mockResolvedValueOnce({
         data: {
@@ -498,7 +497,12 @@ describe('MyPage', () => {
     })
 
     expect(toast.success).toHaveBeenCalledWith('기록이 삭제되었습니다.')
-    expect(screen.getByText('아직 저장된 기록이 없습니다.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(getMyRecords).toHaveBeenCalledTimes(2)
+      expect(screen.queryByText('2026년 4월 4일 오후 6시 11분')).not.toBeInTheDocument()
+    })
+    expect(getMyProfile).toHaveBeenCalledTimes(1)
+    expect(getMyRecords).toHaveBeenCalledWith({ page: 1, size: 10 })
   })
 
   it('should_show_error_message_when_profile_loading_fails', async () => {
@@ -531,6 +535,8 @@ describe('MyPage', () => {
     render(<MyPage />)
 
     expect(await screen.findByText('프로필 조회 실패')).toBeInTheDocument()
+    expect(screen.getByText('Current PB')).toBeInTheDocument()
+    expect(screen.getByText('아직 저장된 기록이 없습니다.')).toBeInTheDocument()
 
     fireEvent.click(screen.getAllByRole('button', { name: '다시 시도' })[0])
 
@@ -558,6 +564,8 @@ describe('MyPage', () => {
     render(<MyPage />)
 
     expect(await screen.findAllByText('기록 조회 실패')).toHaveLength(1)
+    expect(screen.getByText('Tester')).toBeInTheDocument()
+    expect(screen.getByText('Current PB')).toBeInTheDocument()
 
     fireEvent.click(screen.getAllByRole('button', { name: '다시 시도' })[0])
 
@@ -696,6 +704,34 @@ describe('MyPage', () => {
     expect(getMyGrowth).toHaveBeenCalledWith({ eventType: 'WCA_333' })
     expect(getMyGrowthTrend).toHaveBeenCalledWith({ eventType: 'WCA_333', period: '30D' })
     expect(getMyGrowthPbProgression).toHaveBeenCalledWith({ eventType: 'WCA_333', page: 1, size: 50 })
+  })
+
+  it('should_not_use_profile_summary_values_for_growth_metrics', async () => {
+    vi.mocked(getMyProfile).mockResolvedValue({
+      data: {
+        userId: 1,
+        nickname: 'Tester',
+        mainEvent: 'WCA_333',
+        summary: {
+          totalSolveCount: 999,
+          personalBestTimeMs: 19999,
+          averageTimeMs: 88888,
+        },
+      },
+    })
+    vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse([createRecord()]))
+    vi.mocked(getMyGrowth).mockResolvedValue(createGrowthSummaryResponse({
+      currentPb: { status: 'AVAILABLE', effectiveTimeMs: 9344 },
+      recentAo5: { status: 'AVAILABLE', valueMs: 10200 },
+      recentAo12: { status: 'AVAILABLE', valueMs: 10500 },
+    }))
+
+    render(<MyPage />)
+
+    const currentPerformance = await screen.findByRole('region', { name: '현재 기록' })
+    expect(within(currentPerformance).getByText('9.344')).toBeInTheDocument()
+    expect(within(currentPerformance).queryByText('19.999')).not.toBeInTheDocument()
+    expect(within(currentPerformance).queryByText('88.888')).not.toBeInTheDocument()
   })
 
   it.each([
@@ -1010,10 +1046,8 @@ describe('MyPage', () => {
     expect(screen.queryByText(/PB progression 조회 실패/)).not.toBeInTheDocument()
   })
 
-  it('should_refresh_growth_after_penalty_success_when_profile_refresh_fails', async () => {
-    vi.mocked(getMyProfile)
-      .mockResolvedValueOnce({ data: { userId: 1, nickname: 'Tester', mainEvent: 'WCA_333' } })
-      .mockRejectedValueOnce(new Error('프로필 갱신 실패'))
+  it('should_refresh_growth_after_penalty_success_without_requesting_profile_again', async () => {
+    vi.mocked(getMyProfile).mockResolvedValue({ data: { userId: 1, nickname: 'Tester', mainEvent: 'WCA_333' } })
     vi.mocked(getMyRecords).mockResolvedValue(createRecordsResponse([createRecord()]))
     vi.mocked(updateRecordPenalty).mockResolvedValue({ message: '기록 페널티가 수정되었습니다.' })
 
@@ -1028,7 +1062,7 @@ describe('MyPage', () => {
       expect(getMyGrowthTrend).toHaveBeenCalledTimes(2)
       expect(getMyGrowthPbProgression).toHaveBeenCalledTimes(2)
     })
-    expect(await screen.findByText('프로필 갱신 실패')).toBeInTheDocument()
+    expect(getMyProfile).toHaveBeenCalledTimes(1)
   })
 
   it('should_refresh_growth_after_delete_success_when_record_history_refresh_fails', async () => {
@@ -1090,15 +1124,6 @@ describe('MyPage', () => {
     expect(getEventLabel('WCA_222')).toBe('2x2x2')
     expect(getEventLabel('CUSTOM')).toBe('CUSTOM')
     expect(getEventLabel(null)).toBe('-')
-    expect(buildFirstPageFromRecentRecords(null)).toEqual({
-      items: [],
-      page: 1,
-      size: 10,
-      totalElements: 0,
-      totalPages: 0,
-      hasNext: false,
-      hasPrevious: false,
-    })
     expect(buildPbProgressionChartData([
       { recordId: 3, effectiveTimeMs: 8888, createdAt: '2026-08-03T09:00:00Z' },
       { recordId: 2, effectiveTimeMs: 9123, createdAt: '2026-08-02T09:00:00Z' },
@@ -1195,29 +1220,6 @@ describe('MyPage', () => {
     render(<GrowthPeriodCard label="최근 7일" period={{ fromDate: '2026-08-08', toDateExclusive: '2026-08-15', medianTimeMs: 10100, recordCount: 12, dnfCount: 1 }} />)
 
     expect(screen.getByText('2026년 8월 8일 ~ 2026년 8월 14일')).toBeInTheDocument()
-  })
-
-  it('should_render_record_trend_tooltip_when_payload_is_active', () => {
-    const { rerender } = render(<RecordTrendTooltip active={false} payload={[]} />)
-
-    expect(screen.queryByText('9.344')).not.toBeInTheDocument()
-
-    rerender(
-      <RecordTrendTooltip
-        active
-        payload={[
-          {
-            payload: {
-              displayTime: '9.344',
-              createdAt: '2026-04-04T18:11:00',
-            },
-          },
-        ]}
-      />,
-    )
-
-    expect(screen.getByText('9.344')).toBeInTheDocument()
-    expect(screen.getByText('2026년 4월 4일 오후 6시 11분')).toBeInTheDocument()
   })
 
   it('should_use_current_user_fallbacks_when_profile_payload_is_missing', async () => {
@@ -1468,7 +1470,7 @@ describe('MyPage', () => {
     expect(await screen.findByText('비밀번호 변경 실패')).toBeInTheDocument()
   })
 
-  it('should_show_empty_states_when_recent_records_source_payload_is_null', async () => {
+  it('should_show_empty_states_when_record_page_payload_is_null', async () => {
     vi.mocked(getMyProfile).mockResolvedValue({
       data: {
         userId: 1,
@@ -1527,7 +1529,7 @@ describe('MyPage', () => {
     expect(screen.getByRole('button', { name: '다음' })).toBeDisabled()
   })
 
-  it('should_normalize_current_page_after_record_penalty_update_when_synced_page_count_shrinks', async () => {
+  it('should_normalize_current_page_after_record_delete_when_record_page_count_shrinks', async () => {
     vi.mocked(getMyProfile)
       .mockResolvedValueOnce({
         data: {
@@ -1558,17 +1560,9 @@ describe('MyPage', () => {
       .mockResolvedValueOnce(createRecordsResponse([
         createRecord({ id: 11, createdAt: '2026-04-04T18:22:00' }),
       ], { page: 2, totalElements: 11, totalPages: 2, hasPrevious: true }))
-      .mockResolvedValueOnce(createRecordsResponse([], { totalElements: 0, totalPages: 0 }))
       .mockResolvedValueOnce(createRecordsResponse([], { page: 2, totalElements: 0, totalPages: 0 }))
-    vi.mocked(updateRecordPenalty).mockResolvedValue({
-      message: '기록 페널티가 수정되었습니다.',
-      data: {
-        id: 11,
-        timeMs: 9344,
-        effectiveTimeMs: 11344,
-        penalty: 'PLUS_TWO',
-      },
-    })
+      .mockResolvedValueOnce(createRecordsResponse([], { totalElements: 0, totalPages: 0 }))
+    vi.mocked(deleteRecord).mockResolvedValue({ message: '기록이 삭제되었습니다.', data: null })
 
     render(<MyPage />)
 
@@ -1577,7 +1571,7 @@ describe('MyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '다음' }))
     expect(await screen.findByText('2026년 4월 4일 오후 6시 22분')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: '+2' }))
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }))
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '1' })).toBeDisabled()
@@ -1669,7 +1663,7 @@ describe('MyPage', () => {
     expect(screen.queryByText('2026년 4월 4일 오후 6시 22분')).not.toBeInTheDocument()
   })
 
-  it('should_keep_current_page_when_record_penalty_update_sync_returns_same_page_count', async () => {
+  it('should_keep_current_page_when_record_penalty_update_returns_same_page_count', async () => {
     let pageOneFetchCount = 0
     let pageTwoFetchCount = 0
     vi.mocked(getMyProfile)
@@ -1685,20 +1679,8 @@ describe('MyPage', () => {
           },
         },
       })
-      .mockResolvedValueOnce({
-        data: {
-          userId: 1,
-          nickname: 'Tester',
-          mainEvent: 'WCA_333',
-          summary: {
-            totalSolveCount: 11,
-            personalBestTimeMs: 11344,
-            averageTimeMs: 11344,
-          },
-        },
-      })
     vi.mocked(getMyRecords).mockImplementation(({ page, size }) => {
-      if (page === 1 && size === 100) {
+      if (page === 1 && size === 10) {
         pageOneFetchCount += 1
         return Promise.resolve(
           createRecordsResponse([createRecord()], { totalElements: 11, totalPages: 2, hasNext: true }),
@@ -1746,12 +1728,13 @@ describe('MyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '+2' }))
 
     await waitFor(() => {
-      expect(pageOneFetchCount).toBeGreaterThanOrEqual(2)
+      expect(pageOneFetchCount).toBe(1)
       expect(pageTwoFetchCount).toBeGreaterThanOrEqual(2)
       expect(screen.getByRole('button', { name: '2' })).toBeDisabled()
       expect(screen.getByRole('button', { name: '다음' })).toBeDisabled()
       expect(screen.getAllByText('11.344').length).toBeGreaterThanOrEqual(1)
     })
+    expect(getMyProfile).toHaveBeenCalledTimes(1)
   })
 
   it('should_ignore_pending_profile_and_record_requests_when_component_is_unmounted', async () => {


### PR DESCRIPTION
## Goal

MyPage의 legacy Profile/Record metric consumer를 canonical Growth API 경계에 맞춘다.

## Consumer Transition

- Profile API는 account settings와 password management에 유지
- Growth metric, trend, PB progression, activity는 Growth aggregate API만 사용
- Record History는 server pagination과 penalty/delete 관리에 한정

## Record Pagination

- 첫 Record History 요청을 `page=1&size=10`으로 전환
- legacy 100-record source와 raw Record trend consumer 제거
- 마지막 Record 삭제 뒤 server totalPages 기준으로 현재 page 정규화 유지

## Refresh Boundaries

- penalty/delete 성공 후 Growth와 현재 Record History page만 갱신
- Profile PATCH 성공 후 Profile read와 AuthContext nickname만 동기화

## Compatibility

- Profile endpoint와 backend response shape 변경 없음
- Account/profile, password, Record History, penalty/delete 계약 유지

## Tests

- MyPage focused: 59 passed
- frontend lint, full Vitest: 508 passed, production build 통과
- legacy consumer 및 pagination/refresh boundary regression 추가

## Out of Scope

- Profile provider field cleanup
- Home summary metric transition
- backend, schema, runtime, deployment, PR E

## Production Changes

None